### PR TITLE
fix: issue where the same logs would get sent multiple times

### DIFF
--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -98,8 +98,7 @@ describe('#metrics', () => {
           // This is the important part of this test,
           // the delay mimics the latency of a real
           // HTTP request
-          .delayConnection(1000)
-          .delayBody(2000)
+          .delay(1000)
           .reply(200)
       );
 

--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -107,8 +107,8 @@ describe('#metrics', () => {
       app.get('/test', (req, res) => res.sendStatus(200));
 
       return Promise.all(
-        [...new Array(numberOfLogs).keys()].map(() => {
-          return request(app).get('/test').expect(200);
+        [...new Array(numberOfLogs).keys()].map(i => {
+          return request(app).get(`/test?log=${i}`).expect(200);
         })
       ).then(() => {
         mocks.map(mock => mock.done());

--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -76,7 +76,7 @@ describe('#metrics', () => {
       mock.done();
     }, 5000);
 
-    it('should clear out the queue when sent', (done) => {
+    it('should clear out the queue when sent', done => {
       const group = '5afa21b97011c63320226ef3';
 
       const numberOfLogs = 20;
@@ -93,21 +93,25 @@ describe('#metrics', () => {
           // the delay mimics the latency of a real
           // HTTP request
           .delay(1)
-          .reply(200)
+          .reply(200),
       );
 
       const app = express();
-      app.use(middleware.metrics(apiKey, () => group, { bufferLength }, (e) => done(e)));
+      app.use(middleware.metrics(apiKey, () => group, { bufferLength }, e => done(e)));
       app.get('/test', (req, res) => res.sendStatus(200));
 
-      Promise.all([...Array(numberOfLogs).keys()].map(() =>
-        request(app)
-          .get('/test')
-          .expect(200)
-      )).then(() => {
-        mocks.map(mock => mock.done());
-        return done();
-      }).catch(done);
+      Promise.all(
+        [...Array(numberOfLogs).keys()].map(() =>
+          request(app)
+            .get('/test')
+            .expect(200),
+        ),
+      )
+        .then(() => {
+          mocks.map(mock => mock.done());
+          return done();
+        })
+        .catch(done);
     });
   });
 

--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const request = require('supertest');
 const nock = require('nock');
+const crypto = require('crypto');
 const config = require('../config');
 
 const middleware = require('..');
 
-const apiKey = 'OUW3RlI4gUCwWGpO10srIo2ufdWmMhMH';
+const apiKey = 'fakeApiKey';
+const group = '5afa21b97011c63320226ef3';
 
 describe('#metrics', () => {
   beforeEach(() => {
@@ -28,8 +30,6 @@ describe('#metrics', () => {
   });
 
   it('should send a request to the metrics server', async function test() {
-    const group = '5afa21b97011c63320226ef3';
-
     const mock = nock(config.host)
       .post('/v1/request', ([body]) => {
         expect(body.group).toBe(group);
@@ -50,8 +50,6 @@ describe('#metrics', () => {
 
   describe('#bufferLength', () => {
     it('should send requests when number hits `bufferLength` size', async function test() {
-      const group = '5afa21b97011c63320226ef3';
-
       const mock = nock(config.host)
         .post('/v1/request', body => {
           expect(body).toHaveLength(3);
@@ -76,42 +74,46 @@ describe('#metrics', () => {
       mock.done();
     }, 5000);
 
-    it('should clear out the queue when sent', done => {
-      const group = '5afa21b97011c63320226ef3';
-
+    it('should clear out the queue when sent', () => {
       const numberOfLogs = 20;
       const numberOfMocks = 4;
       const bufferLength = numberOfLogs / numberOfMocks;
 
-      const mocks = [...Array(numberOfMocks).keys()].map(() =>
+      const seenLogs = [];
+
+      const mocks = [...new Array(numberOfMocks).keys()].map(() =>
         nock(config.host)
           .post('/v1/request', body => {
-            assert.equal(body.length, bufferLength);
+            expect(body).toHaveLength(bufferLength);
+
+            // Ensure that our executed requests and the buffered queue they're in remain unique.
+            body.forEach(req => {
+              const requestHash = crypto.createHash('md5').update(JSON.stringify(req)).digest('hex');
+              expect(seenLogs).not.toContain(requestHash);
+              seenLogs.push(requestHash);
+            });
+
             return true;
           })
           // This is the important part of this test,
           // the delay mimics the latency of a real
           // HTTP request
-          .delay(1)
-          .reply(200),
+          .delayConnection(1000)
+          .delayBody(2000)
+          .reply(200)
       );
 
       const app = express();
-      app.use(middleware.metrics(apiKey, () => group, { bufferLength }, e => done(e)));
+      app.use(middleware.metrics(apiKey, () => group, { bufferLength }));
       app.get('/test', (req, res) => res.sendStatus(200));
 
-      Promise.all(
-        [...Array(numberOfLogs).keys()].map(() =>
-          request(app)
-            .get('/test')
-            .expect(200),
-        ),
-      )
-        .then(() => {
-          mocks.map(mock => mock.done());
-          return done();
+      return Promise.all(
+        [...new Array(numberOfLogs).keys()].map(() => {
+          return request(app).get('/test').expect(200);
         })
-        .catch(done);
+      ).then(() => {
+        mocks.map(mock => mock.done());
+      });
     });
   });
 
@@ -129,7 +131,7 @@ describe('#metrics', () => {
     it('should buffer up res.write() calls', async function test() {
       const mock = createMock();
       const app = express();
-      app.use(middleware.metrics(apiKey, () => '123'));
+      app.use(middleware.metrics(apiKey, () => group));
       app.get('/test', (req, res) => {
         res.write('{"a":1,');
         res.write('"b":2,');
@@ -145,7 +147,7 @@ describe('#metrics', () => {
     it('should buffer up res.end() calls', async function test() {
       const mock = createMock();
       const app = express();
-      app.use(middleware.metrics(apiKey, () => '123'));
+      app.use(middleware.metrics(apiKey, () => group));
       app.get('/test', (req, res) => res.end(JSON.stringify(responseBody)));
 
       await request(app).get('/test').expect(200);
@@ -156,7 +158,7 @@ describe('#metrics', () => {
     it('should work for res.send() calls', async function test() {
       const mock = createMock();
       const app = express();
-      app.use(middleware.metrics(apiKey, () => '123'));
+      app.use(middleware.metrics(apiKey, () => group));
       app.get('/test', (req, res) => res.send(responseBody));
 
       await request(app).get('/test').expect(200);

--- a/packages/node/config/default.json
+++ b/packages/node/config/default.json
@@ -1,5 +1,4 @@
 {
   "host": "https://metrics.readme.io",
-  "readmeUrl": "https://dash.readme.io",
   "bufferLength": 1
 }

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -52,7 +52,7 @@ module.exports.metrics = (apiKey, group, options = {}, cb = () => {}) => {
             json,
           })
           // We only expose this callback for testing purposes
-          .response.catch((e) => cb && cb(e));
+          .response.catch(e => cb && cb(e));
       }
 
       cleanup(); // eslint-disable-line no-use-before-define

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -52,7 +52,7 @@ module.exports.metrics = (apiKey, group, options = {}, cb = () => {}) => {
             json,
           })
           // We only expose this callback for testing purposes
-          .response.catch(e => cb && cb(e));
+          .response.catch(/* istanbul ignore next */ e => cb && cb(e));
       }
 
       cleanup(); // eslint-disable-line no-use-before-define

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -26,7 +26,7 @@ function patchResponse(res) {
   };
 }
 
-module.exports.metrics = (apiKey, group, options = {}, cb = () => {}) => {
+module.exports.metrics = (apiKey, group, options = {}) => {
   if (!apiKey) throw new Error('You must provide your ReadMe API key');
   if (!group) throw new Error('You must provide a grouping function');
 
@@ -46,13 +46,10 @@ module.exports.metrics = (apiKey, group, options = {}, cb = () => {}) => {
       if (queue.length >= bufferLength) {
         const json = queue.slice();
         queue = [];
-        request
-          .post(`${config.host}/v1/request`, {
-            headers: { authorization: `Basic ${encoded}` },
-            json,
-          })
-          // We only expose this callback for testing purposes
-          .response.catch(/* istanbul ignore next */ e => cb && cb(e));
+        request.post(`${config.host}/v1/request`, {
+          headers: { authorization: `Basic ${encoded}` },
+          json,
+        });
       }
 
       cleanup(); // eslint-disable-line no-use-before-define


### PR DESCRIPTION
> Previously started on as https://github.com/readmeio/readme-node/pull/7 but pulled over here to be completed.

## 🧰 What's being changed?

This resolves a race condition where our buffer doesn't always get cleaned out after logs are attempted to be sent.
