### PR TITLE
feat: reworking `x-readme-log` into `x-documentation-url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the monorepo for the following [ReadMe Metrics](https://readme.com/metri
 
 | Language / Framework | Package | Version |
 | :--- | :--- | :--- |
-| NodeJS (General) | [readmeio](https://github.com/readmeio/metrics-sdks/tree/master/packages/node) | ![](https://img.shields.io/npm/v/readmeio) |
+| NodeJS (Express) | [readmeio](https://github.com/readmeio/metrics-sdks/tree/master/packages/node) | ![](https://img.shields.io/npm/v/readmeio) |
 | PHP (Laravel) | [readme/metrics](https://github.com/readmeio/metrics-sdks/tree/master/packages/php) | ![](https://img.shields.io/packagist/v/readme/metrics) |
 
 Want to build your own SDK for Developer Metrics? [Check out our guide.](https://docs.readme.com/metrics/docs/building-api-metrics-middleware)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This is the monorepo for the following [ReadMe Metrics](https://readme.com/metrics/) SDKs:
 
-* [readmeio](https://github.com/readmeio/metrics-sdks/tree/master/packages/node) (NodeJS)
-* [readme/metrics](https://github.com/readmeio/metrics-sdks/tree/master/packages/php) (PHP)
+| Language / Framework | Package | Version |
+| :--- | :--- | :--- |
+| NodeJS (General) | [readmeio](https://github.com/readmeio/metrics-sdks/tree/master/packages/node) | ![](https://img.shields.io/npm/v/readmeio) |
+| PHP (Laravel) | [readme/metrics](https://github.com/readmeio/metrics-sdks/tree/master/packages/php) | ![](https://img.shields.io/packagist/v/readme/metrics) |
 
-
-Guide for building SDKs for Developer Metrics: https://docs.readme.com/metrics/docs/building-api-metrics-middleware
+Want to build your own SDK for Developer Metrics? [Check out our guide.](https://docs.readme.com/metrics/docs/building-api-metrics-middleware)

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -15,7 +15,7 @@ npm install readmeio
 
 ## Usage
 
-Just add the middleware to express, and that's it!
+Just add the middleware to [Express](https://expressjs.com/), and that's it!
 
 ```javascript
 const readme = require('readmeio');

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -21,25 +21,43 @@ Just add the middleware to [Express](https://expressjs.com/), and that's it!
 const readme = require('readmeio');
 
 app.use(readme.metrics('<<apiKey>>', req => ({
-  id: req.project._id,
-  label: req.project.name,
-  email: req.project.owner
+  id: req.<userId>,
+  label: req.<userNameToShowInDashboard>,
+  email: req.<userEmailAddress>,
 })));
 ```
 
 View full documentation here: [https://docs.readme.com/docs/sending-logs-to-readme-with-nodejs](https://docs.readme.com/docs/sending-logs-to-readme-with-nodejs)
 
+### Configuration Options
+There are a few options you can pass in to change how the logs are sent to ReadMe. These are passed in an object as the third parameter to the `readme.metrics`.
+
+```js
+const readme = require('readmeio');
+const env = process.env.NODE_ENV;
+
+app.use(readme.metrics('', req => ({
+  id: req.<userId>,
+  label: req.<userNameToShowInDashboard>,
+  email: req.<userEmailAddress>,
+}), {
+  development: env !== 'production',
+  bufferLength: 1,
+  blacklist: [[arrayOfSensitiveKeysToOmit]],
+  whitelist: [[arrayofKeysOnlyToSend]],
+}));
+```
+
+| Option | Use |
+| :--- | :--- |
+| development | **default: false** If true, the log will be separate from normal production logs. This is great for separating staging or test data from data coming from customers |
+| bufferLength | **default: 10** By default, we only send logs to ReadMe after 10 requests are made. Depending on the usage of your API it make make sense to send logs more or less frequently |
+| blacklist | **optional** An array of keys from your API requests and responses headers and bodies that you wish to blacklist from sending to ReadMe.<br /><br />If you configure a blacklist, it will override any whitelist configuration. |
+| whitelist | **optional** An array of keys from your API requests and responses headers and bodies that you only wish to send to ReadMe. |
+| baseLogUrl | **optional** This is the base URL for your ReadMe project. Normally this would be `https://projectName.readme.io` or `https://docs.yourdomain.com`, however if this value is not supplied, a request to the ReadMe API will be made once a day to retrieve. This data will be cached to `node_modules/.cache/readmeio`.
 
 ### Limitations
 - Currently only supports JSON request bodies. Adding a whitelist/blacklist for non-JSON bodies will not work (unless they're added to `req.body`) the same way that `body-parser` does it. The properties will be passed into [`postData`](http://www.softwareishard.com/blog/har-12-spec/#postData) as a `params` array.
 - Needs more support for getting URLs when behind a reverse proxy: `x-forwarded-for`, `x-forwarded-proto`, etc.
 - Needs more support for getting client IP address when behind a reverse proxy.
 - Logs are "fire and forget" to the metrics server, so any failed requests (even for incorrect API key!) will currently fail silently.
-
-## Credits
-[Dom Harrington](https://github.com/domharrington/)
-[Marc Cuva](https://github.com/mjcuva/)
-
-## License
-
-ISC

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -29,6 +29,13 @@ app.use(readme.metrics('<<apiKey>>', req => ({
 
 View full documentation here: [https://docs.readme.com/docs/sending-logs-to-readme-with-nodejs](https://docs.readme.com/docs/sending-logs-to-readme-with-nodejs)
 
+### `res.headers['x-documentation-url']`
+With the middleware loaded, all requests that funneled through it will receive a `x-documentation-url` header applied to the response. The value of this header will be the URL on ReadMe Metrics with which you can view the log for that request.
+
+Note that in order to generate this URL, an API request is made to ReadMe once a day, and cached to a local file in `node_modules/.cache/readmeio`, to retrieve your projects `baseUrl`. If this request to ReadMe fails, the `x-documentation-url` header will not be added to responses.
+
+If you wish to not rely on this cache, you can opt to supply a `baseLogUrl` option into the middleware, which should evaluate to the public-facing URL of your ReadMe project.
+
 ### Configuration Options
 There are a few options you can pass in to change how the logs are sent to ReadMe. These are passed in an object as the third parameter to the `readme.metrics`.
 
@@ -54,7 +61,7 @@ app.use(readme.metrics('', req => ({
 | bufferLength | **default: 10** By default, we only send logs to ReadMe after 10 requests are made. Depending on the usage of your API it make make sense to send logs more or less frequently |
 | blacklist | **optional** An array of keys from your API requests and responses headers and bodies that you wish to blacklist from sending to ReadMe.<br /><br />If you configure a blacklist, it will override any whitelist configuration. |
 | whitelist | **optional** An array of keys from your API requests and responses headers and bodies that you only wish to send to ReadMe. |
-| baseLogUrl | **optional** This is the base URL for your ReadMe project. Normally this would be `https://projectName.readme.io` or `https://docs.yourdomain.com`, however if this value is not supplied, a request to the ReadMe API will be made once a day to retrieve. This data will be cached to `node_modules/.cache/readmeio`.
+| baseLogUrl | **optional** This is the base URL for your ReadMe project. Normally this would be `https://projectName.readme.io` or `https://docs.yourdomain.com`, however if this value is not supplied, a request to the ReadMe API will be made once a day to retrieve it. This data is cached into `node_modules/.cache/readmeio`.
 
 ### Limitations
 - Currently only supports JSON request bodies. Adding a whitelist/blacklist for non-JSON bodies will not work (unless they're added to `req.body`) the same way that `body-parser` does it. The properties will be passed into [`postData`](http://www.softwareishard.com/blog/har-12-spec/#postData) as a `params` array.

--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -271,7 +271,7 @@ describe('#metrics', () => {
       metricsMock.done();
     });
 
-    it('should refresh the cache if out of date', async () => {
+    it('should refresh the cache if stale', async () => {
       // Hydate and postdate the cache to two days ago so it'll bee seen as stale.
       hydrateCache(Math.round(Date.now() / 1000 - 86400 * 2));
 

--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -37,11 +37,11 @@ function hydrateCache(lastUpdated) {
 }
 
 expect.extend({
-  toHaveLogHeader(res) {
+  toHaveDocumentationHeader(res) {
     const { matcherHint, printExpected, printReceived } = this.utils;
     const message = (pass, actual) => () => {
       return (
-        `${matcherHint(pass ? '.not.toHaveLogHeader' : '.toHaveLogHeader')}\n\n` +
+        `${matcherHint(pass ? '.not.toHaveDocumentationHeader' : '.toHaveDocumentationHeader')}\n\n` +
         `Expected response headers to have a ${printExpected('x-documentation-url')} header with a valid UUIDv4 ID.\n` +
         'Received:\n' +
         `\t${printReceived(actual)}`
@@ -105,7 +105,7 @@ describe('#metrics', () => {
     return request(app)
       .get('/test')
       .expect(200)
-      .expect(res => expect(res).toHaveLogHeader())
+      .expect(res => expect(res).toHaveDocumentationHeader())
       .then(() => {
         apiMock.done();
         mock.done();
@@ -133,7 +133,7 @@ describe('#metrics', () => {
         .get('/test')
         .expect(200)
         .expect(res => {
-          expect(res).toHaveLogHeader();
+          expect(res).toHaveDocumentationHeader();
           logUrl = res.headers['x-documentation-url'];
         });
 
@@ -144,7 +144,7 @@ describe('#metrics', () => {
         .get('/test')
         .expect(200)
         .expect(res => {
-          expect(res).toHaveLogHeader();
+          expect(res).toHaveDocumentationHeader();
           expect(res.headers['x-documentation-url']).not.toBe(logUrl);
           logUrl = res.headers['x-documentation-url'];
         });
@@ -155,7 +155,7 @@ describe('#metrics', () => {
         .get('/test')
         .expect(200)
         .expect(res => {
-          expect(res).toHaveLogHeader();
+          expect(res).toHaveDocumentationHeader();
           expect(res.headers['x-documentation-url']).not.toBe(logUrl);
         });
 
@@ -219,7 +219,7 @@ describe('#metrics', () => {
       await request(app)
         .get('/test')
         .expect(200)
-        .expect(res => expect(res).toHaveLogHeader());
+        .expect(res => expect(res).toHaveDocumentationHeader());
 
       mock.done();
     });
@@ -236,7 +236,7 @@ describe('#metrics', () => {
       await request(app)
         .get('/test')
         .expect(200)
-        .expect(res => expect(res).toHaveLogHeader());
+        .expect(res => expect(res).toHaveDocumentationHeader());
 
       // Spin up a new app so we're forced to look for the baseUrl in the cache instead of what's saved in-memory
       // within the middleware.
@@ -248,7 +248,7 @@ describe('#metrics', () => {
       await request(app2)
         .get('/test')
         .expect(200)
-        .expect(res => expect(res).toHaveLogHeader());
+        .expect(res => expect(res).toHaveDocumentationHeader());
 
       apiMock.done();
       metricsMock.done();
@@ -265,7 +265,7 @@ describe('#metrics', () => {
       await request(app)
         .get('/test')
         .expect(200)
-        .expect(res => expect(res).toHaveLogHeader());
+        .expect(res => expect(res).toHaveDocumentationHeader());
 
       apiMock.done();
       metricsMock.done();
@@ -285,7 +285,7 @@ describe('#metrics', () => {
       await request(app)
         .get('/test')
         .expect(200)
-        .expect(res => expect(res).toHaveLogHeader());
+        .expect(res => expect(res).toHaveDocumentationHeader());
 
       apiMock.done();
       metricsMock.done();
@@ -337,7 +337,7 @@ describe('#metrics', () => {
       await request(app)
         .get('/test')
         .expect(200)
-        .expect(res => expect(res).toHaveLogHeader());
+        .expect(res => expect(res).toHaveDocumentationHeader());
 
       mock.done();
     });
@@ -351,7 +351,7 @@ describe('#metrics', () => {
       await request(app)
         .get('/test')
         .expect(200)
-        .expect(res => expect(res).toHaveLogHeader());
+        .expect(res => expect(res).toHaveDocumentationHeader());
 
       mock.done();
     });

--- a/packages/node/config/default.json
+++ b/packages/node/config/default.json
@@ -1,5 +1,5 @@
 {
   "host": "https://metrics.readme.io",
-  "readmeUrl": "https://dash.readme.io",
+  "readmeApiUrl": "https://dash.readme.io/api",
   "bufferLength": 1
 }

--- a/packages/node/config/localhost.json
+++ b/packages/node/config/localhost.json
@@ -1,3 +1,4 @@
 {
-  "host": "http://localhost:3003"
+  "host": "http://localhost:3003",
+  "readmeApiUrl": "https://dash.readme.local:3000/api/"
 }

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -1,6 +1,10 @@
 const fetch = require('node-fetch');
 const { v4: uuidv4 } = require('uuid');
+const crypto = require('crypto');
 const config = require('./config');
+const flatCache = require('flat-cache');
+const findCacheDir = require('find-cache-dir');
+const pkg = require('./package.json');
 
 const constructPayload = require('./lib/construct-payload');
 
@@ -27,19 +31,59 @@ function patchResponse(res) {
   };
 }
 
+async function getProjectBaseUrl(encodedApiKey) {
+  const cacheDir = findCacheDir({ name: pkg.name, create: true });
+  const fsSafeApikey = crypto.createHash('md5').update(encodedApiKey).digest('hex');
+
+  // Since we might have differences of cache management, set the package version into the cache key so all caches will
+  // automatically get refreshed when the package is updated/installed.
+  const cacheKey = `${pkg.name}-${pkg.version}-${fsSafeApikey}`;
+
+  const cache = flatCache.load(cacheKey, cacheDir);
+
+  // Does the cache exist? If it doesn't, let's fill it. If it does, let's see if it's stale. Caches should have a TTL
+  // of 1 day.
+  const lastUpdated = cache.getKey('lastUpdated');
+
+  if (
+    lastUpdated === undefined ||
+    (lastUpdated !== undefined && Math.abs(lastUpdated - Math.round(Date.now() / 1000)) >= 86400)
+  ) {
+    const project = await fetch(`${config.readmeApiUrl}/v1/`, {
+      method: 'get',
+      headers: {
+        Authorization: `Basic ${encodedApiKey}`,
+      },
+    }).then(res => res.json());
+
+    cache.setKey('baseUrl', project.baseUrl);
+    cache.setKey('lastUpdated', Math.round(Date.now() / 1000));
+    cache.save();
+
+    return project.baseUrl;
+  }
+
+  return cache.getKey('baseUrl');
+}
+
 module.exports.metrics = (apiKey, group, options = {}) => {
   if (!apiKey) throw new Error('You must provide your ReadMe API key');
   if (!group) throw new Error('You must provide a grouping function');
 
   const bufferLength = options.bufferLength || config.bufferLength;
-  const encoded = Buffer.from(`${apiKey}:`).toString('base64');
+  const encodedApiKey = Buffer.from(`${apiKey}:`).toString('base64');
+  let baseLogUrl = options.baseLogUrl || undefined;
   let queue = [];
 
-  return (req, res, next) => {
+  return async (req, res, next) => {
+    if (baseLogUrl === undefined) {
+      baseLogUrl = await getProjectBaseUrl(encodedApiKey);
+    }
+
     const startedDateTime = new Date();
     const logId = uuidv4();
 
-    res.setHeader('x-readme-log', logId);
+    res.setHeader('x-documentation-url', `${baseLogUrl}/logs/${logId}`);
     patchResponse(res);
 
     function send() {
@@ -53,7 +97,7 @@ module.exports.metrics = (apiKey, group, options = {}) => {
           method: 'post',
           body: JSON.stringify(queue),
           headers: {
-            Authorization: `Basic ${encoded}`,
+            Authorization: `Basic ${encodedApiKey}`,
           },
         })
           .then(() => {

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -1,4 +1,4 @@
-const request = require('r2');
+const fetch = require('node-fetch');
 const { v4: uuidv4 } = require('uuid');
 const config = require('./config');
 
@@ -49,12 +49,17 @@ module.exports.metrics = (apiKey, group, options = {}) => {
       const payload = constructPayload(req, res, group, options, { logId, startedDateTime });
       queue.push(payload);
       if (queue.length >= bufferLength) {
-        request
-          .post(`${config.host}/v1/request`, {
-            headers: { authorization: `Basic ${encoded}` },
-            json: queue,
+        fetch(`${config.host}/v1/request`, {
+          method: 'post',
+          body: JSON.stringify(queue),
+          headers: {
+            Authorization: `Basic ${encoded}`,
+          },
+        })
+          .then(() => {
+            queue = [];
           })
-          .response.then(() => {
+          .catch(() => {
             queue = [];
           });
       }

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1491,8 +1491,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1580,7 +1579,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1840,6 +1838,11 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+    },
     "compare-func": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
@@ -1859,8 +1862,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "confusing-browser-globals": {
       "version": "1.0.9",
@@ -3470,6 +3472,69 @@
         "unpipe": "~1.0.0"
       }
     },
+    "find-cache-dir": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        }
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -3483,18 +3548,26 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-      "dev": true,
       "requires": {
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-      "dev": true
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -3549,8 +3622,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
@@ -3996,7 +4068,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4310,7 +4381,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4319,8 +4389,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -5812,7 +5881,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
       "requires": {
         "semver": "^6.0.0"
       },
@@ -5820,8 +5888,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -6061,7 +6128,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -6069,8 +6135,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "4.0.2",
@@ -6115,7 +6180,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -6438,7 +6502,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6553,8 +6616,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -7081,9 +7143,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -8526,14 +8588,12 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1674,7 +1674,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.1",
@@ -4569,7 +4570,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -6766,16 +6768,6 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
-    "r2": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/r2/-/r2-2.0.1.tgz",
-      "integrity": "sha512-EEmxoxYCe3LHzAUhRIRxdCKERpeRNmlLj6KLUSORqnK6dWl/K5ShmDGZqM2lRZQeqJgF+wyqk0s1M7SWUveNOQ==",
-      "requires": {
-        "caseless": "^0.12.0",
-        "node-fetch": "^2.0.0-alpha.8",
-        "typedarray-to-buffer": "^3.1.2"
-      }
-    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8229,6 +8221,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,6 +7,8 @@
   },
   "dependencies": {
     "content-type": "^1.0.4",
+    "find-cache-dir": "^3.3.1",
+    "flat-cache": "^2.0.1",
     "lodash": "^4.17.15",
     "node-fetch": "^2.6.0",
     "uuid": "^8.2.0"
@@ -40,6 +42,7 @@
     "jsinspect": "^0.12.7",
     "nock": "^13.0.0",
     "prettier": "^2.0.1",
+    "rimraf": "^3.0.2",
     "supertest": "^4.0.2"
   },
   "jest": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "content-type": "^1.0.4",
     "lodash": "^4.17.15",
-    "r2": "^2.0.1",
+    "node-fetch": "^2.6.0",
     "uuid": "^8.2.0"
   },
   "scripts": {

--- a/packages/php/README.md
+++ b/packages/php/README.md
@@ -27,3 +27,20 @@ php artisan vendor:publish --provider="ReadMe\ServiceProvider"
 3. In that config file, you will also see a `group_handler` that will be set to `App\Handler\ReadMe::class`. This file will exist within `app\Handler` in your application and you should change the contents of its `constructGroup` function to return data that's relevant to your codebase and users. We've provided some simple defaults but you'll likely need to change them.
 
 Once you've done all that, add `\ReadMe\Middleware::class` into your API middleware in `app/Http/Kernel.php` and API Metrics will start streaming to your ReadMe project!
+
+### `res.headers['x-documentation-url']`
+With the middleware loaded, all requests that funneled through it will receive a `x-documentation-url` header applied to the response. The value of this header will be the URL on ReadMe Metrics with which you can view the log for that request.
+
+Note that in order to generate this URL, an API request is made to ReadMe once a day, and cached to a local file in `$COMPOSER_HOME/cache`, to retrieve your projects `base_url`. If this request to ReadMe fails, the `x-documentation-url` header will not be added to responses.
+
+If you wish to not rely on this cache, you can opt to supply a `base_log_url` option within `config/readme.php`. This value should evaluate to the public-facing URL of your ReadMe project.
+
+### Configuration Options
+There are a few options you can pass in to change how the logs are sent to ReadMe. These are configured within `config/readme.php`.
+
+| Option | Use |
+| :--- | :--- |
+| development_mode | **default: false** If true, the log will be separate from normal production logs. This is great for separating staging or test data from data coming from customers |
+| blacklist | **optional** An array of keys from your API requests and responses headers and bodies that you wish to blacklist from sending to ReadMe.<br /><br />If you configure a blacklist, it will override any whitelist configuration. |
+| whitelist | **optional** An array of keys from your API requests and responses headers and bodies that you only wish to send to ReadMe. |
+| base_log_url | **optional** This is the base URL for your ReadMe project. Normally this would be `https://projectName.readme.io` or `https://docs.yourdomain.com`, however if this value is not supplied, a request to the ReadMe API will be made once a day to retrieve it. This data is cached into `$COMPOSER_HOME/cache`.

--- a/packages/php/composer.json
+++ b/packages/php/composer.json
@@ -24,13 +24,14 @@
     "illuminate/support": "^6.8 | ^7.0",
     "guzzlehttp/guzzle": "^6.4",
     "ocramius/package-versions": "^1.4",
-    "ramsey/uuid": "^3.7 | ^4.0"
+    "ramsey/uuid": "^3.7 | ^4.0",
+    "composer/composer": "^1.10"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",
     "squizlabs/php_codesniffer": "^3.5",
     "mockery/mockery": "^1.3",
-    "vimeo/psalm": ">=3.10"
+    "vimeo/psalm": "^3.12"
   },
   "extra": {
     "laravel": {

--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -3,9 +3,11 @@
 namespace ReadMe;
 
 use Closure;
+use Composer\Factory;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Exception\ClientException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -19,6 +21,7 @@ class Metrics
 {
     protected const PACKAGE_NAME = 'readme/metrics';
     protected const METRICS_API = 'https://metrics.readme.io';
+    protected const README_API = 'https://dash.readme.io';
 
     /** @var string */
     private $api_key;
@@ -32,6 +35,9 @@ class Metrics
     /** @var array */
     private $whitelist = [];
 
+    /** @var string|null */
+    private $base_log_url = null;
+
     /** @var class-string */
     private $group_handler;
 
@@ -41,8 +47,17 @@ class Metrics
     /** @var Client */
     private $client;
 
+    /** @var Client */
+    private $readme_api_client;
+
     /** @var string */
     private $package_version;
+
+    /** @var string */
+    private $cache_dir;
+
+    /** @var string */
+    private $user_agent;
 
     /**
      * @param string $api_key
@@ -51,7 +66,7 @@ class Metrics
      */
     public function __construct(string $api_key, string $group_handler, array $options = [])
     {
-        $this->api_key = $api_key;
+        $this->api_key = base64_encode($api_key . ':');
         $this->group_handler = $group_handler;
         $this->development_mode = array_key_exists('development_mode', $options)
             ? (bool)$options['development_mode']
@@ -65,20 +80,32 @@ class Metrics
             $this->whitelist = $options['whitelist'];
         }
 
+        if (!empty($options['base_log_url'])) {
+            $this->base_log_url = $options['base_log_url'];
+        }
+
+        // In development mode, requests are sent asynchronously (as well as PHP can without directly invoking
+        // shell cURL commands), so a very small timeout here ensures that the Metrics code will finish as fast as
+        // possible, send the POST request to the background and continue on with whatever else the application
+        // needs to execute.
+        $curl_timeout = (!$this->development_mode) ? 0.2 : 0;
+
         $this->curl_handler = new CurlMultiHandler();
         $this->client = (isset($options['client'])) ? $options['client'] : new Client([
             'handler' => HandlerStack::create($this->curl_handler),
-
             'base_uri' => self::METRICS_API,
+            'timeout' => $curl_timeout,
+        ]);
 
-            // In development mode, requests are sent asynchronously (as well as PHP can without directly invoking
-            // shell cURL commands), so a very small timeout here ensures that the Metrics code will finish as fast as
-            // possible, send the POST request to the background and continue on with whatever else the application
-            // needs to execute.
-            'timeout' => (!$this->development_mode) ? 0.2 : 0,
+        $this->readme_api_client = (isset($options['client_readme'])) ? $options['client_readme'] : new Client([
+            'base_uri' => self::README_API,
+            'timeout' => $curl_timeout,
         ]);
 
         $this->package_version = Versions::getVersion(self::PACKAGE_NAME);
+        $this->cache_dir = Factory::createConfig()->get('cache-dir');
+
+        $this->user_agent = 'readme-metrics-php/' . $this->package_version;
     }
 
     /**
@@ -90,14 +117,21 @@ class Metrics
      */
     public function track(Request $request, &$response): void
     {
+        if (empty($this->base_log_url)) {
+            $this->base_log_url = $this->getProjectBaseUrl();
+        }
+
         $log_id = Uuid::uuid4()->toString();
-        $response->headers->set('x-readme-log', $log_id);
+        if (!is_null($this->base_log_url)) {
+            // Only set the header if we have a fully-formed log URL to give to users.
+            $response->headers->set('x-documentation-url', $this->base_log_url . '/logs/' . $log_id);
+        }
 
         $payload = $this->constructPayload($log_id, $request, $response);
 
         $headers = [
-            'Authorization' => 'Basic ' . base64_encode($this->api_key . ':'),
-            'User-Agent' => 'readme-metrics-php/' . $this->package_version
+            'Authorization' => 'Basic ' . $this->api_key,
+            'User-Agent' => $this->user_agent
         ];
 
         // If not in development mode, all requests should be async.
@@ -254,6 +288,100 @@ class Metrics
                 'mimeType' => $response->headers->get('Content-Type')
             ]
         ];
+    }
+
+    /**
+     * Make an API request to ReadMe to retrieve the base log URL that'll be used to populate the `x-documentation-url`
+     * header.
+     *
+     * @return string|null
+     */
+    private function getProjectBaseUrl(): ?string
+    {
+        $cache_file = $this->getCacheFile();
+        $cache = new \stdClass();
+        if (file_exists($cache_file)) {
+            try {
+                $cache = file_get_contents($cache_file);
+                $cache = json_decode($cache);
+            } catch (\Exception $e) {
+                // If we can't decode the cache then we should act as if it doesn't exist and let it rehydrate itself.
+            }
+        }
+
+        // Does the cache exist? If it doesn't, let's fill it. If it does, let's see if it's stale. Caches should have
+        // a TTL of 1 day.
+        $last_updated = property_exists($cache, 'last_updated') ? $cache->last_updated : null;
+
+        if (is_null($last_updated) || (!is_null($last_updated) && abs($last_updated - time()) > 86400)) {
+            try {
+                $response = $this->readme_api_client->get('/api/v1/', [
+                    'headers' => [
+                        'Authorization' => 'Basic ' . $this->api_key,
+                        'User-Agent' => $this->user_agent
+                    ],
+                ]);
+
+                $json = (string) $response->getBody();
+                $json = json_decode($json);
+
+                $cache->last_updated = time();
+                $cache->base_url = $json->baseUrl;
+            } catch (\Exception $e) {
+                // If we're running in development mode, toss any errors that happen when we try to call the ReadMe API.
+                //
+                // These errors will likely be from invalid API keys, so it'll be good to surface those to users before
+                // it hits production.
+                if ($this->development_mode) {
+                    try {
+                        // If we don't have a ClientException here, throw again so we end up below and handle this
+                        // exception as a non-HTTP response problem.
+                        if (!($e instanceof ClientException)) {
+                            throw $e;
+                        }
+
+                        /** @psalm-suppress PossiblyNullReference */
+                        $json = (string) $e->getResponse()->getBody();
+                        $json = json_decode($json);
+                    } catch (\Exception $e) {
+                        $ex = new MetricsException($e->getMessage());
+                        throw $ex;
+                    }
+
+                    throw new MetricsException($json->message);
+                }
+
+                // If unable to access the ReadMe API for whatever reason, let's set the last updated time to two
+                // minutes from now yesterday so that in 2 minutes we'll automatically make another attempt.
+                $cache->last_updated = (time() - 86400) + 120;
+                $cache->base_url = null;
+            }
+
+            file_put_contents($cache_file, json_encode($cache));
+        }
+
+        return $cache->base_url;
+    }
+
+    /**
+     * Retrieve the cache file that'll be used to store the base URL for the `x-documentation-url` header.
+     *
+     * @return string
+     */
+    public function getCacheFile(): string
+    {
+        // Since we might have differences of cache management, set the package version into the cache key so all
+        // caches will automatically get refreshed when the package is updated/installed.
+        $cache_key = join('-', [
+            str_replace('/', '_', self::PACKAGE_NAME),
+            $this->package_version,
+            md5($this->api_key)
+        ]);
+
+        // Replace potentially unsafe characters in the cache key so it can be safely used as a filename on the server.
+        $cache_key = str_replace([DIRECTORY_SEPARATOR, '@'], '-', $cache_key);
+
+        return $this->cache_dir . DIRECTORY_SEPARATOR . $cache_key;
     }
 
     /**

--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -325,8 +325,8 @@ class Metrics
                 $json = (string) $response->getBody();
                 $json = json_decode($json);
 
-                $cache->last_updated = time();
                 $cache->base_url = $json->baseUrl;
+                $cache->last_updated = time();
             } catch (\Exception $e) {
                 // If we're running in development mode, toss any errors that happen when we try to call the ReadMe API.
                 //
@@ -353,8 +353,8 @@ class Metrics
 
                 // If unable to access the ReadMe API for whatever reason, let's set the last updated time to two
                 // minutes from now yesterday so that in 2 minutes we'll automatically make another attempt.
-                $cache->last_updated = (time() - 86400) + 120;
                 $cache->base_url = null;
+                $cache->last_updated = (time() - 86400) + 120;
             }
 
             file_put_contents($cache_file, json_encode($cache));

--- a/packages/php/src/Middleware.php
+++ b/packages/php/src/Middleware.php
@@ -18,7 +18,8 @@ class Middleware
             [
                 'development_mode' => config('readme.development_mode', false),
                 'blacklist' => config('readme.blacklist', []),
-                'whitelist' => config('readme.whitelist', [])
+                'whitelist' => config('readme.whitelist', []),
+                'base_log_url' => config('readme.base_log_url'),
             ]
         );
     }

--- a/packages/php/src/config.dist.php
+++ b/packages/php/src/config.dist.php
@@ -46,4 +46,17 @@ return [
      * be whitelisted.
      */
     'whitelist' => [],
+
+    /**
+     * Optionally, this is the base URL for your ReadMe project.
+     *
+     * This URL will be the basis for the `x-documentation-url` that's applied to
+     * responses that contains the URL to the log in ReadMe Metrics.
+     *
+     * Normally this would be https://projectName.readme.io or
+     * https://docs.yourdomain.com, however if this value is not supplied, a
+     * request to the ReadMe API will be made once a day to retrieve it. This data
+     * will is cached into `$COMPOSER_HOME/cache`.
+     */
+    'base_log_url' => null,
 ];

--- a/packages/php/tests/ConfigTest.php
+++ b/packages/php/tests/ConfigTest.php
@@ -13,7 +13,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             'group_handler',
             'development_mode',
             'blacklist',
-            'whitelist'
+            'whitelist',
+            'base_log_url'
         ], array_keys($config));
     }
 }

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -62,6 +62,18 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
     /** @var class-string */
     private $group_handler = TestHandler::class;
 
+    /** @var array */
+    private $api_calls = [];
+
+    /** @var array */
+    private $api_calls_to_readme = [];
+
+    /** @var string */
+    private $api_key = 'mockReadMeApiKey';
+
+    /** @var string */
+    private $base_log_url = 'https://docs.example.com';
+
     /** @var string */
     private $log_uuid;
 
@@ -77,51 +89,57 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->requests = [];
-
-        $this->metrics = new Metrics('fakeApiKey', $this->group_handler);
+        $this->metrics = new Metrics($this->api_key, $this->group_handler);
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        $this->requests = [];
+        $this->api_calls = [];
+        $this->api_calls_to_readme = [];
+
+        // Clean up the cache dir between tests. Caching to the filesystem should probably be mocked out. 🤷‍♂️
+        $cache_file = $this->metrics->getCacheFile();
+        if (file_exists($cache_file)) {
+            unlink($cache_file);
+        }
     }
 
     /**
+     * @group track
      * @dataProvider providerDevelopmentModeToggle
      * @param bool $development_mode
      */
     public function testTrack(bool $development_mode): void
     {
-        // Mock out a 200 request from the Metrics server.
-        $mock = new MockHandler([
+        // Mock out a 200 request from the Metrics and ReadMe APIs.
+        $handlers = $this->getMockHandlers(
             new \GuzzleHttp\Psr7\Response(200, [], 'OK'),
-        ]);
+            new \GuzzleHttp\Psr7\Response(200, [], json_encode(['baseUrl' => $this->base_log_url]))
+        );
 
-        $handlerStack = HandlerStack::create($mock);
-        $handlerStack->push(Middleware::history($this->requests));
-
-        $metrics = new Metrics('fakeApiKey', $this->group_handler, [
+        $this->metrics = new Metrics($this->api_key, $this->group_handler, [
             'development_mode' => $development_mode,
-            'client' => new Client(['handler' => $handlerStack])
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
         ]);
 
         $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
         $response = $this->getMockJsonResponse();
 
-        $metrics->track($request, $response);
+        $this->metrics->track($request, $response);
 
-        // Assert that the x-readme-log header was properly added into the current response.
-        $this->assertContains('x-readme-log', array_keys($response->headers->all()));
-        $log_header_id = array_shift($response->headers->all()['x-readme-log']);
-        $this->assertRegExp(self::UUID_PATTERN, $log_header_id);
+        // Assert that the `x-documentation-url` header was properly added into the current response.
+        $this->assertContains('x-documentation-url', array_keys($response->headers->all()));
+        $documentation_header = array_shift($response->headers->all()['x-documentation-url']);
+        $log_id = $this->getLogIdFromDocumentationHeader($documentation_header);
+        $this->assertRegExp(self::UUID_PATTERN, $log_id);
 
         // Assert that we only tracked a single request and also the payload looks as expected.
-        $this->assertCount(1, $this->requests);
+        $this->assertCount(1, $this->api_calls);
 
-        $actual_request = array_shift($this->requests);
+        $actual_request = array_shift($this->api_calls);
         $actual_request = $actual_request['request'];
 
         $this->assertSame('/request', $actual_request->getRequestTarget());
@@ -131,7 +149,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
 
         $actual_payload = array_shift($actual_payload);
         $this->assertSame(['_id', 'group', 'clientIPAddress', 'development', 'request'], array_keys($actual_payload));
-        $this->assertSame($log_header_id, $actual_payload['_id']);
+        $this->assertSame($log_id, $actual_payload['_id']);
 
         $this->assertSame([
             'method' => 'GET',
@@ -160,13 +178,14 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         // Make sure that our x-readme-log header ended up being logged as a response header in the metrics request.
         $response_headers = $actual_payload['request']['log']['entries'][0]['response']['headers'];
         $readme_log_header = array_filter($response_headers, function ($header) {
-            return $header['name'] === 'x-readme-log';
+            return $header['name'] === 'x-documentation-url';
         });
 
-        $this->assertSame($log_header_id, array_shift($readme_log_header)['value']);
+        $this->assertSame($log_id, $this->getLogIdFromDocumentationHeader(array_shift($readme_log_header)['value']));
     }
 
     /**
+     * @group track
      * @dataProvider providerDevelopmentModeToggle
      * @param bool $development_mode
      */
@@ -178,7 +197,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
             $this->expectExceptionMessage('ValidationError: queryString.0.value: Path `value` is required.');
         }
 
-        $mock = new MockHandler([
+        $handlers = $this->getMockHandlers(
             new \GuzzleHttp\Psr7\Response(200, [], json_encode([
                 'errors' => [
                     'queryString.0.value' => [
@@ -194,20 +213,19 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
                 'message' => 'RequestModel validation failed: queryString.0.value: Path `value` is required.',
                 'name' => 'ValidationError',
             ])),
-        ]);
+            new \GuzzleHttp\Psr7\Response(200, [], json_encode(['baseUrl' => $this->base_log_url]))
+        );
 
-        $handlerStack = HandlerStack::create($mock);
-        $metrics = new Metrics('fakeApiKey', $this->group_handler, [
+        $this->metrics = new Metrics($this->api_key, $this->group_handler, [
             'development_mode' => $development_mode,
-            'client' => new Client([
-                'handler' => $handlerStack
-            ])
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
         ]);
 
         $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
         $response = $this->getMockJsonResponse();
 
-        $metrics->track($request, $response);
+        $this->metrics->track($request, $response);
 
         if (!$development_mode) {
             $this->assertTrue(
@@ -218,6 +236,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @group track
      * @dataProvider providerDevelopmentModeToggle
      * @param bool $development_mode
      */
@@ -229,20 +248,21 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
             $this->expectExceptionMessageMatches('/500 Internal Server Error/');
         }
 
-        $mock = new MockHandler([
+        $handlers = $this->getMockHandlers(
             new \GuzzleHttp\Psr7\Response(500),
-        ]);
+            new \GuzzleHttp\Psr7\Response(200, [], json_encode(['baseUrl' => $this->base_log_url]))
+        );
 
-        $handlerStack = HandlerStack::create($mock);
-        $metrics = new Metrics('fakeApiKey', $this->group_handler, [
+        $this->metrics = new Metrics($this->api_key, $this->group_handler, [
             'development_mode' => $development_mode,
-            'client' => new Client(['handler' => $handlerStack])
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
         ]);
 
         $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
         $response = $this->getMockJsonResponse();
 
-        $metrics->track($request, $response);
+        $this->metrics->track($request, $response);
 
         if (!$development_mode) {
             $this->assertTrue(
@@ -252,13 +272,16 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    /**
+     * @group constructPayload
+     */
     public function testConstructPayload(): void
     {
         $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
         $response = $this->getMockJsonResponse();
-        $payload = $this->metrics->constructPayload('fakeId', $request, $response);
+        $payload = $this->metrics->constructPayload('fake-uuid', $request, $response);
 
-        $this->assertSame('fakeId', $payload['_id']);
+        $this->assertSame('fake-uuid', $payload['_id']);
 
         $this->assertSame([
             'id' => '123457890',
@@ -331,11 +354,14 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($response->headers->get('Content-Type'), $payload_response['content']['mimeType']);
     }
 
+    /**
+     * @group constructPayload
+     */
     public function testConstructPayloadWithNonJsonResponse(): void
     {
         $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
         $response = $this->getMockTextResponse();
-        $payload = $this->metrics->constructPayload('fakeId', $request, $response);
+        $payload = $this->metrics->constructPayload('fake-uuid', $request, $response);
 
         $payload_response = $payload['request']['log']['entries'][0]['response'];
         $this->assertSame(200, $payload_response['status']);
@@ -345,11 +371,14 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('text/plain', $payload_response['content']['mimeType']);
     }
 
+    /**
+     * @group constructPayload
+     */
     public function testConstructPayloadWithUploadFileInRequest(): void
     {
         $request = $this->getMockRequest([], self::MOCK_POST_PARAMS, self::MOCK_FILES_PARAMS);
         $response = $this->getMockJsonResponse();
-        $payload = $this->metrics->constructPayload('fakeId', $request, $response);
+        $payload = $this->metrics->constructPayload('fake-uuid', $request, $response);
 
         $params = $payload['request']['log']['entries'][0]['request']['postData']['params'];
         $this->assertSame([
@@ -365,6 +394,9 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         ], $params);
     }
 
+    /**
+     * @group constructPayload
+     */
     public function testConstructPayloadShouldThrowErrorIfGroupFunctionDoesNotReturnExpectedPayload(): void
     {
         $this->expectException(\TypeError::class);
@@ -373,9 +405,16 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         $request = \Mockery::mock(Request::class);
         $response = \Mockery::mock(JsonResponse::class);
 
-        (new Metrics('fakeApiKey', TestHandlerReturnsNoData::class))->constructPayload('fakeId', $request, $response);
+        (new Metrics($this->api_key, TestHandlerReturnsNoData::class))->constructPayload(
+            'fake-uuid',
+            $request,
+            $response
+        );
     }
 
+    /**
+     * @group constructPayload
+     */
     public function testConstructPayloadShouldThrowErrorIfGroupFunctionReturnsAnEmptyId(): void
     {
         $this->expectException(\TypeError::class);
@@ -384,18 +423,25 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         $request = \Mockery::mock(Request::class);
         $response = \Mockery::mock(JsonResponse::class);
 
-        (new Metrics('fakeApiKey', TestHandlerReturnsEmptyId::class))->constructPayload('fakeId', $request, $response);
+        (new Metrics($this->api_key, TestHandlerReturnsEmptyId::class))->constructPayload(
+            'fake-uuid',
+            $request,
+            $response
+        );
     }
 
+    /**
+     * @group processRequest
+     */
     public function testProcessRequestShouldFilterOutItemsInBlacklist(): void
     {
-        $metrics = new Metrics('fakeApiKey', $this->group_handler, [
+        $metrics = new Metrics($this->api_key, $this->group_handler, [
             'blacklist' => ['val', 'password']
         ]);
 
         $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS, self::MOCK_POST_PARAMS);
         $response = $this->getMockJsonResponse();
-        $payload = $metrics->constructPayload('fakeId', $request, $response);
+        $payload = $metrics->constructPayload('fake-uuid', $request, $response);
 
         $request_data = $payload['request']['log']['entries'][0]['request'];
 
@@ -412,15 +458,18 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         ], $params);
     }
 
+    /**
+     * @group processRequest
+     */
     public function testProcessRequestShouldFilterOnlyItemsInWhitelist(): void
     {
-        $metrics = new Metrics('fakeApiKey', $this->group_handler, [
+        $metrics = new Metrics($this->api_key, $this->group_handler, [
             'whitelist' => ['val', 'password']
         ]);
 
         $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS, self::MOCK_POST_PARAMS);
         $response = $this->getMockJsonResponse();
-        $payload = $metrics->constructPayload('fakeId', $request, $response);
+        $payload = $metrics->constructPayload('fake-uuid', $request, $response);
 
         $request_data = $payload['request']['log']['entries'][0]['request'];
 
@@ -436,15 +485,18 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         ], $params);
     }
 
+    /**
+     * @group processResponse
+     */
     public function testProcessResponseShouldFilterOutItemsInBlacklist(): void
     {
-        $metrics = new Metrics('fakeApiKey', $this->group_handler, [
+        $metrics = new Metrics($this->api_key, $this->group_handler, [
             'blacklist' => ['value']
         ]);
 
         $request = $this->getMockRequest();
         $response = $this->getMockJsonResponse();
-        $payload = $metrics->constructPayload('fakeId', $request, $response);
+        $payload = $metrics->constructPayload('fake-uuid', $request, $response);
 
         $content = $payload['request']['log']['entries'][0]['response']['content'];
 
@@ -454,15 +506,18 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         ], json_decode($content['text'], true));
     }
 
+    /**
+     * @group processResponse
+     */
     public function testProcessResponseShouldFilterOnlyItemsInWhitelist(): void
     {
-        $metrics = new Metrics('fakeApiKey', $this->group_handler, [
+        $metrics = new Metrics($this->api_key, $this->group_handler, [
             'whitelist' => ['value']
         ]);
 
         $request = $this->getMockRequest();
         $response = $this->getMockJsonResponse();
-        $payload = $metrics->constructPayload('fakeId', $request, $response);
+        $payload = $metrics->constructPayload('fake-uuid', $request, $response);
 
         $content = $payload['request']['log']['entries'][0]['response']['content'];
 
@@ -470,6 +525,223 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
             ['value' => '123456'],
             ['value' => 'abcdef']
         ], json_decode($content['text'], true));
+    }
+
+    /**
+     * @group getProjectBaseUrl
+     * @dataProvider providerDevelopmentModeToggle
+     * @param bool $development_mode
+     */
+    public function testProjectBaseUrlIsNotFetchedIfSuppliedAsOption(bool $development_mode): void
+    {
+        $handlers = $this->getMockHandlers(
+            new \GuzzleHttp\Psr7\Response(200),
+            new \GuzzleHttp\Psr7\Response(200, [], json_encode(['baseUrl' => $this->base_log_url]))
+        );
+
+        $this->metrics = new Metrics($this->api_key, $this->group_handler, [
+            'development_mode' => $development_mode,
+            'base_log_url' => $this->base_log_url,
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
+        ]);
+
+        $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
+        $response = $this->getMockJsonResponse();
+
+        $this->metrics->track($request, $response);
+
+        $this->assertEmpty(
+            $this->api_calls_to_readme,
+            'A call was made to ReadMe to get the baseUrl even though it was supplied.'
+        );
+    }
+
+    /**
+     * @group getProjectBaseUrl
+     * @dataProvider providerDevelopmentModeToggle
+     * @param bool $development_mode
+     */
+    public function testProjectBaseUrlNotFetchedIfCacheIsFresh(bool $development_mode): void
+    {
+        $handlers = $this->getMockHandlers(
+            new \GuzzleHttp\Psr7\Response(200),
+            new \GuzzleHttp\Psr7\Response(200, [], json_encode(['baseUrl' => $this->base_log_url]))
+        );
+
+        $this->metrics = new Metrics($this->api_key, $this->group_handler, [
+            'development_mode' => $development_mode,
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
+        ]);
+
+        // Hydrate the cache so it can be seen as fresh
+        file_put_contents($this->metrics->getCacheFile(), json_encode([
+            'last_updated' => time(),
+            'base_url' => $this->base_log_url
+        ]));
+
+        $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
+        $response = $this->getMockJsonResponse();
+
+        $this->metrics->track($request, $response);
+
+        $this->assertEmpty(
+            $this->api_calls_to_readme,
+            'A call was made to ReadMe to get the baseUrl even though it was fresh in the cache.'
+        );
+    }
+
+    /**
+     * @group getProjectBaseUrl
+     * @dataProvider providerDevelopmentModeToggle
+     * @param bool $development_mode
+     */
+    public function testProjectBaseUrlDataCacheIsRefreshedIfStale(bool $development_mode): void
+    {
+        $handlers = $this->getMockHandlers(
+            new \GuzzleHttp\Psr7\Response(200),
+            new \GuzzleHttp\Psr7\Response(200, [], json_encode(['baseUrl' => $this->base_log_url]))
+        );
+
+        $this->metrics = new Metrics($this->api_key, $this->group_handler, [
+            'development_mode' => $development_mode,
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
+        ]);
+
+        // Hydrate the cache so it can be seen as fresh
+        file_put_contents($this->metrics->getCacheFile(), json_encode([
+            'last_updated' => time() - (86400 * 2),
+            'base_url' => $this->base_log_url
+        ]));
+
+        $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
+        $response = $this->getMockJsonResponse();
+
+        $this->metrics->track($request, $response);
+
+        $this->assertCount(
+            1,
+            $this->api_calls_to_readme,
+            'A call was not made to ReadMe to get the baseUrl when the cache is stale.'
+        );
+    }
+
+    /**
+     * @group getProjectBaseUrl
+     */
+    public function testProjectBaseUrlIsTemporarilyIfReadMeCallFailsWhileNotInDevelopmentMode(): void
+    {
+        $handlers = $this->getMockHandlers(
+            new \GuzzleHttp\Psr7\Response(200),
+            new \GuzzleHttp\Psr7\Response(401, [], json_encode([
+                'error' => 'APIKEY_NOTFOUNDD',
+                'message' => "We couldn't find your API key",
+                'suggestion' => "The API key you passed in (moc··········Key) doesn't match any keys we have in our " .
+                    'system. API keys must be passed in as the username part of basic auth. You can get your API ' .
+                    'key in Configuration > API Key, or in the docs.',
+                'docs' => 'https://docs.readme.com/developers/logs/fake-uuid',
+                'help' => "If you need help, email support@readme.io and mention log 'fake-uuid'.",
+            ]))
+        );
+
+        $this->metrics = new Metrics($this->api_key, $this->group_handler, [
+            'development_mode' => false,
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
+        ]);
+
+        $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
+        $response = $this->getMockJsonResponse();
+
+        $this->metrics->track($request, $response);
+
+        // Since the call to ReadMe failed, the `x-documentation-url` header shouldn't be present as we didn't get a
+        // base log URL to create suffix against.
+        $this->assertNotContains('x-documentation-url', array_keys($response->headers->all()));
+
+        $cache = json_decode(file_get_contents($this->metrics->getCacheFile()));
+        $this->assertNull($cache->base_url);
+    }
+
+    /**
+     * @group getProjectBaseUrl
+     */
+    public function testProjectBaseUrlFailsInDevelopmentModeIfReadMeCallHasErrorResponse(): void
+    {
+        $this->expectException(MetricsException::class);
+        $this->expectExceptionMessageMatches("/We couldn't find your API key/");
+
+        $handlers = $this->getMockHandlers(
+            new \GuzzleHttp\Psr7\Response(200),
+            new \GuzzleHttp\Psr7\Response(401, [], json_encode([
+                'error' => 'APIKEY_NOTFOUNDD',
+                'message' => "We couldn't find your API key",
+                'suggestion' => "The API key you passed in (moc··········Key) doesn't match any keys we have in our " .
+                    'system. API keys must be passed in as the username part of basic auth. You can get your API ' .
+                    'key in Configuration > API Key, or in the docs.',
+                'docs' => 'https://docs.readme.com/developers/logs/fake-uuid',
+                'help' => "If you need help, email support@readme.io and mention log 'fake-uuid'.",
+            ]))
+        );
+
+        $this->metrics = new Metrics($this->api_key, $this->group_handler, [
+            'development_mode' => true,
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
+        ]);
+
+        $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
+        $response = $this->getMockJsonResponse();
+
+        $this->metrics->track($request, $response);
+    }
+
+    /**
+     * @group getProjectBaseUrl
+     */
+    public function testProjectBaseUrlFailsInDevelopmentModeIfItCantTalkToReadMe(): void
+    {
+        $this->expectException(MetricsException::class);
+        $this->expectExceptionMessageMatches('/500 Internal Server Error/');
+
+        $handlers = $this->getMockHandlers(
+            new \GuzzleHttp\Psr7\Response(200),
+            new \GuzzleHttp\Psr7\Response(500)
+        );
+
+        $this->metrics = new Metrics($this->api_key, $this->group_handler, [
+            'development_mode' => true,
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
+        ]);
+
+        $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
+        $response = $this->getMockJsonResponse();
+
+        $this->metrics->track($request, $response);
+    }
+
+    private function getMockHandlers(
+        \GuzzleHttp\Psr7\Response $mock_metrics_response,
+        \GuzzleHttp\Psr7\Response $mock_readme_response = null
+    ): \stdClass {
+        $handlers = new \stdClass();
+
+        $mock = new MockHandler([$mock_metrics_response]);
+        $handlers->metrics = HandlerStack::create($mock);
+        $handlers->metrics->push(Middleware::history($this->api_calls));
+
+        if (empty($mock_readme_response)) {
+            $handlers->readme = null;
+        } else {
+            $mock = new MockHandler([$mock_readme_response]);
+            $handlers->readme = HandlerStack::create($mock);
+            $handlers->readme->push(Middleware::history($this->api_calls_to_readme));
+        }
+
+        return $handlers;
     }
 
     private function getMockRequest($query_params = [], $post_params = [], $file_params = []): Request
@@ -522,6 +794,11 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
                 'Content-Length' => 11
             ])
         );
+    }
+
+    private function getLogIdFromDocumentationHeader(string $header): string
+    {
+        return str_replace($this->base_log_url . '/logs/', '', $header);
     }
 
     public function providerDevelopmentModeToggle(): array

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -577,8 +577,8 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
 
         // Hydrate the cache so it can be seen as fresh
         file_put_contents($this->metrics->getCacheFile(), json_encode([
-            'last_updated' => time(),
-            'base_url' => $this->base_log_url
+            'base_url' => $this->base_log_url,
+            'last_updated' => time()
         ]));
 
         $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
@@ -612,8 +612,8 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
 
         // Hydrate the cache so it can be seen as fresh
         file_put_contents($this->metrics->getCacheFile(), json_encode([
-            'last_updated' => time() - (86400 * 2),
-            'base_url' => $this->base_log_url
+            'base_url' => $this->base_log_url,
+            'last_updated' => time() - (86400 * 2)
         ]));
 
         $request = $this->getMockRequest(self::MOCK_QUERY_PARAMS);
@@ -631,7 +631,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
     /**
      * @group getProjectBaseUrl
      */
-    public function testProjectBaseUrlIsTemporarilyIfReadMeCallFailsWhileNotInDevelopmentMode(): void
+    public function testProjectBaseUrlIsTemporarilyNullIfReadMeCallFailsWhileNotInDevelopmentMode(): void
     {
         $handlers = $this->getMockHandlers(
             new \GuzzleHttp\Psr7\Response(200),


### PR DESCRIPTION
## 🧰 What's being changed?

> 🚧  &nbsp; This work is dependent upon https://github.com/readmeio/readme/pull/2844 getting into production as that change updates the `baseUrl` property in `GET /api/v1` to support projects with custom domains.

This reworks the new `x-readme-log` header for returning the metrics log UUID to the client into a new `x-documentation-url` header that returns a fully-formed URL to view that log on the Developer Metrics page for the requesting ReadMe project.

Since this URL isn't something that the Metrics API has access to, we need to first make an API request to the ReadMe API `GET /api/v1` to retrieve the `baseUrl` for the project that is being set up with Metrics. As we don't want to make this request for every single Metrics call, we're caching to a local file. 

Along with storing the base URL in the cache file we're also storing a last updated timestamp that'll allow us to keep the URL from becoming stale by automatically refreshing the cache once per day.

Additionally, since it might not be ideal for everyone to be making this request (like our own API where we'll be hitting ourselves twice for that first API call to cache), cached or not, I've introduced a `baseLogUrl` option that when supplied, will bypass the ReadMe API request and use that URL as the base URL for these fully-formed `x-documentation-url` values.

* [x] Updates the Node SDK
* [x] Updates the PHP SDK