### PR TITLE
fix: add content-type and user-agent headers

### DIFF
--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -17,7 +17,11 @@ const baseLogUrl = 'https://docs.example.com';
 const cacheDir = findCacheDir({ name: pkg.name });
 
 function getReadMeApiMock(numberOfTimes) {
-  return nock(config.readmeApiUrl)
+  return nock(config.readmeApiUrl, {
+    reqheaders: {
+      'User-Agent': `${pkg.name}/${pkg.version}`,
+    },
+  })
     .get('/v1/')
     .basicAuth({ user: apiKey })
     .times(numberOfTimes)
@@ -97,6 +101,7 @@ describe('#metrics', () => {
     const mock = nock(config.host, {
       reqheaders: {
         'Content-Type': 'application/json',
+        'User-Agent': `${pkg.name}/${pkg.version}`,
       },
     })
       .post('/v1/request', ([body]) => {
@@ -127,6 +132,7 @@ describe('#metrics', () => {
       const mock = nock(config.host, {
         reqheaders: {
           'Content-Type': 'application/json',
+          'User-Agent': `${pkg.name}/${pkg.version}`,
         },
       })
         .post('/v1/request', body => {
@@ -191,6 +197,7 @@ describe('#metrics', () => {
         nock(config.host, {
           reqheaders: {
             'Content-Type': 'application/json',
+            'User-Agent': `${pkg.name}/${pkg.version}`,
           },
         })
           .post('/v1/request', body => {
@@ -231,6 +238,7 @@ describe('#metrics', () => {
       const mock = nock(config.host, {
         reqheaders: {
           'Content-Type': 'application/json',
+          'User-Agent': `${pkg.name}/${pkg.version}`,
         },
       })
         .post('/v1/request')
@@ -253,6 +261,7 @@ describe('#metrics', () => {
       const metricsMock = nock(config.host, {
         reqheaders: {
           'Content-Type': 'application/json',
+          'User-Agent': `${pkg.name}/${pkg.version}`,
         },
       })
         .post('/v1/request')
@@ -290,6 +299,7 @@ describe('#metrics', () => {
       const metricsMock = nock(config.host, {
         reqheaders: {
           'Content-Type': 'application/json',
+          'User-Agent': `${pkg.name}/${pkg.version}`,
         },
       })
         .post('/v1/request')
@@ -317,6 +327,7 @@ describe('#metrics', () => {
       const metricsMock = nock(config.host, {
         reqheaders: {
           'Content-Type': 'application/json',
+          'User-Agent': `${pkg.name}/${pkg.version}`,
         },
       })
         .post('/v1/request')
@@ -337,18 +348,26 @@ describe('#metrics', () => {
     });
 
     it('should temporarily set baseUrl to null if the call to the ReadMe API fails for whatever reason', async () => {
-      const apiMock = nock(config.readmeApiUrl).get('/v1/').basicAuth({ user: apiKey }).reply(200, {
-        error: 'APIKEY_NOTFOUNDD',
-        message: "We couldn't find your API key",
-        suggestion:
-          "The API key you passed in (moc··········Key) doesn't match any keys we have in our system. API keys must be passed in as the username part of basic auth. You can get your API key in Configuration > API Key, or in the docs.",
-        docs: 'https://docs.readme.com/developers/logs/fake-uuid',
-        help: "If you need help, email support@readme.io and mention log 'fake-uuid'.",
-      });
+      const apiMock = nock(config.readmeApiUrl, {
+        reqheaders: {
+          'User-Agent': `${pkg.name}/${pkg.version}`,
+        },
+      })
+        .get('/v1/')
+        .basicAuth({ user: apiKey })
+        .reply(200, {
+          error: 'APIKEY_NOTFOUNDD',
+          message: "We couldn't find your API key",
+          suggestion:
+            "The API key you passed in (moc··········Key) doesn't match any keys we have in our system. API keys must be passed in as the username part of basic auth. You can get your API key in Configuration > API Key, or in the docs.",
+          docs: 'https://docs.readme.com/developers/logs/fake-uuid',
+          help: "If you need help, email support@readme.io and mention log 'fake-uuid'.",
+        });
 
       const metricsMock = nock(config.host, {
         reqheaders: {
           'Content-Type': 'application/json',
+          'User-Agent': `${pkg.name}/${pkg.version}`,
         },
       })
         .post('/v1/request')
@@ -381,6 +400,7 @@ describe('#metrics', () => {
       return nock(config.host, {
         reqheaders: {
           'Content-Type': 'application/json',
+          'User-Agent': `${pkg.name}/${pkg.version}`,
         },
       })
         .post('/v1/request', ([body]) => {

--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -94,7 +94,11 @@ describe('#metrics', () => {
 
   it('should send a request to the metrics server', () => {
     const apiMock = getReadMeApiMock(1);
-    const mock = nock(config.host)
+    const mock = nock(config.host, {
+      reqheaders: {
+        'Content-Type': 'application/json',
+      },
+    })
       .post('/v1/request', ([body]) => {
         expect(body.group).toBe(group);
         expect(typeof body.request.log.entries[0].startedDateTime).toBe('string');
@@ -120,7 +124,11 @@ describe('#metrics', () => {
   describe('#bufferLength', () => {
     it('should send requests when number hits `bufferLength` size', async function test() {
       const apiMock = getReadMeApiMock(1);
-      const mock = nock(config.host)
+      const mock = nock(config.host, {
+        reqheaders: {
+          'Content-Type': 'application/json',
+        },
+      })
         .post('/v1/request', body => {
           expect(body).toHaveLength(3);
           return true;
@@ -180,7 +188,11 @@ describe('#metrics', () => {
       const seenLogs = [];
 
       const mocks = [...new Array(numberOfMocks).keys()].map(() =>
-        nock(config.host)
+        nock(config.host, {
+          reqheaders: {
+            'Content-Type': 'application/json',
+          },
+        })
           .post('/v1/request', body => {
             expect(body).toHaveLength(bufferLength);
 
@@ -216,7 +228,14 @@ describe('#metrics', () => {
 
   describe('#baseLogUrl', () => {
     it('should not call the API if the baseLogUrl supplied as a middleware option', async () => {
-      const mock = nock(config.host).post('/v1/request').basicAuth({ user: apiKey }).reply(200);
+      const mock = nock(config.host, {
+        reqheaders: {
+          'Content-Type': 'application/json',
+        },
+      })
+        .post('/v1/request')
+        .basicAuth({ user: apiKey })
+        .reply(200);
       const app = express();
       app.use(middleware.metrics(apiKey, () => group, { baseLogUrl }));
       app.get('/test', (req, res) => res.sendStatus(200));
@@ -231,7 +250,14 @@ describe('#metrics', () => {
 
     it('should not call the API for project data if the cache is fresh', async () => {
       const apiMock = getReadMeApiMock(1);
-      const metricsMock = nock(config.host).post('/v1/request').basicAuth({ user: apiKey }).reply(200);
+      const metricsMock = nock(config.host, {
+        reqheaders: {
+          'Content-Type': 'application/json',
+        },
+      })
+        .post('/v1/request')
+        .basicAuth({ user: apiKey })
+        .reply(200);
 
       const app = express();
       app.use(middleware.metrics(apiKey, () => group));
@@ -261,7 +287,14 @@ describe('#metrics', () => {
 
     it('should populate the cache if not present', async () => {
       const apiMock = getReadMeApiMock(1);
-      const metricsMock = nock(config.host).post('/v1/request').basicAuth({ user: apiKey }).reply(200);
+      const metricsMock = nock(config.host, {
+        reqheaders: {
+          'Content-Type': 'application/json',
+        },
+      })
+        .post('/v1/request')
+        .basicAuth({ user: apiKey })
+        .reply(200);
 
       const app = express();
       app.use(middleware.metrics(apiKey, () => group));
@@ -281,7 +314,14 @@ describe('#metrics', () => {
       hydrateCache(Math.round(Date.now() / 1000 - 86400 * 2));
 
       const apiMock = getReadMeApiMock(1);
-      const metricsMock = nock(config.host).post('/v1/request').basicAuth({ user: apiKey }).reply(200);
+      const metricsMock = nock(config.host, {
+        reqheaders: {
+          'Content-Type': 'application/json',
+        },
+      })
+        .post('/v1/request')
+        .basicAuth({ user: apiKey })
+        .reply(200);
 
       const app = express();
       app.use(middleware.metrics(apiKey, () => group));
@@ -306,7 +346,14 @@ describe('#metrics', () => {
         help: "If you need help, email support@readme.io and mention log 'fake-uuid'.",
       });
 
-      const metricsMock = nock(config.host).post('/v1/request').basicAuth({ user: apiKey }).reply(200);
+      const metricsMock = nock(config.host, {
+        reqheaders: {
+          'Content-Type': 'application/json',
+        },
+      })
+        .post('/v1/request')
+        .basicAuth({ user: apiKey })
+        .reply(200);
 
       const app = express();
       app.use(middleware.metrics(apiKey, () => group));
@@ -331,7 +378,11 @@ describe('#metrics', () => {
     let apiMock;
     const responseBody = { a: 1, b: 2, c: 3 };
     function createMock() {
-      return nock(config.host)
+      return nock(config.host, {
+        reqheaders: {
+          'Content-Type': 'application/json',
+        },
+      })
         .post('/v1/request', ([body]) => {
           expect(body.request.log.entries[0].response.content.text).toBe(JSON.stringify(responseBody));
           return true;

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -54,6 +54,7 @@ async function getProjectBaseUrl(encodedApiKey) {
       method: 'get',
       headers: {
         Authorization: `Basic ${encodedApiKey}`,
+        'User-Agent': `${pkg.name}/${pkg.version}`,
       },
     })
       .then(res => res.json())
@@ -116,6 +117,7 @@ module.exports.metrics = (apiKey, group, options = {}) => {
           headers: {
             Authorization: `Basic ${encodedApiKey}`,
             'Content-Type': 'application/json',
+            'User-Agent': `${pkg.name}/${pkg.version}`,
           },
         })
           .then(() => {})

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -115,6 +115,7 @@ module.exports.metrics = (apiKey, group, options = {}) => {
           body: JSON.stringify(json),
           headers: {
             Authorization: `Basic ${encodedApiKey}`,
+            'Content-Type': 'application/json',
           },
         })
           .then(() => {})


### PR DESCRIPTION
## 🧰 What's being changed?

Since [this commit](https://github.com/readmeio/metrics-sdks/pull/15/commits/50ebe66c43048ea9990ccce3ed7dcd7d9f3e7d50), the Metrics API will 400 when receiving new logs. This has been happening since our migration away from `request` to the `node-fetch` library for our external API requests. The `node-fetch` library [requires that we set a  `Content-Type` header when sending JSON POST bodies](https://www.npmjs.com/package/node-fetch#post-with-json).

Also, per discussion with @erunion, this PR also adds `User-Agent` headers for requests to the ReadMe and ReadMe Metrics APIs.