### PR TITLE
fix: prevent potentially null base log urls from being used

### DIFF
--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -355,7 +355,7 @@ describe('#metrics', () => {
       })
         .get('/v1/')
         .basicAuth({ user: apiKey })
-        .reply(200, {
+        .reply(401, {
           error: 'APIKEY_NOTFOUNDD',
           message: "We couldn't find your API key",
           suggestion:
@@ -382,7 +382,7 @@ describe('#metrics', () => {
         .get('/test')
         .expect(200)
         .expect(res => {
-          expect(getCache().getKey('baseUrl')).toBeUndefined();
+          expect(getCache().getKey('baseUrl')).toBeNull();
 
           // `x-documentation-url` header should not be present since we couldn't get the base URL!
           expect(Object.keys(res.headers)).not.toContain('x-documentation-url');

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -96,7 +96,7 @@ module.exports.metrics = (apiKey, group, options = {}) => {
     const startedDateTime = new Date();
     const logId = uuidv4();
 
-    if (baseLogUrl !== undefined) {
+    if (baseLogUrl !== undefined && typeof baseLogUrl === 'string') {
       res.setHeader('x-documentation-url', `${baseLogUrl}/logs/${logId}`);
     }
 

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -57,7 +57,13 @@ async function getProjectBaseUrl(encodedApiKey) {
         'User-Agent': `${pkg.name}/${pkg.version}`,
       },
     })
-      .then(res => res.json())
+      .then(res => {
+        if (res.status >= 400 && res.status <= 599) {
+          throw res;
+        }
+
+        return res.json();
+      })
       .then(project => {
         baseUrl = project.baseUrl;
 


### PR DESCRIPTION
## 🧰 What's being changed?

Noticed this earlier when we had some high response times from our API and `null` was dumped into the `x-documentation-url` header, resulting in ReadMe API responses that looked like

```json
{
  "error": "APIKEY_NOTFOUND",
  "message": "We couldn't find your API key",
  "suggestion": "The API key you passed in (T3d······················To=) doesn't match any keys we have in our system. API keys must be passed in as the username part of basic auth. You can get your API key in Configuration > API Key, or in the docs.",
  "docs": "null/logs/<uuid>",
  "help": "If you need help, email support@readme.io and include the following link to your API log: 'null/logs/<uuid>'.",
  "poem": [
    "The ancient gatekeeper declares:",
    "'To pass, reveal your API key'",
    "'T3dsZ…', you start to ramble",
    "Oops, you remembered it poorly!"
  ]
}
```


This bug only affects the Node SDK because the PHP one was already doing an `is_null()` check on the saved data before using it, Node just made sure it wasn't `undefined`.