### PR TITLE
Create simple HTTP-logging middleware

### DIFF
--- a/packages/ruby/Gemfile
+++ b/packages/ruby/Gemfile
@@ -8,3 +8,5 @@ gemspec
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "standard"
+gem "rack-test"
+gem "webmock"

--- a/packages/ruby/Gemfile.lock
+++ b/packages/ruby/Gemfile.lock
@@ -2,15 +2,32 @@ PATH
   remote: .
   specs:
     readme-metrics (0.1.0)
+      httparty
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.4.4)
+    hashdiff (1.0.1)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
+    multi_xml (0.6.0)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    public_suffix (4.0.5)
+    rack (2.2.3)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rake (12.3.3)
     regexp_parser (1.7.1)
@@ -42,19 +59,26 @@ GEM
     rubocop-performance (1.6.1)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
+    safe_yaml (1.0.5)
     standard (0.4.7)
       rubocop (~> 0.85.0)
       rubocop-performance (~> 1.6.0)
     unicode-display_width (1.7.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  rack-test
   rake (~> 12.0)
   readme-metrics!
   rspec (~> 3.0)
   standard
+  webmock
 
 BUNDLED WITH
    2.1.4

--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -7,3 +7,24 @@ Track your API metrics within ReadMe.
 ## Installation
 
 ## Usage
+
+`Readme::Metrics` is a Rack middleware and is compatible with all Rack-based
+apps, including Rails.
+
+### Rails
+
+```ruby
+# application.rb
+require "readme/metrics"
+
+config.middleware.use Readme::Metrics, "http://example.com/your/logging/api"
+```
+
+### Rack::Builder
+
+```ruby
+Rack::Builder.new do |builder|
+  builder.use Readme::Metrics, "http://example.com/your/logging/api"
+  builder.run your_app
+end
+```

--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -1,8 +1,17 @@
 require "readme/metrics/version"
+require "httparty"
 
 module Readme
-  module Metrics
-    class Error < StandardError; end
-    # Your code goes here...
+  class Metrics
+    def initialize(app, endpoint)
+      @app = app
+      @endpoint = endpoint
+    end
+
+    def call(env)
+      path = "#{env["REQUEST_METHOD"]} #{env["PATH_INFO"]}"
+      HTTParty.post(@endpoint, body: {path: path}.to_json)
+      @app.call(env)
+    end
   end
 end

--- a/packages/ruby/lib/readme/metrics/version.rb
+++ b/packages/ruby/lib/readme/metrics/version.rb
@@ -1,5 +1,5 @@
 module Readme
-  module Metrics
+  class Metrics
     VERSION = "0.1.0"
   end
 end

--- a/packages/ruby/readme-metrics.gemspec
+++ b/packages/ruby/readme-metrics.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   # spec.bindir        = "exe"
   # spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "httparty"
 end

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -1,5 +1,52 @@
+require "rack/test"
+require "webmock/rspec"
+
 RSpec.describe Readme::Metrics do
+  include Rack::Test::Methods
+
+  before do
+    stub_request(:post, readme_endpoint)
+  end
+
   it "has a version number" do
     expect(Readme::Metrics::VERSION).not_to be nil
+  end
+
+  it "doesn't modify the response" do
+    get "/"
+
+    response_without_middleware = noop_app.call(double)
+    response_with_middleware = mock_response_to_raw(last_response)
+
+    expect(response_with_middleware).to eq response_without_middleware
+  end
+
+  it "posts request urls to Readme API" do
+    get "/api/foo"
+    post "/api/bar"
+
+    expect(WebMock).to have_requested(:post, readme_endpoint)
+      .with(body: {path: "GET /api/foo"}.to_json)
+
+    expect(WebMock).to have_requested(:post, readme_endpoint)
+      .with(body: {path: "POST /api/bar"}.to_json)
+  end
+
+  def readme_endpoint
+    "http://example.com/"
+  end
+
+  def app
+    Readme::Metrics.new(noop_app, readme_endpoint)
+  end
+
+  def noop_app
+    lambda do |env|
+      [200, {"Content-Type" => "text/plain"}, ["OK"]]
+    end
+  end
+
+  def mock_response_to_raw(mock_response)
+    [mock_response.status, mock_response.headers, [mock_response.body]]
   end
 end


### PR DESCRIPTION
## 🧰 What's being changed?

This creates a simple middleware that logs requests received to the
given logging API endpoint in the format: `"GET http://example.com"`.

The actual Readme.io payload format is more complicated than this. We
will add support for it in a follow-up commit.


## 🧪 Testing

There is an **automated test** using `Rspec` and `Rack::Test`. We also tested **manually** with a simple Rack application that acts as both the client API and the Readme API:

```ruby
# config.ru
$LOAD_PATH << File.expand_path("../path/to/metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    puts "=== API ==="
    [200, {}, ["Ok"]]
  end
end

class ReadmeApp
  def call(env)
    puts "=== README ==="
    puts env['rack.input'].read
    [200, {}, ["Ok"]]
  end
end

map "/readme" do |builder|
  run ReadmeApp.new
end

map "/api" do
  use Readme::Metrics, "http://localhost:9292/readme"
  run ApiApp.new
end
```

Run this on the command-line with

```
$ rackup
```

Then try to hit one of the "client API" endpoints:

```
$ curl http://localhost:9292/api/path/to/thing
```

In the server logs of the rack application, you should expect to see:

![Webcam 2020-08-11 11-01-46](https://user-images.githubusercontent.com/1006966/89913880-39517700-dbc2-11ea-8f3b-3f930cb2491a.jpg)

