### PR TITLE
Send valid payloads to Readme API

### DIFF
--- a/packages/ruby/Gemfile
+++ b/packages/ruby/Gemfile
@@ -5,8 +5,9 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in readme-metrics.gemspec
 gemspec
 
+gem "json-schema"
+gem "rack-test"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "standard"
-gem "rack-test"
 gem "webmock"

--- a/packages/ruby/Gemfile.lock
+++ b/packages/ruby/Gemfile.lock
@@ -17,6 +17,8 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
@@ -73,6 +75,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  json-schema
   rack-test
   rake (~> 12.0)
   readme-metrics!

--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -17,14 +17,14 @@ apps, including Rails.
 # application.rb
 require "readme/metrics"
 
-config.middleware.use Readme::Metrics, "http://example.com/your/logging/api"
+config.middleware.use Readme::Metrics, "YOUR_API_KEY"
 ```
 
 ### Rack::Builder
 
 ```ruby
 Rack::Builder.new do |builder|
-  builder.use Readme::Metrics, "http://example.com/your/logging/api"
+  builder.use Readme::Metrics, "YOUR_API_KEY"
   builder.run your_app
 end
 ```

--- a/packages/ruby/lib/data.json
+++ b/packages/ruby/lib/data.json
@@ -1,0 +1,78 @@
+[
+  {
+    "group": {
+      "id": "abc123",
+      "email": "user@example.com",
+      "label": "Joel"
+    },
+    "clientIPAddress": "1.1.1.1",
+    "development": true,
+    "request": {
+      "log": {
+        "version": "1.2",
+        "creator": {
+          "name": "Ruby",
+          "version": "1.0",
+          "comment": "hello"
+        },
+        "entries": [
+          {
+            "cache": {},
+            "timings": {
+              "send": 0,
+              "wait": 2000,
+              "receive": 0
+            },
+            "pageref": "http://example.com/api/foo",
+            "startedDateTime": "2020-08-11T15:56:56.573Z",
+            "time": 2000,
+            "request": {
+              "cookies": [],
+              "headersSize": 50,
+              "bodySize": 200,
+              "method": "GET",
+              "url": "http://example.com/api/foo",
+              "httpVersion": "HTTP 1.1",
+              "headers": [
+                {
+                  "name": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "queryString": [
+                {
+                  "name": "id",
+                  "value": "1"
+                }
+              ],
+              "postData": {
+                "text": "[REQUEST BODY]",
+                "mimeType": "application/json"
+              }
+            },
+            "response": {
+              "status": 200,
+              "statusText": "Ok",
+              "httpVersion": "HTTP 1.1",
+              "redirectURL": "",
+              "headersSize": 50,
+              "bodySize": 200,
+              "cookies": [],
+              "headers": [
+                {
+                  "name": "Content-Length",
+                  "value": "10"
+                }
+              ],
+              "content": {
+                "text": "[RESPONSE CONTENT]",
+                "size": 10,
+                "mimeType": "application/json"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+]

--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -3,14 +3,21 @@ require "httparty"
 
 module Readme
   class Metrics
-    def initialize(app, endpoint)
+    ENDPOINT = "https://metrics.readme.io/v1/request"
+
+    def initialize(app, api_key)
       @app = app
-      @endpoint = endpoint
+      @api_key = api_key
     end
 
     def call(env)
-      path = "#{env["REQUEST_METHOD"]} #{env["PATH_INFO"]}"
-      HTTParty.post(@endpoint, body: {path: path}.to_json)
+      json = File.read(File.expand_path("../../data.json", __FILE__))
+      HTTParty.post(
+        ENDPOINT,
+        basic_auth: {username: @api_key, password: ""},
+        headers: {"Content-Type" => "application/json"},
+        body: json
+      )
       @app.call(env)
     end
   end

--- a/packages/ruby/spec/schema/afterRequest.json
+++ b/packages/ruby/spec/schema/afterRequest.json
@@ -1,0 +1,30 @@
+{
+  "$id": "afterRequest.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "optional": true,
+  "required": [
+    "lastAccess",
+    "eTag",
+    "hitCount"
+  ],
+  "properties": {
+    "expires": {
+      "type": "string",
+      "pattern": "^(\\d{4})(-)?(\\d\\d)(-)?(\\d\\d)(T)?(\\d\\d)(:)?(\\d\\d)(:)?(\\d\\d)(\\.\\d+)?(Z|([+-])(\\d\\d)(:)?(\\d\\d))?"
+    },
+    "lastAccess": {
+      "type": "string",
+      "pattern": "^(\\d{4})(-)?(\\d\\d)(-)?(\\d\\d)(T)?(\\d\\d)(:)?(\\d\\d)(:)?(\\d\\d)(\\.\\d+)?(Z|([+-])(\\d\\d)(:)?(\\d\\d))?"
+    },
+    "eTag": {
+      "type": "string"
+    },
+    "hitCount": {
+      "type": "integer"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/beforeRequest.json
+++ b/packages/ruby/spec/schema/beforeRequest.json
@@ -1,0 +1,30 @@
+{
+  "$id": "beforeRequest.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "optional": true,
+  "required": [
+    "lastAccess",
+    "eTag",
+    "hitCount"
+  ],
+  "properties": {
+    "expires": {
+      "type": "string",
+      "pattern": "^(\\d{4})(-)?(\\d\\d)(-)?(\\d\\d)(T)?(\\d\\d)(:)?(\\d\\d)(:)?(\\d\\d)(\\.\\d+)?(Z|([+-])(\\d\\d)(:)?(\\d\\d))?"
+    },
+    "lastAccess": {
+      "type": "string",
+      "pattern": "^(\\d{4})(-)?(\\d\\d)(-)?(\\d\\d)(T)?(\\d\\d)(:)?(\\d\\d)(:)?(\\d\\d)(\\.\\d+)?(Z|([+-])(\\d\\d)(:)?(\\d\\d))?"
+    },
+    "eTag": {
+      "type": "string"
+    },
+    "hitCount": {
+      "type": "integer"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/browser.json
+++ b/packages/ruby/spec/schema/browser.json
@@ -1,0 +1,20 @@
+{
+  "$id": "browser.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "name",
+    "version"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/cache.json
+++ b/packages/ruby/spec/schema/cache.json
@@ -1,0 +1,21 @@
+{
+  "$id": "cache.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "beforeRequest": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "beforeRequest.json#" }
+      ]
+    },
+    "afterRequest": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "afterRequest.json#" }
+      ]
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/content.json
+++ b/packages/ruby/spec/schema/content.json
@@ -1,0 +1,29 @@
+{
+  "$id": "content.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "size",
+    "mimeType"
+  ],
+  "properties": {
+    "size": {
+      "type": "integer"
+    },
+    "compression": {
+      "type": "integer"
+    },
+    "mimeType": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "encoding": {
+      "type": "string"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/cookie.json
+++ b/packages/ruby/spec/schema/cookie.json
@@ -1,0 +1,36 @@
+{
+  "$id": "cookie.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "name",
+    "value"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    },
+    "domain": {
+      "type": "string"
+    },
+    "expires": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "httpOnly": {
+      "type": "boolean"
+    },
+    "secure": {
+      "type": "boolean"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/creator.json
+++ b/packages/ruby/spec/schema/creator.json
@@ -1,0 +1,20 @@
+{
+  "$id": "creator.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "name",
+    "version"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/entry.json
+++ b/packages/ruby/spec/schema/entry.json
@@ -1,0 +1,53 @@
+{
+  "$id": "entry.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "optional": true,
+  "required": [
+    "startedDateTime",
+    "time",
+    "request",
+    "response",
+    "cache",
+    "timings"
+  ],
+  "properties": {
+    "pageref": {
+      "type": "string"
+    },
+    "startedDateTime": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(\\d{4})(-)?(\\d\\d)(-)?(\\d\\d)(T)?(\\d\\d)(:)?(\\d\\d)(:)?(\\d\\d)(\\.\\d+)?(Z|([+-])(\\d\\d)(:)?(\\d\\d))"
+    },
+    "time": {
+      "type": "number",
+      "min": 0
+    },
+    "request": {
+      "$ref": "request.json#"
+    },
+    "response": {
+      "$ref": "response.json#"
+    },
+    "cache": {
+      "$ref": "cache.json#"
+    },
+    "timings": {
+      "$ref": "timings.json#"
+    },
+    "serverIPAddress": {
+      "type": "string",
+      "oneOf": [
+        { "format": "ipv4" },
+        { "format": "ipv6" }
+      ]
+    },
+    "connection": {
+      "type": "string"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/har.json
+++ b/packages/ruby/spec/schema/har.json
@@ -1,0 +1,13 @@
+{
+  "$id": "har.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "log"
+  ],
+  "properties": {
+    "log": {
+      "$ref": "log.json#"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/header.json
+++ b/packages/ruby/spec/schema/header.json
@@ -1,0 +1,20 @@
+{
+  "$id": "header.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "name",
+    "value"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/log.json
+++ b/packages/ruby/spec/schema/log.json
@@ -1,0 +1,36 @@
+{
+  "$id": "log.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "version",
+    "creator",
+    "entries"
+  ],
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "creator": {
+      "$ref": "creator.json#"
+    },
+    "browser": {
+      "$ref": "browser.json#"
+    },
+    "pages": {
+      "type": "array",
+      "items": {
+        "$ref": "page.json#"
+      }
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "$ref": "entry.json#"
+      }
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/page.json
+++ b/packages/ruby/spec/schema/page.json
@@ -1,0 +1,32 @@
+{
+  "$id": "page.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "optional": true,
+  "required": [
+    "startedDateTime",
+    "id",
+    "title",
+    "pageTimings"
+  ],
+  "properties": {
+    "startedDateTime": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(\\d{4})(-)?(\\d\\d)(-)?(\\d\\d)(T)?(\\d\\d)(:)?(\\d\\d)(:)?(\\d\\d)(\\.\\d+)?(Z|([+-])(\\d\\d)(:)?(\\d\\d))"
+    },
+    "id": {
+      "type": "string",
+      "unique": true
+    },
+    "title": {
+      "type": "string"
+    },
+    "pageTimings": {
+      "$ref": "pageTimings.json#"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/pageTimings.json
+++ b/packages/ruby/spec/schema/pageTimings.json
@@ -1,0 +1,18 @@
+{
+  "$id": "pageTimings.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "onContentLoad": {
+      "type": "number",
+      "min": -1
+    },
+    "onLoad": {
+      "type": "number",
+      "min": -1
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/postData.json
+++ b/packages/ruby/spec/schema/postData.json
@@ -1,0 +1,43 @@
+{
+  "$id": "postData.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "optional": true,
+  "required": [
+    "mimeType"
+  ],
+  "properties": {
+    "mimeType": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "params": {
+      "type": "array",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "fileName": {
+          "type": "string"
+        },
+        "contentType": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        }
+      }
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/query.json
+++ b/packages/ruby/spec/schema/query.json
@@ -1,0 +1,20 @@
+{
+  "$id": "query.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "name",
+    "value"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/readmeGroup.json
+++ b/packages/ruby/spec/schema/readmeGroup.json
@@ -1,0 +1,21 @@
+{
+  "$id": "readmeGroup.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "email",
+    "label"
+  ]
+}

--- a/packages/ruby/spec/schema/readmeMetrics.json
+++ b/packages/ruby/spec/schema/readmeMetrics.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "group": {
+        "$ref": "readmeGroup.json#"
+      },
+      "clientIPAddress": {
+        "type": "string"
+      },
+      "development": {
+        "type": "boolean"
+      },
+      "request": {
+        "$ref": "har.json#"
+      }
+    },
+    "required": [
+      "group",
+      "clientIPAddress",
+      "development",
+      "request"
+    ]
+  }
+}

--- a/packages/ruby/spec/schema/request.json
+++ b/packages/ruby/spec/schema/request.json
@@ -1,0 +1,57 @@
+{
+  "$id": "request.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "method",
+    "url",
+    "httpVersion",
+    "cookies",
+    "headers",
+    "queryString",
+    "headersSize",
+    "bodySize"
+  ],
+  "properties": {
+    "method": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "httpVersion": {
+      "type": "string"
+    },
+    "cookies": {
+      "type": "array",
+      "items": {
+        "$ref": "cookie.json#"
+      }
+    },
+    "headers": {
+      "type": "array",
+      "items": {
+        "$ref": "header.json#"
+      }
+    },
+    "queryString": {
+      "type": "array",
+      "items": {
+        "$ref": "query.json#"
+      }
+    },
+    "postData": {
+      "$ref": "postData.json#"
+    },
+    "headersSize": {
+      "type": "integer"
+    },
+    "bodySize": {
+      "type": "integer"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/response.json
+++ b/packages/ruby/spec/schema/response.json
@@ -1,0 +1,54 @@
+{
+  "$id": "response.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "status",
+    "statusText",
+    "httpVersion",
+    "cookies",
+    "headers",
+    "content",
+    "redirectURL",
+    "headersSize",
+    "bodySize"
+  ],
+  "properties": {
+    "status": {
+      "type": "integer"
+    },
+    "statusText": {
+      "type": "string"
+    },
+    "httpVersion": {
+      "type": "string"
+    },
+    "cookies": {
+      "type": "array",
+      "items": {
+        "$ref": "cookie.json#"
+      }
+    },
+    "headers": {
+      "type": "array",
+      "items": {
+        "$ref": "header.json#"
+      }
+    },
+    "content": {
+      "$ref": "content.json#"
+    },
+    "redirectURL": {
+      "type": "string"
+    },
+    "headersSize": {
+      "type": "integer"
+    },
+    "bodySize": {
+      "type": "integer"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/ruby/spec/schema/timings.json
+++ b/packages/ruby/spec/schema/timings.json
@@ -1,0 +1,42 @@
+{
+  "$id": "timings.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [
+    "send",
+    "wait",
+    "receive"
+  ],
+  "properties": {
+    "dns": {
+      "type": "number",
+      "min": -1
+    },
+    "connect": {
+      "type": "number",
+      "min": -1
+    },
+    "blocked": {
+      "type": "number",
+      "min": -1
+    },
+    "send": {
+      "type": "number",
+      "min": -1
+    },
+    "wait": {
+      "type": "number",
+      "min": -1
+    },
+    "receive": {
+      "type": "number",
+      "min": -1
+    },
+    "ssl": {
+      "type": "number",
+      "min": -1
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
## 🧰 What's being changed?

This sends a valid hardcoded payload (in the form of the `data.json` file)
to the Readme API with all the proper headers and authentication.

The middleware now takes an API key during initialization and no longer
needs an endpoint which has become a constant.

The hard-coded data we wrote is valid according to [HAR
1.2](http://www.softwareishard.com/blog/har-12-spec). We noticed that
there are some required fields from the spec that are neither mentioned
by the API nor used in the nodejs implementation. We decided to include
them for validity sake and at some point the backend might want to fully
support the HAR 1.2 spec.

The added fields are:

* `entries.cache`
* `entries.timing`
* `entries[].request.cookies`
* `entries[].request.headerSize`
* `entries[].request.bodySize`
* `entries[].response.cookies`
* `entries[].response.headerSize`
* `entries[].response.bodySize`
* `entries[].response.redirectURL`
* `entries[].response.httpVersion`

Some of these are empty arrays or objects but the keys are required to
be present.

As part of our development process, we introduced json-schema to check
the generated JSON we use (for now the static JSON file). We wrote a
schema file for the Readme.io-specific structure but were able to re-use
an [existing implementation for the HAR
format](https://github.com/ahmadnassri/node-har-schema).


## 🧪 Testing

There is an **automated** test the uses json-schema to guarantee the JSON is in the right format. We also manually tested this with the following Rack app:

```ruby
$LOAD_PATH << File.expand_path("../path/to/metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    puts "=== API ==="
    [200, {}, ["Ok"]]
  end
end

map "/api" do
  use Readme::Metrics, "YOUR_API_KEY_HERE"
  run ApiApp.new
end
```

run it on the command-line with:

```
$ rackup
```

Make a request:

```
$ curl http://localhost:9292/api/foo
```

then log into Readme.io dashboard and expect to see your request(s) there. Note that all the data will be from the hard-coded JSON file rather than actual data from the request.

![ReadMe 2020-08-11 16-57-11](https://user-images.githubusercontent.com/1006966/89948264-c95be480-dbf3-11ea-9a6c-bc544056279d.jpg)

