### PR TITLE
Generate real HAR from request and response

### DIFF
--- a/packages/ruby/lib/readme/har.rb
+++ b/packages/ruby/lib/readme/har.rb
@@ -1,11 +1,140 @@
+require "rack"
+require "rack/request"
+
 module Readme
   class Har
-    def initialize(env)
-      @env = env
+    HAR_VERSION = "1.2"
+    HTTP_NON_HEADERS = [
+      Rack::HTTP_COOKIE,
+      Rack::HTTP_VERSION,
+      Rack::HTTP_HOST,
+      Rack::HTTP_PORT
+    ]
+
+    def initialize(env, status, headers, response, start_time, end_time)
+      @env = Rack::Request.new(env)
+      @response = Rack::Response.new(response, status, headers)
+      @start_time = start_time
+      @end_time = end_time
     end
 
     def to_json
-      File.read(File.expand_path("../../har.json", __FILE__))
+      {
+        log: {
+          version: HAR_VERSION,
+          creator: creator,
+          entries: entries
+        }
+      }.to_json
+    end
+
+    private
+
+    def creator
+      {
+        name: Readme::Metrics::SDK_NAME,
+        version: Readme::Metrics::VERSION
+      }
+    end
+
+    def entries
+      [
+        {
+          cache: {},
+          timings: timings,
+          request: request,
+          response: response,
+          startedDateTime: @start_time.iso8601,
+          time: elapsed_time
+        }
+      ]
+    end
+
+    def timings
+      {
+        send: 0,
+        receive: 0,
+        wait: elapsed_time
+      }
+    end
+
+    def elapsed_time
+      ((@end_time - @start_time) * 1000).to_i
+    end
+
+    def request
+      {
+        method: @env.request_method,
+        queryString: to_hash_array(@env.GET),
+        url: @env.url,
+        httpVersion: @env.get_header("HTTP_VERSION"),
+        headers: http_headers,
+        cookies: cookies,
+        postData: {
+          text: request_body,
+          mimeType: @env.content_type
+        },
+        headersSize: -1,
+        bodySize: @env.content_length.to_i
+      }
+    end
+
+    def http_headers
+      @env
+        .each_header
+        .select { |key, _| http_header?(key) }
+        .map do |header, value|
+          {name: normalize_header_name(header), value: value}
+        end
+    end
+
+    # "headers" in Rack::Request just means any key in the env. The HTTP headers
+    # are all the headers prefixed with `HTTP_` as per the spec:
+    # https://github.com/rack/rack/blob/master/SPEC.rdoc#the-environment-
+    # Other "headers" like version and host are prefixed with `HTTP_` by Rack but
+    # don't seem to be considered legit HTTP headers.
+    def http_header?(name)
+      name.start_with?("HTTP") && !HTTP_NON_HEADERS.include?(name)
+    end
+
+    # Headers like `Content-Type: application/json` come into rack like
+    # `"HTTP_CONTENT_TYPE" => "application/json"`.
+    def normalize_header_name(header)
+      header.delete_prefix("HTTP_").split("_").map(&:capitalize).join("-")
+    end
+
+    def request_body
+      @env.body.rewind
+      body = @env.body.read
+      @env.body.rewind
+
+      body
+    end
+
+    def cookies
+      to_hash_array(@env.cookies)
+    end
+
+    def response
+      {
+        status: @response.status,
+        statusText: Rack::Utils::HTTP_STATUS_CODES[@response.status],
+        httpVersion: @env.get_header("HTTP_VERSION"),
+        headers: to_hash_array(@response.headers),
+        content: {
+          text: @response.body.each.reduce(:+),
+          size: @response.content_length,
+          mimeType: @response.content_type
+        },
+        redirectURL: @response.location.to_s,
+        headersSize: -1,
+        bodySize: @response.content_length,
+        cookies: cookies
+      }
+    end
+
+    def to_hash_array(hash)
+      hash.map { |name, value| {name: name, value: value} }
     end
   end
 end

--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -5,6 +5,7 @@ require "httparty"
 
 module Readme
   class Metrics
+    SDK_NAME = "Readme.io Ruby SDK"
     ENDPOINT = "https://metrics.readme.io/v1/request"
 
     def initialize(app, api_key)
@@ -13,7 +14,11 @@ module Readme
     end
 
     def call(env)
-      har = Har.new(env)
+      start_time = Time.now
+      status, headers, body = @app.call(env)
+      end_time = Time.now
+
+      har = Har.new(env, status, headers, body, start_time, end_time)
       payload = Payload.new(har)
 
       HTTParty.post(
@@ -22,7 +27,8 @@ module Readme
         headers: {"Content-Type" => "application/json"},
         body: payload.to_json
       )
-      @app.call(env)
+
+      [status, headers, body]
     end
   end
 end

--- a/packages/ruby/spec/fixtures/har.json
+++ b/packages/ruby/spec/fixtures/har.json
@@ -3,8 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "Ruby",
-      "version": "1.0",
-      "comment": "hello"
+      "version": "1.0"
     },
     "entries": [
       {

--- a/packages/ruby/spec/readme/har_spec.rb
+++ b/packages/ruby/spec/readme/har_spec.rb
@@ -1,9 +1,108 @@
 require "readme/har"
+require "rack/lint"
 
 RSpec.describe Readme::Har do
-  it "returns a valid har object" do
-    har = Readme::Har.new(double)
+  describe "#to_json" do
+    it "builds the correct values out of the env" do
+      env = {
+        "CONTENT_TYPE" => "application/json",
+        "CONTENT_LENGTH" => 0,
+        "HTTP_AUTHORIZATION" => "Basic abc123",
+        "HTTP_COOKIE" => "cookie1=value1; cookie2=value2",
+        "HTTP_VERSION" => "HTTP/1.1",
+        "HTTP_X_CUSTOM" => "custom",
+        "PATH_INFO" => "/foo/bar",
+        "REQUEST_METHOD" => "POST",
+        "SCRIPT_NAME" => "/api",
+        "QUERY_STRING" => "id=1&name=joel",
+        "SERVER_NAME" => "example.com",
+        "SERVER_PORT" => "443",
+        "rack.input" => Rack::Lint::InputWrapper.new(StringIO.new("[BODY]")),
+        "rack.url_scheme" => "https"
+      }
+      status_code = 200
+      response_body = ["OK"]
+      headers = {
+        "Content-Type" => "application/json",
+        "Content-Length" => "2",
+        "Location" => "https://example.com"
+      }
+      start_time = Time.now
+      end_time = start_time + 1
+      har = Readme::Har.new(
+        env,
+        status_code,
+        headers,
+        response_body,
+        start_time,
+        end_time
+      )
+      json = JSON.parse(har.to_json)
 
-    expect(har.to_json).to match_json_schema("har")
+      expect(json).to match_json_schema("har")
+
+      expect(json.dig("log", "version")).to eq Readme::Har::HAR_VERSION
+      expect(json.dig("log", "creator", "name")).to eq Readme::Metrics::SDK_NAME
+      expect(json.dig("log", "creator", "version")).to eq Readme::Metrics::VERSION
+      expect(json.dig("log", "entries").length).to eq 1
+      expect(json.dig("log", "entries", 0, "cache")).to be_empty
+      expect(json.dig("log", "entries", 0, "timings", "send")).to eq 0
+      expect(json.dig("log", "entries", 0, "timings", "receive")).to eq 0
+      expect(json.dig("log", "entries", 0, "timings", "wait")).to eq 1000
+      expect(json.dig("log", "entries", 0, "startedDateTime")).to eq start_time.iso8601
+      expect(json.dig("log", "entries", 0, "time")).to eq 1000
+
+      request = json.dig("log", "entries", 0, "request")
+
+      expect(request["method"]).to eq "POST"
+      expect(request["url"]).to eq "https://example.com/api/foo/bar?id=1&name=joel"
+      expect(request["httpVersion"]).to eq "HTTP/1.1"
+      expect(request.dig("postData", "text")).to eq "[BODY]"
+      expect(request.dig("postData", "mimeType")).to eq "application/json"
+      expect(request["headersSize"]).to eq(-1)
+      expect(request["bodySize"]).to eq 0
+      expect(request["headers"]).to match_array(
+        [
+          {"name" => "Authorization", "value" => "Basic abc123"},
+          {"name" => "X-Custom", "value" => "custom"}
+        ]
+      )
+      expect(request["queryString"]).to match_array(
+        [
+          {"name" => "id", "value" => "1"},
+          {"name" => "name", "value" => "joel"}
+        ]
+      )
+      expect(request["cookies"]).to match_array(
+        [
+          {"name" => "cookie1", "value" => "value1"},
+          {"name" => "cookie2", "value" => "value2"}
+        ]
+      )
+
+      response = json.dig("log", "entries", 0, "response")
+
+      expect(response["status"]).to eq status_code
+      expect(response["statusText"]).to eq "OK"
+      expect(response["headers"]).to match_array(
+        [
+          {"name" => "Content-Type", "value" => "application/json"},
+          {"name" => "Content-Length", "value" => "2"},
+          {"name" => "Location", "value" => "https://example.com"}
+        ]
+      )
+      expect(response["headersSize"]).to eq(-1)
+      expect(response["bodySize"]).to eq 2
+      expect(response["redirectURL"]).to eq headers["Location"]
+      expect(response["cookies"]).to match_array(
+        [
+          {"name" => "cookie1", "value" => "value1"},
+          {"name" => "cookie2", "value" => "value2"}
+        ]
+      )
+      expect(response["content"]["text"]).to eq "OK"
+      expect(response["content"]["size"]).to eq 2
+      expect(response["content"]["mimeType"]).to eq "application/json"
+    end
   end
 end

--- a/packages/ruby/spec/readme/payload_spec.rb
+++ b/packages/ruby/spec/readme/payload_spec.rb
@@ -3,7 +3,8 @@ require "readme/har"
 
 RSpec.describe Readme::Payload do
   it "returns JSON matching the readmeMetrics schema" do
-    har = Readme::Har.new(double)
+    har_json = File.read(File.expand_path("../../fixtures/har.json", __FILE__))
+    har = double("har", to_json: har_json)
     result = Readme::Payload.new(har)
 
     expect(result.to_json).to match_json_schema("readmeMetrics")


### PR DESCRIPTION
## 🧰 What's being changed?

Previously, we were using hard-coded values for the HAR. Now we correctly derive a HAR from the Rack env (request) and response.

The HAR spec was designed to describe requests made from a client so there are some keys that are nonsensical in the context of a middleware.

## 🧪 Testing

We added a bunch of automated tests around the HAR generation. Currently only for the happy path of a POST request with a JSON payload.

For manual testing, run the folllowing rack app:

```ruby
# config.ru
$LOAD_PATH << File.expand_path("../path/to/metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {}, ["Ok"]]
  end
end

map "/api" do
  use Readme::Metrics, "YOUR_API_KEY_HERE"
  run ApiApp.new
end
```

with

```
rackup
```

make a request:

```
curl 'http://localhost:9292/api/foo?id=1&name=joel' -H "X-Custom: my custom header" -H "Content-Type: application/json" -X POST -d '{"key": "value"}'
```

![Screen Shot 2020-08-13 at 5 28 43 PM](https://user-images.githubusercontent.com/11845816/90189071-88e29f00-dd8a-11ea-9277-a1918301adcb.png)

