### PR TITLE
Gather user info for calls to ReadMe API

### DIFF
--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -11,20 +11,42 @@ Track your API metrics within ReadMe.
 `Readme::Metrics` is a Rack middleware and is compatible with all Rack-based
 apps, including Rails.
 
+When configuring the middleware, you must provide a block to tell the
+middleware how to get values for the current user. These may be values taken
+from the environment, or you may hardcode them.
+
+If you're using Warden-based authentication like Devise, you may fetch the
+current_user for a given request from the environment.
+
 ### Rails
 
 ```ruby
 # application.rb
 require "readme/metrics"
 
-config.middleware.use Readme::Metrics, "YOUR_API_KEY"
+config.middleware.use Readme::Metrics, "YOUR_API_KEY"do |env|
+  current_user = env['warden'].authenticate(scope: :current_user)
+
+  {
+    id: current_user.id
+    label: current_user.full_name,
+    email: current_user.email
+  }
+end
+
 ```
 
 ### Rack::Builder
 
 ```ruby
 Rack::Builder.new do |builder|
-  builder.use Readme::Metrics, "YOUR_API_KEY"
+  builder.use Readme::Metrics, "YOUR_API_KEY" do |env|
+    {
+      id: "my_application_id"
+      label: "My Application",
+      email: "my.application@example.com"
+    }
+  end
   builder.run your_app
 end
 ```

--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -8,9 +8,10 @@ module Readme
     SDK_NAME = "Readme.io Ruby SDK"
     ENDPOINT = "https://metrics.readme.io/v1/request"
 
-    def initialize(app, api_key)
+    def initialize(app, api_key, &get_user_info)
       @app = app
       @api_key = api_key
+      @get_user_info = get_user_info
     end
 
     def call(env)
@@ -19,7 +20,8 @@ module Readme
       end_time = Time.now
 
       har = Har.new(env, status, headers, body, start_time, end_time)
-      payload = Payload.new(har)
+      user_info = @get_user_info.call(env)
+      payload = Payload.new(har, user_info)
 
       HTTParty.post(
         ENDPOINT,

--- a/packages/ruby/lib/readme/payload.rb
+++ b/packages/ruby/lib/readme/payload.rb
@@ -1,13 +1,14 @@
 module Readme
   class Payload
-    def initialize(har)
+    def initialize(har, user_info)
       @har = har
+      @user_info = user_info
     end
 
     def to_json
       [
         {
-          group: {id: "abc123", email: "user@example.com", label: "Joel"},
+          group: @user_info,
           clientIPAddress: "1.1.1.1",
           development: true,
           request: JSON.parse(@har.to_json)

--- a/packages/ruby/spec/readme/payload_spec.rb
+++ b/packages/ruby/spec/readme/payload_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Readme::Payload do
   it "returns JSON matching the readmeMetrics schema" do
     har_json = File.read(File.expand_path("../../fixtures/har.json", __FILE__))
     har = double("har", to_json: har_json)
-    result = Readme::Payload.new(har)
+
+    result = Readme::Payload.new(har, {id: "1", label: "Anthony", email: "anthony@example.com"})
 
     expect(result.to_json).to match_json_schema("readmeMetrics")
   end


### PR DESCRIPTION
## 🧰 What's being changed?

This commit adds a new block argument to the middleware which, given the environment, can fetch user info. The result is passed into the `Metrics::Payload` and added to the payload sent out to the ReadMe API.

## 🧪 Testing

With a small example app, I was able to pass in a block with some hardcoded values:

```ruby
$LOAD_PATH << File.expand_path("../../metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {}, ["Ok"]]
  end
end

map "/api" do
  use Readme::Metrics, "API_KEY" do |env|
    {id: "anthonym", label: "Anthony M.", email: "anthony@example.com"}
  end
  run ApiApp.new
end
```

Which successfully posted the data:
![Screen Shot 2020-08-14 at 2 50 41 PM](https://user-images.githubusercontent.com/11845816/90283112-8f7e1e80-de3d-11ea-9910-cb8005a009f7.png)

`curl 'http://localhost:9292/api/foo?id=1&name=joel' -H "X-Custom: my custom header" -H "Content-Type: application/json" -X POST -d '{"key": "value"}'`

The automated test suite was also expanded to cover this new functionality. 
