### PR TITLE
Set development flag in middleware configuration

### DIFF
--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -24,7 +24,8 @@ current_user for a given request from the environment.
 # application.rb
 require "readme/metrics"
 
-config.middleware.use Readme::Metrics, "YOUR_API_KEY"do |env|
+options = {api_key: "YOUR_API_KEY", development: false}
+config.middleware.use Readme::Metrics, options do |env|
   current_user = env['warden'].authenticate(scope: :current_user)
 
   {
@@ -33,14 +34,14 @@ config.middleware.use Readme::Metrics, "YOUR_API_KEY"do |env|
     email: current_user.email
   }
 end
-
 ```
 
 ### Rack::Builder
 
 ```ruby
 Rack::Builder.new do |builder|
-  builder.use Readme::Metrics, "YOUR_API_KEY" do |env|
+  options = {api_key: "YOUR_API_KEY", development: false}
+  builder.use Readme::Metrics, options do |env|
     {
       id: "my_application_id"
       label: "My Application",

--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -8,9 +8,12 @@ module Readme
     SDK_NAME = "Readme.io Ruby SDK"
     ENDPOINT = "https://metrics.readme.io/v1/request"
 
-    def initialize(app, api_key, &get_user_info)
+    def initialize(app, options, &get_user_info)
+      raise("Missing API key") if options[:api_key].nil?
+
       @app = app
-      @api_key = api_key
+      @api_key = options[:api_key]
+      @development = options[:development] || false
       @get_user_info = get_user_info
     end
 
@@ -21,7 +24,7 @@ module Readme
 
       har = Har.new(env, status, headers, body, start_time, end_time)
       user_info = @get_user_info.call(env)
-      payload = Payload.new(har, user_info)
+      payload = Payload.new(har, user_info, development: @development)
 
       HTTParty.post(
         ENDPOINT,

--- a/packages/ruby/lib/readme/payload.rb
+++ b/packages/ruby/lib/readme/payload.rb
@@ -1,8 +1,9 @@
 module Readme
   class Payload
-    def initialize(har, user_info)
+    def initialize(har, user_info, development:)
       @har = har
       @user_info = user_info
+      @development = development
     end
 
     def to_json
@@ -10,7 +11,7 @@ module Readme
         {
           group: @user_info,
           clientIPAddress: "1.1.1.1",
-          development: true,
+          development: @development,
           request: JSON.parse(@har.to_json)
         }
       ].to_json

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Readme::Metrics do
   end
 
   def app
-    app = Readme::Metrics.new(noop_app, "API_KEY") { |env|
+    options = {api_key: "API KEY", development: true}
+    app = Readme::Metrics.new(noop_app, options) { |env|
       {
         id: env["CURRENT_USER"].id,
         label: env["CURRENT_USER"].name,

--- a/packages/ruby/spec/readme/payload_spec.rb
+++ b/packages/ruby/spec/readme/payload_spec.rb
@@ -5,8 +5,11 @@ RSpec.describe Readme::Payload do
   it "returns JSON matching the readmeMetrics schema" do
     har_json = File.read(File.expand_path("../../fixtures/har.json", __FILE__))
     har = double("har", to_json: har_json)
-
-    result = Readme::Payload.new(har, {id: "1", label: "Anthony", email: "anthony@example.com"})
+    result = Readme::Payload.new(
+      har,
+      {id: "1", label: "Anthony", email: "anthony@example.com"},
+      development: true
+    )
 
     expect(result.to_json).to match_json_schema("readmeMetrics")
   end


### PR DESCRIPTION
## 🧰 What's being changed?

This commit allows users to set whether or not requests will be flagged as development data or not.

## 🧪 Testing

We used a small example application and set `development: false` . This application successfully posted non-development data to the dashboard:

`curl 'http://localhost:9292/api/foo?id=1&name=joel' -H "X-Custom: my custom header" -H "Content-Type: application/json" -X POST -d '{"key": "value"}'`

```ruby
$LOAD_PATH << File.expand_path("../../metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {}, ["Ok"]]
  end
end

map "/api" do
  options = {api_key: "lyBlA1eaaKUXFoxQDbJ9FX2B5VajBAHA", development: false} 
  use Readme::Metrics, options do |env|
    {id: "anthonym", label: "Anthony M.", email: "anthony@example.com"}
  end
  run ApiApp.new
end

```