### PR TITLE
Extract `HarRequest` object

### DIFF
--- a/packages/ruby/lib/readme/har.rb
+++ b/packages/ruby/lib/readme/har.rb
@@ -1,18 +1,12 @@
 require "rack"
-require "rack/request"
+require "readme/har_request"
 
 module Readme
   class Har
     HAR_VERSION = "1.2"
-    HTTP_NON_HEADERS = [
-      Rack::HTTP_COOKIE,
-      Rack::HTTP_VERSION,
-      Rack::HTTP_HOST,
-      Rack::HTTP_PORT
-    ]
 
     def initialize(env, status, headers, response, start_time, end_time)
-      @env = Rack::Request.new(env)
+      @request = HarRequest.new(env)
       @response = Rack::Response.new(response, status, headers)
       @start_time = start_time
       @end_time = end_time
@@ -63,63 +57,14 @@ module Readme
     end
 
     def request
-      {
-        method: @env.request_method,
-        queryString: to_hash_array(@env.GET),
-        url: @env.url,
-        httpVersion: @env.get_header("HTTP_VERSION"),
-        headers: http_headers,
-        cookies: cookies,
-        postData: {
-          text: request_body,
-          mimeType: @env.content_type
-        },
-        headersSize: -1,
-        bodySize: @env.content_length.to_i
-      }
-    end
-
-    def http_headers
-      @env
-        .each_header
-        .select { |key, _| http_header?(key) }
-        .map do |header, value|
-          {name: normalize_header_name(header), value: value}
-        end
-    end
-
-    # "headers" in Rack::Request just means any key in the env. The HTTP headers
-    # are all the headers prefixed with `HTTP_` as per the spec:
-    # https://github.com/rack/rack/blob/master/SPEC.rdoc#the-environment-
-    # Other "headers" like version and host are prefixed with `HTTP_` by Rack but
-    # don't seem to be considered legit HTTP headers.
-    def http_header?(name)
-      name.start_with?("HTTP") && !HTTP_NON_HEADERS.include?(name)
-    end
-
-    # Headers like `Content-Type: application/json` come into rack like
-    # `"HTTP_CONTENT_TYPE" => "application/json"`.
-    def normalize_header_name(header)
-      header.delete_prefix("HTTP_").split("_").map(&:capitalize).join("-")
-    end
-
-    def request_body
-      @env.body.rewind
-      body = @env.body.read
-      @env.body.rewind
-
-      body
-    end
-
-    def cookies
-      to_hash_array(@env.cookies)
+      @request.as_json
     end
 
     def response
       {
         status: @response.status,
         statusText: Rack::Utils::HTTP_STATUS_CODES[@response.status],
-        httpVersion: @env.get_header("HTTP_VERSION"),
+        httpVersion: @request.http_version,
         headers: to_hash_array(@response.headers),
         content: {
           text: @response.body.each.reduce(:+),
@@ -129,7 +74,7 @@ module Readme
         redirectURL: @response.location.to_s,
         headersSize: -1,
         bodySize: @response.content_length,
-        cookies: cookies
+        cookies: @request.cookies
       }
     end
 

--- a/packages/ruby/lib/readme/har_request.rb
+++ b/packages/ruby/lib/readme/har_request.rb
@@ -1,0 +1,79 @@
+require "rack/request"
+
+module Readme
+  class HarRequest
+    HTTP_NON_HEADERS = [
+      Rack::HTTP_COOKIE,
+      Rack::HTTP_VERSION,
+      Rack::HTTP_HOST,
+      Rack::HTTP_PORT
+    ]
+
+    def initialize(env)
+      @env = Rack::Request.new(env)
+    end
+
+    def as_json
+      {
+        method: @env.request_method,
+        queryString: to_hash_array(@env.GET),
+        url: @env.url,
+        httpVersion: http_version,
+        headers: http_headers,
+        cookies: cookies,
+        postData: {
+          text: request_body,
+          mimeType: @env.content_type
+        },
+        headersSize: -1,
+        bodySize: @env.content_length.to_i
+      }
+    end
+
+    def cookies
+      to_hash_array(@env.cookies)
+    end
+
+    def http_version
+      @env.get_header("HTTP_VERSION")
+    end
+
+    private
+
+    def to_hash_array(hash)
+      hash.map { |name, value| {name: name, value: value} }
+    end
+
+    def http_headers
+      @env
+        .each_header
+        .select { |key, _| http_header?(key) }
+        .map do |header, value|
+          {name: normalize_header_name(header), value: value}
+        end
+    end
+
+    # "headers" in Rack::Request just means any key in the env. The HTTP headers
+    # are all the headers prefixed with `HTTP_` as per the spec:
+    # https://github.com/rack/rack/blob/master/SPEC.rdoc#the-environment-
+    # Other "headers" like version and host are prefixed with `HTTP_` by Rack but
+    # don't seem to be considered legit HTTP headers.
+    def http_header?(name)
+      name.start_with?("HTTP") && !HTTP_NON_HEADERS.include?(name)
+    end
+
+    # Headers like `Content-Type: application/json` come into rack like
+    # `"HTTP_CONTENT_TYPE" => "application/json"`.
+    def normalize_header_name(header)
+      header.delete_prefix("HTTP_").split("_").map(&:capitalize).join("-")
+    end
+
+    def request_body
+      @env.body.rewind
+      body = @env.body.read
+      @env.body.rewind
+
+      body
+    end
+  end
+end

--- a/packages/ruby/spec/fixtures/har_request.json
+++ b/packages/ruby/spec/fixtures/har_request.json
@@ -1,0 +1,24 @@
+{
+  "cookies": [],
+  "headersSize": 50,
+  "bodySize": 200,
+  "method": "GET",
+  "url": "http://example.com/api/foo",
+  "httpVersion": "HTTP 1.1",
+  "headers": [
+    {
+      "name": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "queryString": [
+    {
+      "name": "id",
+      "value": "1"
+    }
+  ],
+  "postData": {
+    "text": "[REQUEST BODY]",
+    "mimeType": "application/json"
+  }
+}

--- a/packages/ruby/spec/readme/har_request_spec.rb
+++ b/packages/ruby/spec/readme/har_request_spec.rb
@@ -1,0 +1,84 @@
+require "spec_helper"
+require "readme/har_request"
+
+RSpec.describe Readme::HarRequest do
+  describe "#as_json" do
+    it "builds valid json" do
+      env = {
+        "CONTENT_TYPE" => "application/json",
+        "CONTENT_LENGTH" => 0,
+        "HTTP_AUTHORIZATION" => "Basic abc123",
+        "HTTP_COOKIE" => "cookie1=value1; cookie2=value2",
+        "HTTP_VERSION" => "HTTP/1.1",
+        "HTTP_X_CUSTOM" => "custom",
+        "PATH_INFO" => "/foo/bar",
+        "REQUEST_METHOD" => "POST",
+        "SCRIPT_NAME" => "/api",
+        "QUERY_STRING" => "id=1&name=joel",
+        "SERVER_NAME" => "example.com",
+        "SERVER_PORT" => "443",
+        "rack.input" => Rack::Lint::InputWrapper.new(StringIO.new("[BODY]")),
+        "rack.url_scheme" => "https"
+      }
+      request = Readme::HarRequest.new(env)
+      json = request.as_json
+
+      expect(json).to match_json_schema("request")
+
+      expect(json[:method]).to eq "POST"
+      expect(json[:url]).to eq "https://example.com/api/foo/bar?id=1&name=joel"
+      expect(json[:httpVersion]).to eq "HTTP/1.1"
+      expect(json.dig(:postData, :text)).to eq "[BODY]"
+      expect(json.dig(:postData, :mimeType)).to eq "application/json"
+      expect(json[:headersSize]).to eq(-1)
+      expect(json[:bodySize]).to eq 0
+      expect(json[:headers]).to match_array(
+        [
+          {name: "Authorization", value: "Basic abc123"},
+          {name: "X-Custom", value: "custom"}
+        ]
+      )
+      expect(json[:queryString]).to match_array(
+        [
+          {name: "id", value: "1"},
+          {name: "name", value: "joel"}
+        ]
+      )
+      expect(json[:cookies]).to match_array(
+        [
+          {name: "cookie1", value: "value1"},
+          {name: "cookie2", value: "value2"}
+        ]
+      )
+    end
+  end
+
+  describe "#cookies" do
+    it "returns the cookies as an array of name/value hashes" do
+      env = {
+        "HTTP_COOKIE" => "cookie1=value1; cookie2=value2"
+      }
+
+      request = Readme::HarRequest.new(env)
+
+      expect(request.cookies).to match_array(
+        [
+          {name: "cookie1", value: "value1"},
+          {name: "cookie2", value: "value2"}
+        ]
+      )
+    end
+  end
+
+  describe "#http_version" do
+    it "returns the version from the ENV" do
+      env = {
+        "HTTP_VERSION" => "HTTP/1.1"
+      }
+
+      request = Readme::HarRequest.new(env)
+
+      expect(request.http_version).to eq "HTTP/1.1"
+    end
+  end
+end


### PR DESCRIPTION
## 🧰 What's being changed?

This pulls out all the request logic from `Har` to its own object so
it's easier to test variations.

## 🧪 Testing

This is a pure refactor, there are no behavior changes. New automated unit tests were added around some existing behavior.
