### PR TITLE
Allow user to set attribute names to filter

### DIFF
--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -18,13 +18,25 @@ from the environment, or you may hardcode them.
 If you're using Warden-based authentication like Devise, you may fetch the
 current_user for a given request from the environment.
 
+### Sensitive Data
+
+If you have sensitive data you'd like to prevent from being sent to the Metrics
+API via headers, query params or payload bodies, you can specify a list of keys
+to filter via the `filter_params` option. Key-value pairs matching these keys
+will not be included in the request to the Metrics API.
+
 ### Rails
 
 ```ruby
 # application.rb
 require "readme/metrics"
 
-options = {api_key: "YOUR_API_KEY", development: false}
+options = {
+  api_key: "YOUR_API_KEY",
+  development: false,
+  filter_params: ["not_included", "dont_send"]
+}
+
 config.middleware.use Readme::Metrics, options do |env|
   current_user = env['warden'].authenticate(scope: :current_user)
 
@@ -40,7 +52,12 @@ end
 
 ```ruby
 Rack::Builder.new do |builder|
-  options = {api_key: "YOUR_API_KEY", development: false}
+  options = {
+    api_key: "YOUR_API_KEY",
+    development: false,
+    filter_params: ["not_included", "dont_send"]
+  }
+
   builder.use Readme::Metrics, options do |env|
     {
       id: "my_application_id"

--- a/packages/ruby/lib/readme/har_request.rb
+++ b/packages/ruby/lib/readme/har_request.rb
@@ -1,19 +1,20 @@
 module Readme
   class HarRequest
-    def initialize(request)
+    def initialize(request, filter_params = [])
       @request = request
+      @filter_params = filter_params
     end
 
     def as_json
       {
         method: @request.request_method,
-        queryString: to_hash_array(@request.query_params),
+        queryString: filtered_hash_array(@request.query_params),
         url: @request.url,
         httpVersion: @request.http_version,
-        headers: to_hash_array(@request.headers),
-        cookies: to_hash_array(@request.cookies),
+        headers: filtered_hash_array(@request.headers),
+        cookies: filtered_hash_array(@request.cookies),
         postData: {
-          text: @request.body,
+          text: request_body,
           mimeType: @request.content_type
         },
         headersSize: -1,
@@ -23,8 +24,28 @@ module Readme
 
     private
 
+    def request_body
+      parsed_body = JSON.parse(@request.body)
+      filter_hash_with_params(parsed_body)
+    rescue
+      @request.body
+    end
+
     def to_hash_array(hash)
       hash.map { |name, value| {name: name, value: value} }
+    end
+
+    def filter_hash_with_params(hash)
+      hash.select { |key, _value| !@filter_params.include?(key) }
+    end
+
+    def filter_hash_array_with_params(array)
+      array.select { |pair| !@filter_params.include? pair[:name] }
+    end
+
+    def filtered_hash_array(hash)
+      as_array = to_hash_array(hash)
+      filter_hash_array_with_params(as_array)
     end
   end
 end

--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -14,6 +14,7 @@ module Readme
       @app = app
       @api_key = options[:api_key]
       @development = options[:development] || false
+      @filter_params = options[:filter_params] || []
       @get_user_info = get_user_info
     end
 
@@ -22,7 +23,9 @@ module Readme
       status, headers, body = @app.call(env)
       end_time = Time.now
 
-      har = Har.new(env, status, headers, body, start_time, end_time)
+      response = Rack::Response.new(body, status, headers)
+
+      har = Har.new(env, response, start_time, end_time, @filter_params)
       user_info = @get_user_info.call(env)
       payload = Payload.new(har, user_info, development: @development)
 


### PR DESCRIPTION
## 🧰 What's being changed?

This commit allows an optional list of parameters to be filtered to be passed in when configuring the middleware. The argument is an array of string. Values in the `filter_params` array filter the body and headers of both request and response

## 🧪 Testing

We tested this manually using the sample rack application:

`curl 'http://localhost:9292/api/foo?id=1&name=joel' -H "X-Filtered: my custom header" -H "Content-Type: application/json" -X POST -d '{"key": "value", "filtered": "filtered"}'`

```ruby
$LOAD_PATH << File.expand_path("../../metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {}, ["Ok"]]
  end
end

map "/api" do
  options = {
    api_key: "API_KEY",
    development: false,
    filter_params: ["filtered", "X-Filtered"]
  }
  use Readme::Metrics, options do |env|
    {id: "anthonym", label: "Anthony M.", email: "anthony@example.com"}
  end
  run ApiApp.new
end
```

This request in the dashboard does not include the filtered key-value pairs in the header or body:
<img width="465" alt="Screen Shot 2020-08-17 at 3 00 52 PM" src="https://user-images.githubusercontent.com/11845816/90434141-ed5b7200-e09a-11ea-922a-507e52934e20.png">

