### PR TITLE
Extract `HttpRequest` object

### DIFF
--- a/packages/ruby/lib/http_request.rb
+++ b/packages/ruby/lib/http_request.rb
@@ -1,0 +1,75 @@
+require "rack/request"
+
+class HttpRequest
+    HTTP_NON_HEADERS = [
+      Rack::HTTP_COOKIE,
+      Rack::HTTP_VERSION,
+      Rack::HTTP_HOST,
+      Rack::HTTP_PORT
+    ]
+
+  def initialize(env)
+    @request = Rack::Request.new(env)
+  end
+
+  def url
+    @request.url
+  end
+
+  def query_params
+    @request.GET
+  end
+
+  def cookies
+    @request.cookies
+  end
+
+  def http_version
+    @request.get_header(Rack::HTTP_VERSION)
+  end
+
+  def request_method
+    @request.request_method
+  end
+
+  def content_type
+    @request.content_type
+  end
+
+  def content_length
+    @request.content_length.to_i
+  end
+
+  def headers
+    @request
+      .each_header
+      .select { |key, _| http_header?(key) }
+      .to_h
+      .transform_keys { |header| normalize_header_name(header) }
+  end
+
+  def body
+    @request.body.rewind
+    content = @request.body.read
+    @request.body.rewind
+
+    content
+  end
+
+  private
+
+  # "headers" in Rack::Request just means any key in the env. The HTTP headers
+  # are all the headers prefixed with `HTTP_` as per the spec:
+  # https://github.com/rack/rack/blob/master/SPEC.rdoc#the-environment-
+  # Other "headers" like version and host are prefixed with `HTTP_` by Rack but
+  # don't seem to be considered legit HTTP headers.
+  def http_header?(name)
+    name.start_with?("HTTP") && !HTTP_NON_HEADERS.include?(name)
+  end
+
+  # Headers like `Content-Type: application/json` come into rack like
+  # `"HTTP_CONTENT_TYPE" => "application/json"`.
+  def normalize_header_name(header)
+    header.delete_prefix("HTTP_").split("_").map(&:capitalize).join("-")
+  end
+end

--- a/packages/ruby/lib/readme/har.rb
+++ b/packages/ruby/lib/readme/har.rb
@@ -1,12 +1,14 @@
 require "rack"
 require "readme/har_request"
+require "http_request"
 
 module Readme
   class Har
     HAR_VERSION = "1.2"
 
     def initialize(env, status, headers, response, start_time, end_time)
-      @request = HarRequest.new(env)
+      @http_request = HttpRequest.new(env)
+      @request = HarRequest.new(@http_request)
       @response = Rack::Response.new(response, status, headers)
       @start_time = start_time
       @end_time = end_time
@@ -64,7 +66,7 @@ module Readme
       {
         status: @response.status,
         statusText: Rack::Utils::HTTP_STATUS_CODES[@response.status],
-        httpVersion: @request.http_version,
+        httpVersion: @http_request.http_version,
         headers: to_hash_array(@response.headers),
         content: {
           text: @response.body.each.reduce(:+),
@@ -74,7 +76,7 @@ module Readme
         redirectURL: @response.location.to_s,
         headersSize: -1,
         bodySize: @response.content_length,
-        cookies: @request.cookies
+        cookies: to_hash_array(@http_request.cookies)
       }
     end
 

--- a/packages/ruby/lib/readme/har_request.rb
+++ b/packages/ruby/lib/readme/har_request.rb
@@ -1,79 +1,30 @@
-require "rack/request"
-
 module Readme
   class HarRequest
-    HTTP_NON_HEADERS = [
-      Rack::HTTP_COOKIE,
-      Rack::HTTP_VERSION,
-      Rack::HTTP_HOST,
-      Rack::HTTP_PORT
-    ]
-
-    def initialize(env)
-      @env = Rack::Request.new(env)
+    def initialize(request)
+      @request = request
     end
 
     def as_json
       {
-        method: @env.request_method,
-        queryString: to_hash_array(@env.GET),
-        url: @env.url,
-        httpVersion: http_version,
-        headers: http_headers,
-        cookies: cookies,
+        method: @request.request_method,
+        queryString: to_hash_array(@request.query_params),
+        url: @request.url,
+        httpVersion: @request.http_version,
+        headers: to_hash_array(@request.headers),
+        cookies: to_hash_array(@request.cookies),
         postData: {
-          text: request_body,
-          mimeType: @env.content_type
+          text: @request.body,
+          mimeType: @request.content_type
         },
         headersSize: -1,
-        bodySize: @env.content_length.to_i
+        bodySize: @request.content_length
       }
-    end
-
-    def cookies
-      to_hash_array(@env.cookies)
-    end
-
-    def http_version
-      @env.get_header("HTTP_VERSION")
     end
 
     private
 
     def to_hash_array(hash)
       hash.map { |name, value| {name: name, value: value} }
-    end
-
-    def http_headers
-      @env
-        .each_header
-        .select { |key, _| http_header?(key) }
-        .map do |header, value|
-          {name: normalize_header_name(header), value: value}
-        end
-    end
-
-    # "headers" in Rack::Request just means any key in the env. The HTTP headers
-    # are all the headers prefixed with `HTTP_` as per the spec:
-    # https://github.com/rack/rack/blob/master/SPEC.rdoc#the-environment-
-    # Other "headers" like version and host are prefixed with `HTTP_` by Rack but
-    # don't seem to be considered legit HTTP headers.
-    def http_header?(name)
-      name.start_with?("HTTP") && !HTTP_NON_HEADERS.include?(name)
-    end
-
-    # Headers like `Content-Type: application/json` come into rack like
-    # `"HTTP_CONTENT_TYPE" => "application/json"`.
-    def normalize_header_name(header)
-      header.delete_prefix("HTTP_").split("_").map(&:capitalize).join("-")
-    end
-
-    def request_body
-      @env.body.rewind
-      body = @env.body.read
-      @env.body.rewind
-
-      body
     end
   end
 end

--- a/packages/ruby/spec/http_request_spec.rb
+++ b/packages/ruby/spec/http_request_spec.rb
@@ -1,0 +1,147 @@
+require "spec_helper"
+require "http_request"
+
+RSpec.describe HttpRequest do
+  describe "#url" do
+    it "builds a URL from parts" do
+      env = {
+        "PATH_INFO" => "/foo/bar",
+        "REQUEST_METHOD" => "POST",
+        "QUERY_STRING" => "id=1&name=joel",
+        "SERVER_NAME" => "localhost",
+        "SERVER_PORT" => "8080",
+        "rack.url_scheme" => "http"
+      }
+      request = HttpRequest.new(env)
+
+      expect(request.url).to eq "http://localhost:8080/foo/bar?id=1&name=joel"
+    end
+
+    it "takes into account the Rack SCRIPT_NAME parameter" do
+      env = {
+        "PATH_INFO" => "/foo/bar",
+        "REQUEST_METHOD" => "POST",
+        "QUERY_STRING" => "id=1&name=joel",
+        "SCRIPT_NAME" => "/api",
+        "SERVER_NAME" => "localhost",
+        "SERVER_PORT" => "8080",
+        "rack.url_scheme" => "http"
+      }
+      request = HttpRequest.new(env)
+
+      expect(request.url).to eq "http://localhost:8080/api/foo/bar?id=1&name=joel"
+    end
+  end
+
+  describe "#cookies" do
+    it "builds a hash from the Rack HTTP_COOKIE key" do
+      env = {"HTTP_COOKIE" => "cookie1=value1; cookie2=value2"}
+      request = HttpRequest.new(env)
+
+      expect(request.cookies).to eq({"cookie1" => "value1", "cookie2" => "value2"})
+    end
+
+    it "is an empty hash when the Rack HTTP_COOKIE key is not present" do
+      request = HttpRequest.new({})
+
+      expect(request.cookies).to be_empty
+    end
+  end
+
+  describe "#query_params" do
+    it "builds a hash of strings from the Rack QUERY_STRING key" do
+      env = {"QUERY_STRING" => "id=1&name=joel"}
+      request = HttpRequest.new(env)
+
+      expect(request.query_params).to eq({ "id" => "1", "name" => "joel" })
+    end
+
+    it "is an empty hash when the Rack QUERY_STRING key is not present" do
+      request = HttpRequest.new({})
+
+      expect(request.query_params).to be_empty
+    end
+  end
+
+  describe "#http_version" do
+    it "gets the version from the proper Rack header" do
+      env = { "HTTP_VERSION" => "HTTP/1.1" }
+      request = HttpRequest.new(env)
+
+      expect(request.http_version).to eq "HTTP/1.1"
+    end
+
+    it "is nil when the header is missing" do
+      request = HttpRequest.new({})
+
+      expect(request.http_version).to be_nil
+    end
+  end
+
+  describe "#request_method" do
+    it "gets the value from the Rack REQUEST_METHOD key" do
+      request = HttpRequest.new("REQUEST_METHOD" => "POST")
+
+      expect(request.request_method).to eq "POST"
+    end
+  end
+
+  describe "#content_type" do
+    it "gets the the value from the Rack CONTENT_TYPE key" do
+      request = HttpRequest.new("CONTENT_TYPE" => "application/json")
+
+      expect(request.content_type).to eq "application/json"
+    end
+  end
+
+  describe "#content_length" do
+    it "gets the the value from the Rack CONTENT_LENGTH key" do
+      request = HttpRequest.new("CONTENT_LENGTH" => "256")
+
+      expect(request.content_length).to eq 256
+    end
+
+    it "is zero when the Rack CONTENT_LENGTH isn't set" do
+      request = HttpRequest.new({})
+
+      expect(request.content_length).to eq 0
+    end
+  end
+
+  describe "#headers" do
+    it "is the normalized Rack HTTP_ keys minus a few non-header ones" do
+      env = {
+        "HTTP_COOKIE" => "cookie1=value1; cookie2=value2",
+        "HTTP_VERSION" => "HTTP/1.1",
+        "HTTP_X_CUSTOM" => "custom",
+        "HTTP_ACCEPT" => "text/plain",
+        "HTTP_PORT" => "8080",
+        "HTTP_HOST" => "example.com"
+      }
+      request = HttpRequest.new(env)
+
+      expect(request.headers).to eq ({"X-Custom" => "custom", "Accept" => "text/plain"})
+    end
+  end
+
+  describe "#body" do
+    it "reads the body from the rack.input key" do
+      env = {
+        "rack.input" => Rack::Lint::InputWrapper.new(StringIO.new("[BODY]"))
+      }
+      request = HttpRequest.new(env)
+
+      expect(request.body).to eq "[BODY]"
+    end
+
+    it "can be read safely multiple times" do
+      env = {
+        "rack.input" => Rack::Lint::InputWrapper.new(StringIO.new("[BODY]"))
+      }
+      request = HttpRequest.new(env)
+
+      expect(request.body).to eq "[BODY]"
+      expect(request.body).to eq "[BODY]"
+    end
+  end
+end

--- a/packages/ruby/spec/readme/har_request_spec.rb
+++ b/packages/ruby/spec/readme/har_request_spec.rb
@@ -4,23 +4,19 @@ require "readme/har_request"
 RSpec.describe Readme::HarRequest do
   describe "#as_json" do
     it "builds valid json" do
-      env = {
-        "CONTENT_TYPE" => "application/json",
-        "CONTENT_LENGTH" => 0,
-        "HTTP_AUTHORIZATION" => "Basic abc123",
-        "HTTP_COOKIE" => "cookie1=value1; cookie2=value2",
-        "HTTP_VERSION" => "HTTP/1.1",
-        "HTTP_X_CUSTOM" => "custom",
-        "PATH_INFO" => "/foo/bar",
-        "REQUEST_METHOD" => "POST",
-        "SCRIPT_NAME" => "/api",
-        "QUERY_STRING" => "id=1&name=joel",
-        "SERVER_NAME" => "example.com",
-        "SERVER_PORT" => "443",
-        "rack.input" => Rack::Lint::InputWrapper.new(StringIO.new("[BODY]")),
-        "rack.url_scheme" => "https"
-      }
-      request = Readme::HarRequest.new(env)
+     http_request = double(
+       :http_request,
+       url: "https://example.com/api/foo/bar?id=1&name=joel",
+       query_params: { "id" => "1", "name" => "joel" },
+       request_method: "POST",
+       http_version: "HTTP/1.1",
+       content_length: 6,
+       content_type: "application/json",
+       cookies: { "cookie1" => "value1", "cookie2" => "value2" },
+       headers: { "X-Custom" => "custom", "Authorization" => "Basic abc123" },
+       body: "[BODY]",
+      )
+      request = Readme::HarRequest.new(http_request)
       json = request.as_json
 
       expect(json).to match_json_schema("request")
@@ -31,7 +27,7 @@ RSpec.describe Readme::HarRequest do
       expect(json.dig(:postData, :text)).to eq "[BODY]"
       expect(json.dig(:postData, :mimeType)).to eq "application/json"
       expect(json[:headersSize]).to eq(-1)
-      expect(json[:bodySize]).to eq 0
+      expect(json[:bodySize]).to eq 6
       expect(json[:headers]).to match_array(
         [
           {name: "Authorization", value: "Basic abc123"},
@@ -50,35 +46,6 @@ RSpec.describe Readme::HarRequest do
           {name: "cookie2", value: "value2"}
         ]
       )
-    end
-  end
-
-  describe "#cookies" do
-    it "returns the cookies as an array of name/value hashes" do
-      env = {
-        "HTTP_COOKIE" => "cookie1=value1; cookie2=value2"
-      }
-
-      request = Readme::HarRequest.new(env)
-
-      expect(request.cookies).to match_array(
-        [
-          {name: "cookie1", value: "value1"},
-          {name: "cookie2", value: "value2"}
-        ]
-      )
-    end
-  end
-
-  describe "#http_version" do
-    it "returns the version from the ENV" do
-      env = {
-        "HTTP_VERSION" => "HTTP/1.1"
-      }
-
-      request = Readme::HarRequest.new(env)
-
-      expect(request.http_version).to eq "HTTP/1.1"
     end
   end
 end

--- a/packages/ruby/spec/readme/har_spec.rb
+++ b/packages/ruby/spec/readme/har_spec.rb
@@ -5,13 +5,15 @@ RSpec.describe Readme::Har do
   describe "#to_json" do
     it "builds the correct values out of the env" do
       request_json = File.read(File.expand_path("../../fixtures/har_request.json", __FILE__))
-      har_request = double(
-        :har_request,
-        as_json: JSON.parse(request_json),
-        cookies: [],
+      har_request = double( :har_request, as_json: JSON.parse(request_json))
+      allow(Readme::HarRequest).to receive(:new).and_return(har_request)
+
+      http_request = double(
+        :http_request,
+        cookies: { "cookie1" => "value1"},
         http_version: "HTTP/1.1"
       )
-      allow(Readme::HarRequest).to receive(:new).and_return(har_request)
+      allow(HttpRequest).to receive(:new).and_return(http_request)
       env = double(:env)
 
       status_code = 200
@@ -50,7 +52,7 @@ RSpec.describe Readme::Har do
 
       expect(response["status"]).to eq status_code
       expect(response["statusText"]).to eq "OK"
-      expect(response["httpVersion"]).to eq har_request.http_version
+      expect(response["httpVersion"]).to eq http_request.http_version
       expect(response["headers"]).to match_array(
         [
           {"name" => "Content-Type", "value" => "application/json"},
@@ -61,7 +63,11 @@ RSpec.describe Readme::Har do
       expect(response["headersSize"]).to eq(-1)
       expect(response["bodySize"]).to eq 2
       expect(response["redirectURL"]).to eq headers["Location"]
-      expect(response["cookies"]).to match_array(har_request.cookies)
+      expect(response["cookies"]).to match_array(
+        [
+          {"name" => "cookie1", "value" => "value1"}
+        ]
+      )
       expect(response["content"]["text"]).to eq "OK"
       expect(response["content"]["size"]).to eq 2
       expect(response["content"]["mimeType"]).to eq "application/json"


### PR DESCRIPTION
## 🧰 What's being changed?

`Rack::Request` provides some niceties over a raw env hash but is still
missing some key behavior such as getting HTTP headers or safely reading
the body.

This extracts an object to that wraps `Rack::Request` and provides a
nice interface for these things. Some of the methods just delegate to
existing `Rack::Request` functionality. I made the decision not to try
and isolate the two in testing in order to get more readable tests.

## 🧪 Testing

This is a pure refactor with no behavior changes. Additional automated unit tests were added around newly public behavior.