### PR TITLE
Allow users to specify a set of values that should only be sent to the API

### DIFF
--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -22,8 +22,14 @@ current_user for a given request from the environment.
 
 If you have sensitive data you'd like to prevent from being sent to the Metrics
 API via headers, query params or payload bodies, you can specify a list of keys
-to filter via the `filter_params` option. Key-value pairs matching these keys
+to filter via the `reject_params` option. Key-value pairs matching these keys
 will not be included in the request to the Metrics API.
+
+You are also able to specify a set of `allow_only` which should only be sent through.
+Any header or body values not matching these keys will be filtered out and not
+send to the API.
+
+You may only specify either `reject_params` or `allow_only` keys, not both.
 
 ### Rails
 
@@ -34,7 +40,7 @@ require "readme/metrics"
 options = {
   api_key: "YOUR_API_KEY",
   development: false,
-  filter_params: ["not_included", "dont_send"]
+  reject_params: ["not_included", "dont_send"]
 }
 
 config.middleware.use Readme::Metrics, options do |env|
@@ -55,7 +61,7 @@ Rack::Builder.new do |builder|
   options = {
     api_key: "YOUR_API_KEY",
     development: false,
-    filter_params: ["not_included", "dont_send"]
+    reject_params: ["not_included", "dont_send"]
   }
 
   builder.use Readme::Metrics, options do |env|

--- a/packages/ruby/lib/readme/filter.rb
+++ b/packages/ruby/lib/readme/filter.rb
@@ -1,0 +1,46 @@
+class Filter
+  def self.for(reject: nil, allow_only: nil)
+    if !reject.nil? && !allow_only.nil?
+      raise FilterArgsError
+    elsif !reject.nil?
+      RejectParams.new(reject)
+    elsif !allow_only.nil?
+      AllowOnly.new(allow_only)
+    else
+      None.new
+    end
+  end
+
+  class AllowOnly
+    def initialize(filter_values)
+      @filter_values = filter_values
+    end
+
+    def filter(hash)
+      hash.select { |key, _value| @filter_values.include?(key) }
+    end
+  end
+
+  class RejectParams
+    def initialize(filter_values)
+      @filter_values = filter_values
+    end
+
+    def filter(hash)
+      hash.reject { |key, _value| @filter_values.include?(key) }
+    end
+  end
+
+  class None
+    def filter(hash)
+      hash
+    end
+  end
+
+  class FilterArgsError < StandardError
+    def initialize
+      msg = "Can only supply either reject_params or allow_only, not both."
+      super(msg)
+    end
+  end
+end

--- a/packages/ruby/lib/readme/har_collection.rb
+++ b/packages/ruby/lib/readme/har_collection.rb
@@ -1,0 +1,22 @@
+module Readme
+  class HarCollection
+    def initialize(filter, hash)
+      @filter = filter
+      @hash = hash
+    end
+
+    def to_h
+      filtered_hash
+    end
+
+    def to_a
+      filtered_hash.map { |name, value| {name: name, value: value} }
+    end
+
+    private
+
+    def filtered_hash
+      @filter.filter(@hash)
+    end
+  end
+end

--- a/packages/ruby/lib/readme/har_request.rb
+++ b/packages/ruby/lib/readme/har_request.rb
@@ -1,18 +1,20 @@
+require "readme/har_collection"
+
 module Readme
   class HarRequest
-    def initialize(request, filter_params = [])
+    def initialize(request, filter = Filter::None.new)
       @request = request
-      @filter_params = filter_params
+      @filter = filter
     end
 
     def as_json
       {
         method: @request.request_method,
-        queryString: filtered_hash_array(@request.query_params),
+        queryString: HarCollection.new(@filter, @request.query_params).to_a,
         url: @request.url,
         httpVersion: @request.http_version,
-        headers: filtered_hash_array(@request.headers),
-        cookies: filtered_hash_array(@request.cookies),
+        headers: HarCollection.new(@filter, @request.headers).to_a,
+        cookies: HarCollection.new(@filter, @request.cookies).to_a,
         postData: {
           text: request_body,
           mimeType: @request.content_type
@@ -26,26 +28,9 @@ module Readme
 
     def request_body
       parsed_body = JSON.parse(@request.body)
-      filter_hash_with_params(parsed_body)
+      HarCollection.new(@filter, parsed_body).to_h.to_json
     rescue
       @request.body
-    end
-
-    def to_hash_array(hash)
-      hash.map { |name, value| {name: name, value: value} }
-    end
-
-    def filter_hash_with_params(hash)
-      hash.select { |key, _value| !@filter_params.include?(key) }
-    end
-
-    def filter_hash_array_with_params(array)
-      array.select { |pair| !@filter_params.include? pair[:name] }
-    end
-
-    def filtered_hash_array(hash)
-      as_array = to_hash_array(hash)
-      filter_hash_array_with_params(as_array)
     end
   end
 end

--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -1,5 +1,6 @@
 require "readme/metrics/version"
 require "readme/har"
+require "readme/filter"
 require "readme/payload"
 require "httparty"
 
@@ -14,7 +15,10 @@ module Readme
       @app = app
       @api_key = options[:api_key]
       @development = options[:development] || false
-      @filter_params = options[:filter_params] || []
+      @filter = Filter.for(
+        reject: options[:reject_params],
+        allow_only: options[:allow_only]
+      )
       @get_user_info = get_user_info
     end
 
@@ -25,7 +29,7 @@ module Readme
 
       response = Rack::Response.new(body, status, headers)
 
-      har = Har.new(env, response, start_time, end_time, @filter_params)
+      har = Har.new(env, response, start_time, end_time, @filter)
       user_info = @get_user_info.call(env)
       payload = Payload.new(har, user_info, development: @development)
 

--- a/packages/ruby/spec/readme/filter_spec.rb
+++ b/packages/ruby/spec/readme/filter_spec.rb
@@ -1,0 +1,59 @@
+require "readme/filter"
+
+RSpec.describe Filter do
+  describe ".for" do
+    it "returns RejectParams when only reject argument is given" do
+      result = Filter.for(reject: ["reject"])
+      expect(result).to be_an_instance_of Filter::RejectParams
+    end
+
+    it "returns AllowOnly when only allow_only argument is given" do
+      result = Filter.for(allow_only: ["keep"])
+      expect(result).to be_an_instance_of Filter::AllowOnly
+    end
+
+    it "returns None when neither arugment is given" do
+      result = Filter.for
+      expect(result).to be_an_instance_of Filter::None
+    end
+
+    it "raises if both arguments are given" do
+      expect {
+        Filter.for(reject: ["reject"], allow_only: ["keep"])
+      }.to raise_error(Filter::FilterArgsError)
+    end
+  end
+end
+
+RSpec.describe Filter::RejectParams do
+  describe "#filter" do
+    it "returns the given hash without the given filter values" do
+      hash = {"reject" => "rejected", "keep" => "kept"}
+      result = Filter::RejectParams.new(["reject"]).filter(hash)
+
+      expect(result.keys).to eq ["keep"]
+    end
+  end
+end
+
+RSpec.describe Filter::AllowOnly do
+  describe "#filter" do
+    it "returns the given hash with only the given filter values" do
+      hash = {"reject" => "rejected", "keep" => "kept"}
+      result = Filter::AllowOnly.new(["keep"]).filter(hash)
+
+      expect(result.keys).to eq ["keep"]
+    end
+  end
+end
+
+RSpec.describe Filter::None do
+  describe "#filter" do
+    it "returns the original hash" do
+      hash = {"reject" => "rejected", "keep" => "kept"}
+      result = Filter::None.new.filter(hash)
+
+      expect(result.keys).to match_array ["keep", "reject"]
+    end
+  end
+end

--- a/packages/ruby/spec/readme/har_collection_spec.rb
+++ b/packages/ruby/spec/readme/har_collection_spec.rb
@@ -1,0 +1,24 @@
+require "readme/har_collection"
+require "readme/filter"
+
+RSpec.describe Readme::HarCollection do
+  describe "#to_h" do
+    it "returns a hash with filtering applied" do
+      hash = {keep: "keep", reject: "reject"}
+      filter = double(filter: {keep: "kept"})
+      collection = Readme::HarCollection.new(filter, hash)
+
+      expect(collection.to_h).to eq({keep: "kept"})
+    end
+  end
+
+  describe "#to_a" do
+    it "returns an array with filtering applied" do
+      hash = {keep: "keep", reject: "reject"}
+      filter = double(filter: {keep: "kept"})
+      collection = Readme::HarCollection.new(filter, hash)
+
+      expect(collection.to_a).to eq([{name: :keep, value: "kept"}])
+    end
+  end
+end

--- a/packages/ruby/spec/readme/har_request_spec.rb
+++ b/packages/ruby/spec/readme/har_request_spec.rb
@@ -65,11 +65,11 @@ RSpec.describe Readme::HarRequest do
         },
         body: {key1: "key1", key2: "key2"}.to_json
       )
-      filter_params = ["Filtered-Header", "key1"]
-      request = Readme::HarRequest.new(http_request, filter_params)
+      reject_params = ["Filtered-Header", "key1"]
+      request = Readme::HarRequest.new(http_request, Filter.for(reject: reject_params))
       json = request.as_json
 
-      request_body = json.dig(:postData, :text)
+      request_body = JSON.parse(json.dig(:postData, :text))
       expect(request_body.keys).to_not include "key1"
       expect(request_body.keys).to include "key2"
 

--- a/packages/ruby/spec/readme/har_spec.rb
+++ b/packages/ruby/spec/readme/har_spec.rb
@@ -1,4 +1,5 @@
 require "readme/har"
+require "readme/filter"
 require "rack/lint"
 
 RSpec.describe Readme::Har do
@@ -30,7 +31,7 @@ RSpec.describe Readme::Har do
         Rack::Response.new(response_body, status_code, headers),
         start_time,
         end_time,
-        []
+        Filter::None.new
       )
       json = JSON.parse(har.to_json)
 
@@ -104,13 +105,13 @@ RSpec.describe Readme::Har do
         Rack::Response.new(response_body, status_code, headers),
         Time.now,
         Time.now + 1,
-        ["Filtered-Header", "key1"]
+        Filter.for(reject: ["Filtered-Header", "key1"])
       )
 
       json = JSON.parse(har.to_json)
 
       response = json.dig("log", "entries", 0, "response")
-      response_body = response["content"]["text"]
+      response_body = JSON.parse(response["content"]["text"])
       expect(response_body.keys).to_not include "key1"
       expect(response_body.keys).to include "key2"
 


### PR DESCRIPTION
## 🧰 What's being changed?

This commit expands the ability to users to specify a list of keys that should only be sent up to the metrics API. A new filter class was introduced to wrap the `filter_params` and new `allow_only` values and provide the appropriate filter function given the values.

A `HarCollection` wrapper class was also introduced that filters and formats the given hash.

## 🧪 Testing

Using the following curl command and sample app, we confirmed that the application will only send values matching the given list in the headers, query params and bodies. 

`curl 'http://localhost:9292/api/foo?id=1&name=joel' -H "X-Filtered: my custom header" -H "Content-Type: application/json" -X POST -d '{"key": "value", "dont_filter": "not filtered"}`

```ruby
$LOAD_PATH << File.expand_path("../../metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {}, ["Ok"]]
  end
end

map "/api" do
  options = {
    api_key: "YOUR_API_KEY",
    development: false,
    allow_only: ["dont_filter"]
  }
  use Readme::Metrics, options do |env|
    {id: "anthonym", label: "Anthony M.", email: "anthony@example.com"}
  end
  run ApiApp.new
end
```