### PR TITLE
Allow empty POST bodies

### DIFF
--- a/packages/ruby/lib/readme/har_request.rb
+++ b/packages/ruby/lib/readme/har_request.rb
@@ -15,16 +15,24 @@ module Readme
         httpVersion: @request.http_version,
         headers: HarCollection.new(@filter, @request.headers).to_a,
         cookies: HarCollection.new(@filter, @request.cookies).to_a,
-        postData: {
-          text: request_body,
-          mimeType: @request.content_type
-        },
+        postData: postData,
         headersSize: -1,
         bodySize: @request.content_length
-      }
+      }.compact
     end
 
     private
+
+    def postData
+      if @request.content_type.nil?
+        nil
+      else
+        {
+          text: request_body,
+          mimeType: @request.content_type
+        }
+      end
+    end
 
     def request_body
       parsed_body = JSON.parse(@request.body)

--- a/packages/ruby/spec/readme/har_request_spec.rb
+++ b/packages/ruby/spec/readme/har_request_spec.rb
@@ -69,6 +69,15 @@ RSpec.describe Readme::HarRequest do
       request_headers = json[:headers].map { |pair| pair[:name] }
       expect(request_headers).to_not include "Filtered-Header"
     end
+
+    it "builds proper body when there is no response body" do
+      http_request = build_http_request(content_type: nil, body: "")
+
+      request = Readme::HarRequest.new(http_request)
+      json = request.as_json
+
+      expect(json).not_to have_key(:postData)
+    end
   end
 
   # if overriding `url` to have query parameters make sure to also override

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -21,13 +21,19 @@ RSpec.describe Readme::Metrics do
     expect(response_with_middleware).to eq response_without_middleware
   end
 
-  it "posts request urls to Readme API" do
-    post "/api/foo"
-    post "/api/bar"
+  it "posts request urls to Readme API with a JSON body" do
+    header "Content-Type", "application/json"
+    post "/api/foo", {key: "value"}.to_json
 
     expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
       .with { |request| validate_json("readmeMetrics", request.body) }
-      .twice
+  end
+
+  it "posts request urls to Readme API without a body" do
+    post "/api/foo"
+
+    expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
+      .with { |request| validate_json("readmeMetrics", request.body) }
   end
 
   def app


### PR DESCRIPTION
## 🧰 What's being changed?

When a POST request has no body, don't include the `postBody` key in the
HAR payload. We distinguish between "no body" and empty
text/json/xml/whatever by checking for the presence of the
`Content-Type` header.

## 🧪 Testing

Create a sample API like:

```ruby
# config.ru
$LOAD_PATH << File.expand_path("../path/to/metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {"Content-Length" => "2"}, ["Ok"]]
  end
end

map "/api" do
  use Readme::Metrics, api_key: "YOUR_API_KEY" do
    { id: 1, label: "Joël", email: "user@example.com" }
  end
  run ApiApp.new
end
```

and boot it with:

```
rackup
```

Then make a cURL POST request without a body:

```
$ curl 'http://localhost:9292/api/foo'  -H 'Content-Length: 0' -X POST
```

The request should show up in the Readme.io dashboard