### PR TITLE
Batch API requests to ReadMe

### DIFF
--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -18,6 +18,13 @@ from the environment, or you may hardcode them.
 If you're using Warden-based authentication like Devise, you may fetch the
 current_user for a given request from the environment.
 
+### Batching requests
+
+By default, the middleware will batch requests to the ReadMe API in groups of
+10. For every 10 requests made to your application, the middleware will make a
+single request to ReadMe. If you wish to override this, provide a
+`buffer_length` option when configuring the middleware.
+
 ### Sensitive Data
 
 If you have sensitive data you'd like to prevent from being sent to the Metrics
@@ -40,7 +47,8 @@ require "readme/metrics"
 options = {
   api_key: "YOUR_API_KEY",
   development: false,
-  reject_params: ["not_included", "dont_send"]
+  reject_params: ["not_included", "dont_send"],
+  buffer_length: 5,
 }
 
 config.middleware.use Readme::Metrics, options do |env|

--- a/packages/ruby/lib/readme/payload.rb
+++ b/packages/ruby/lib/readme/payload.rb
@@ -7,14 +7,12 @@ module Readme
     end
 
     def to_json
-      [
-        {
-          group: @user_info,
-          clientIPAddress: "1.1.1.1",
-          development: @development,
-          request: JSON.parse(@har.to_json)
-        }
-      ].to_json
+      {
+        group: @user_info,
+        clientIPAddress: "1.1.1.1",
+        development: @development,
+        request: JSON.parse(@har.to_json)
+      }.to_json
     end
   end
 end

--- a/packages/ruby/lib/readme/request_queue.rb
+++ b/packages/ruby/lib/readme/request_queue.rb
@@ -1,0 +1,35 @@
+module Readme
+  class RequestQueue
+    attr_reader :queue
+
+    def initialize(buffer_length)
+      @queue = []
+      @buffer_length = buffer_length
+    end
+
+    def push(request)
+      @queue << request
+
+      if ready_to_send?
+        payloads = @queue.slice!(0, @buffer_length)
+
+        HTTParty.post(
+          Readme::Metrics::ENDPOINT,
+          basic_auth: {username: @api_key, password: ""},
+          headers: {"Content-Type" => "application/json"},
+          body: to_json(payloads)
+        )
+      end
+    end
+
+    private
+
+    def ready_to_send?
+      @queue.length >= @buffer_length
+    end
+
+    def to_json(payloads)
+      "[#{payloads.join(", ")}]"
+    end
+  end
+end

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -12,42 +12,71 @@ RSpec.describe Readme::Metrics do
     expect(Readme::Metrics::VERSION).not_to be nil
   end
 
-  it "doesn't modify the response" do
-    post "/"
+  context "without batching" do
+    it "doesn't modify the response" do
+      post "/"
 
-    response_without_middleware = noop_app.call(double)
-    response_with_middleware = mock_response_to_raw(last_response)
+      response_without_middleware = noop_app.call(double)
+      response_with_middleware = mock_response_to_raw(last_response)
 
-    expect(response_with_middleware).to eq response_without_middleware
-  end
+      expect(response_with_middleware).to eq response_without_middleware
+    end
 
-  it "posts request urls to Readme API with a JSON body" do
-    header "Content-Type", "application/json"
-    post "/api/foo", {key: "value"}.to_json
+    it "posts request urls to Readme API with a JSON body" do
+      header "Content-Type", "application/json"
+      post "/api/foo", {key: "value"}.to_json
 
-    expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
-      .with { |request| validate_json("readmeMetrics", request.body) }
-  end
+      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) }
+    end
 
-  it "posts request urls to Readme API without a body" do
-    post "/api/foo"
+    it "posts request urls to Readme API without a body" do
+      post "/api/foo"
 
-    expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
-      .with { |request| validate_json("readmeMetrics", request.body) }
-  end
+      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) }
+    end
 
-  def app
-    options = {api_key: "API KEY", development: true}
-    app = Readme::Metrics.new(noop_app, options) { |env|
-      {
-        id: env["CURRENT_USER"].id,
-        label: env["CURRENT_USER"].name,
-        email: env["CURRENT_USER"].email
+    def app
+      options = {api_key: "API KEY", development: true, buffer_length: 1}
+      app = Readme::Metrics.new(noop_app, options) { |env|
+        {
+          id: env["CURRENT_USER"].id,
+          label: env["CURRENT_USER"].name,
+          email: env["CURRENT_USER"].email
+        }
       }
-    }
-    app_with_http_version = SetHttpVersion.new(app)
-    app_with_current_user = SetCurrentUser.new(app_with_http_version)
-    app_with_current_user
+      app_with_http_version = SetHttpVersion.new(app)
+      app_with_current_user = SetCurrentUser.new(app_with_http_version)
+      app_with_current_user
+    end
+  end
+
+  context "with batching" do
+    it "batches requests to the Readme API" do
+      post "/api/foo"
+      post "/api/bar"
+      post "/api/baz"
+      post "/api/biz"
+
+      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) }
+        .twice
+    end
+
+    def app
+      options = {api_key: "API KEY", development: true, buffer_length: 2}
+      app = Readme::Metrics.new(noop_app, options) { |env|
+        {
+          id: env["CURRENT_USER"].id,
+          label: env["CURRENT_USER"].name,
+          email: env["CURRENT_USER"].email
+        }
+      }
+      app_with_http_version = SetHttpVersion.new(app)
+      app_with_current_user = SetCurrentUser.new(app_with_http_version)
+      app_with_current_user
+    end
   end
 
   def noop_app

--- a/packages/ruby/spec/readme/payload_spec.rb
+++ b/packages/ruby/spec/readme/payload_spec.rb
@@ -2,7 +2,7 @@ require "readme/payload"
 require "readme/har"
 
 RSpec.describe Readme::Payload do
-  it "returns JSON matching the readmeMetrics schema" do
+  it "returns JSON matching the payload schema" do
     har_json = File.read(File.expand_path("../../fixtures/har.json", __FILE__))
     har = double("har", to_json: har_json)
     result = Readme::Payload.new(
@@ -11,6 +11,6 @@ RSpec.describe Readme::Payload do
       development: true
     )
 
-    expect(result.to_json).to match_json_schema("readmeMetrics")
+    expect(result.to_json).to match_json_schema("payload")
   end
 end

--- a/packages/ruby/spec/readme/request_queue_spec.rb
+++ b/packages/ruby/spec/readme/request_queue_spec.rb
@@ -1,0 +1,47 @@
+require "readme/request_queue"
+require "webmock/rspec"
+
+RSpec.describe Readme::RequestQueue do
+  describe "#push" do
+    it "adds a value to the queue" do
+      queue = Readme::RequestQueue.new(10)
+      queue.push("value")
+      queue.push("other_value")
+
+      expect(queue.queue).to eq ["value", "other_value"]
+    end
+
+    it "does not send a request until the queue is long enough" do
+      stub_request(:post, Readme::Metrics::ENDPOINT)
+
+      queue = Readme::RequestQueue.new(2)
+      queue.push("value")
+
+      expect(WebMock).to_not have_requested(:post, Readme::Metrics::ENDPOINT)
+    end
+
+    context "when the queue is long enough to be sent" do
+      before do
+        stub_request(:post, Readme::Metrics::ENDPOINT)
+      end
+
+      it "sends a request" do
+        queue = Readme::RequestQueue.new(2)
+        queue.push("value")
+        queue.push("other_value")
+
+        expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
+          .with { |request| request.body == "[value, other_value]" }
+      end
+
+      it "pulls off the appropriate number of items from the queue" do
+        queue = Readme::RequestQueue.new(2)
+        queue.push("value")
+        queue.push("other_value")
+        queue.push("leftover")
+
+        expect(queue.queue).to eq ["leftover"]
+      end
+    end
+  end
+end

--- a/packages/ruby/spec/schema/payload.json
+++ b/packages/ruby/spec/schema/payload.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "group": {
+      "$ref": "readmeGroup.json#"
+    },
+    "clientIPAddress": {
+      "type": "string"
+    },
+    "development": {
+      "type": "boolean"
+    },
+    "request": {
+      "$ref": "har.json#"
+    }
+  },
+  "required": [
+    "group",
+    "clientIPAddress",
+    "development",
+    "request"
+  ]
+}


### PR DESCRIPTION
## 🧰 What's being changed?

This commit adds simple request batching behavior to the middleware.

Previously, each request made to an application using this middleware
would cause a new request to be sent to the ReadMe API. A new
`RequestQueue` object was introduced to collect requests and provide a
batched response to send out when ready.

The batch size can be controlled by the user using the `buffer_length`
option. It defaults to 10.


## 🧪 Testing

Both unit and integrations tests were added to cover the new functionality.

Using the following sample application and curl request, we confirmed that middleware appropriately batches the requests.

`curl 'http://localhost:9292/api/foo?id=1&name=joel' -H "X-Filtered: my custom header" -H "Content-Type: application/json" -X POST -d '{"key": "value", "dont_filter": "not filtered"}'`

```ruby
$LOAD_PATH << File.expand_path("../../metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {}, ["Ok"]]
  end
end

map "/api" do
  options = {
    api_key: "YOUR_API_KEY",
    development: false
  }
  use Readme::Metrics, options do |env|
    {id: "anthonym", label: "Anthony M.", email: "anthony@example.com"}
  end
  run ApiApp.new
end
```