### PR TITLE
Extract HAR body serializer

### DIFF
--- a/packages/ruby/lib/readme/har/response_serializer.rb
+++ b/packages/ruby/lib/readme/har/response_serializer.rb
@@ -1,0 +1,47 @@
+require "rack/utils"
+require "readme/har/collection"
+
+module Readme
+  module Har
+    class ResponseSerializer
+      def initialize(request, response, filter)
+        @request = request
+        @response = response
+        @filter = filter
+      end
+
+      def as_json
+        {
+          status: @response.status,
+          statusText: Rack::Utils::HTTP_STATUS_CODES[@response.status],
+          httpVersion: @request.http_version,
+          headers: Har::Collection.new(@filter, @response.headers).to_a,
+          content: {
+            text: response_body,
+            size: @response.content_length,
+            mimeType: @response.content_type
+          },
+          redirectURL: @response.location.to_s,
+          headersSize: -1,
+          bodySize: @response.content_length,
+          cookies: Har::Collection.new(@filter, @request.cookies).to_a
+        }
+      end
+
+      private
+
+      def response_body
+        if @response.content_type == "application/json"
+          begin
+            parsed_body = JSON.parse(@response.body.first)
+            Har::Collection.new(@filter, parsed_body).to_h.to_json
+          rescue
+            @response.body.each.reduce(:+)
+          end
+        else
+          @response.body.each.reduce(:+)
+        end
+      end
+    end
+  end
+end

--- a/packages/ruby/spec/fixtures/har_response.json
+++ b/packages/ruby/spec/fixtures/har_response.json
@@ -1,0 +1,20 @@
+{
+  "status": 200,
+  "statusText": "Ok",
+  "httpVersion": "HTTP 1.1",
+  "redirectURL": "",
+  "headersSize": 50,
+  "bodySize": 200,
+  "cookies": [],
+  "headers": [
+    {
+      "name": "Content-Length",
+      "value": "10"
+    }
+  ],
+  "content": {
+    "text": "[RESPONSE CONTENT]",
+    "size": 10,
+    "mimeType": "application/json"
+  }
+}

--- a/packages/ruby/spec/readme/har/response_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/response_serializer_spec.rb
@@ -1,0 +1,93 @@
+require "readme/har/response_serializer"
+require "readme/filter"
+
+RSpec.describe Readme::Har::ResponseSerializer do
+  describe "#as_json" do
+    it "creates a structure that is valid according the schema" do
+      request = build_request
+      response = build_response
+
+      serializer = Readme::Har::ResponseSerializer.new(request, response, Filter.for)
+      json = serializer.as_json
+
+      expect(json).to match_json_schema("response")
+    end
+
+    it "serializes values from the response, filtering cookies and headers" do
+      request = build_request(cookies: {"cookie1" => "value1", "reject" => "reject"})
+      response = build_response(
+        status: 200,
+        headers: {"X-Custom" => "custom", "reject" => "reject"},
+        location: nil,
+        body: StringIO.new("OK")
+      )
+
+      serializer = Readme::Har::ResponseSerializer.new(
+        request,
+        response,
+        Filter.for(reject: ["reject"])
+      )
+      json = serializer.as_json
+
+      expect(json[:status]).to eq 200
+      expect(json[:statusText]).to eq "OK"
+      expect(json[:httpVersion]).to eq request.http_version
+      expect(json[:headers]).to match_array(
+        [
+          {name: "X-Custom", value: "custom"}
+        ]
+      )
+      expect(json[:headersSize]).to eq(-1)
+      expect(json[:bodySize]).to eq response.content_length
+      expect(json[:redirectURL]).to eq ""
+      expect(json[:cookies]).to match_array(
+        [
+          {name: "cookie1", value: "value1"}
+        ]
+      )
+      expect(json.dig(:content, :text)).to eq "OK"
+      expect(json.dig(:content, :size)).to eq response.content_length
+      expect(json.dig(:content, :mimeType)).to eq response.content_type
+    end
+
+    it "filters JSON bodies" do
+      request = build_request
+      response = build_response(
+        content_type: "application/json",
+        body: StringIO.new({reject: "reject", keep: "keep"}.to_json)
+      )
+
+      serializer = Readme::Har::ResponseSerializer.new(
+        request,
+        response,
+        Filter.for(reject: ["reject"])
+      )
+      json = serializer.as_json
+
+      expect(json.dig(:content, :text)).to eq({keep: "keep"}.to_json)
+      expect(json.dig(:content, :size)).to eq response.content_length
+      expect(json.dig(:content, :mimeType)).to eq "application/json"
+    end
+  end
+
+  def build_request(overrides = {})
+    defaults = {
+      http_version: "HTTP/1.1",
+      cookies: {"default_cookie" => "default"}
+    }
+    double(:request, defaults.merge(overrides))
+  end
+
+  def build_response(overrides = {})
+    defaults = {
+      status: 200,
+      headers: {"X-Default" => "default"},
+      content_type: "text/plain",
+      content_length: 2,
+      location: nil,
+      body: StringIO.new("OK")
+    }
+
+    double(:response, defaults.merge(overrides))
+  end
+end

--- a/packages/ruby/spec/readme/har/serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/serializer_spec.rb
@@ -8,26 +8,23 @@ RSpec.describe Readme::Har::Serializer do
       har_request = double(:har_request, as_json: JSON.parse(request_json))
       allow(Readme::Har::RequestSerializer).to receive(:new).and_return(har_request)
 
+      response_json = File.read(File.expand_path("../../../fixtures/har_response.json", __FILE__))
+      har_response = double(:har_response, as_json: JSON.parse(response_json))
+      allow(Readme::Har::ResponseSerializer).to receive(:new).and_return(har_response)
+
       http_request = double(
         :http_request,
         cookies: {"cookie1" => "value1"},
         http_version: "HTTP/1.1"
       )
       allow(HttpRequest).to receive(:new).and_return(http_request)
-      env = double(:env)
 
-      status_code = 200
-      response_body = ["OK"]
-      headers = {
-        "Content-Type" => "application/json",
-        "Content-Length" => "2",
-        "Location" => "https://example.com"
-      }
+      env = double(:env)
       start_time = Time.now
       end_time = start_time + 1
       har = Readme::Har::Serializer.new(
         env,
-        Rack::Response.new(response_body, status_code, headers),
+        double(:rack_response),
         start_time,
         end_time,
         Filter::None.new
@@ -46,76 +43,6 @@ RSpec.describe Readme::Har::Serializer do
       expect(json.dig("log", "entries", 0, "timings", "wait")).to eq 1000
       expect(json.dig("log", "entries", 0, "startedDateTime")).to eq start_time.iso8601
       expect(json.dig("log", "entries", 0, "time")).to eq 1000
-
-      response = json.dig("log", "entries", 0, "response")
-
-      expect(response["status"]).to eq status_code
-      expect(response["statusText"]).to eq "OK"
-      expect(response["httpVersion"]).to eq http_request.http_version
-      expect(response["headers"]).to match_array(
-        [
-          {"name" => "Content-Type", "value" => "application/json"},
-          {"name" => "Content-Length", "value" => "2"},
-          {"name" => "Location", "value" => "https://example.com"}
-        ]
-      )
-      expect(response["headersSize"]).to eq(-1)
-      expect(response["bodySize"]).to eq 2
-      expect(response["redirectURL"]).to eq headers["Location"]
-      expect(response["cookies"]).to match_array(
-        [
-          {"name" => "cookie1", "value" => "value1"}
-        ]
-      )
-      expect(response["content"]["text"]).to eq "OK"
-      expect(response["content"]["size"]).to eq 2
-      expect(response["content"]["mimeType"]).to eq "application/json"
-    end
-
-    it "filters out headers and body keys" do
-      request_body = {key1: "key1", key2: "key2"}
-      env = {
-        "CONTENT_TYPE" => "application/json",
-        "CONTENT_LENGTH" => 0,
-        "HTTP_AUTHORIZATION" => "Basic abc123",
-        "HTTP_COOKIE" => "cookie1=value1; cookie2=value2",
-        "HTTP_VERSION" => "HTTP/1.1",
-        "HTTP_X_CUSTOM" => "custom",
-        "PATH_INFO" => "/foo/bar",
-        "REQUEST_METHOD" => "POST",
-        "SCRIPT_NAME" => "/api",
-        "QUERY_STRING" => "id=1&name=joel",
-        "SERVER_NAME" => "example.com",
-        "SERVER_PORT" => "443",
-        "rack.input" => Rack::Lint::InputWrapper.new(StringIO.new(request_body.to_json)),
-        "rack.url_scheme" => "https"
-      }
-      status_code = 200
-      response_body = {key1: "key1", key2: "key2"}.to_json
-      headers = {
-        "Content-Type" => "application/json",
-        "Content-Length" => "2",
-        "Location" => "https://example.com",
-        "Filtered-Header" => "filtered"
-      }
-
-      har = Readme::Har::Serializer.new(
-        env,
-        Rack::Response.new(response_body, status_code, headers),
-        Time.now,
-        Time.now + 1,
-        Filter.for(reject: ["Filtered-Header", "key1"])
-      )
-
-      json = JSON.parse(har.to_json)
-
-      response = json.dig("log", "entries", 0, "response")
-      response_body = JSON.parse(response["content"]["text"])
-      expect(response_body.keys).to_not include "key1"
-      expect(response_body.keys).to include "key2"
-
-      response_headers = response["headers"].map { |pair| pair["name"] }
-      expect(response_headers).to_not include "Filtered-Header"
     end
   end
 end


### PR DESCRIPTION
## 🧰 What's being changed?

We want to handle several variations of serialization with bodies for
HAR. Extracting an standalone object for this allows us to handle all
that logic in one place while making unit testing variants easy.

## 🧪 Testing

This is a pure refactor, with some added unit tests. No behavior changed here.
