### PR TITLE
Validate user info block configuration

### DIFF
--- a/packages/ruby/lib/readme/errors.rb
+++ b/packages/ruby/lib/readme/errors.rb
@@ -1,0 +1,33 @@
+module Readme
+  class Errors
+    API_KEY_ERROR = "Missing API Key"
+    REJECT_PARAMS_ERROR = "The `reject_params` option must be an array of strings"
+    ALLOW_ONLY_ERROR = "The `allow_only` option must be an array of strings"
+    BUFFER_LENGTH_ERROR = "The `buffer_length` must be an Integer"
+    DEVELOPMENT_ERROR = "The `development` option must be a boolean"
+
+    MISSING_BLOCK_ERROR = <<~MESSAGE
+      Missing block argument. You must provide a block when configuring the
+      middleware. The block must return a hash containing user info:
+        use Readme::Metrics, options do |env|
+          { id: "unique_id", label: "Your user label", email: "Your user email" }
+        end
+    MESSAGE
+
+    def self.bad_block_message(result)
+      <<~MESSAGE
+        The request could not be sent to Readme. Something went wrong when
+        setting user info. Double check the block configured on the ReadMe
+        middleware.
+
+        Expected a hash with the shape:
+          { id: "unique_id", label: "Your user label", email: "Your user email" }
+
+        Received value:
+          #{result}
+      MESSAGE
+    end
+
+    class ConfigurationError < StandardError; end
+  end
+end

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -80,12 +80,40 @@ RSpec.describe Readme::Metrics do
     end
   end
 
+  describe "block validation" do
+    it "raises when the block is missing" do
+      options = {api_key: "key"}
+      expect {
+        Readme::Metrics.new(noop_app, options)
+      }.to raise_error(
+        Readme::Errors::ConfigurationError,
+        Readme::Errors::MISSING_BLOCK_ERROR
+      )
+    end
+
+    context "when the block returns a malformed hash" do
+      def app
+        options = {api_key: "API KEY"}
+        Readme::Metrics.new(noop_app, options) { |env| {} }
+      end
+
+      it "logs an error" do
+        expect { post "/api/foo" }
+          .to output(Readme::Errors.bad_block_message({}))
+          .to_stdout
+      end
+    end
+  end
+
   describe "option validation" do
     it "raises when the API key is missing" do
       options = {}
       expect {
         Readme::Metrics.new(noop_app, options)
-      }.to raise_error(Readme::ConfigurationError, "Missing API Key")
+      }.to raise_error(
+        Readme::Errors::ConfigurationError,
+        Readme::Errors::API_KEY_ERROR
+      )
     end
 
     it "raises when the reject_params contains a non-string element" do
@@ -93,8 +121,8 @@ RSpec.describe Readme::Metrics do
       expect {
         Readme::Metrics.new(noop_app, options)
       }.to raise_error(
-        Readme::ConfigurationError,
-        "reject_params option must be an array of strings"
+        Readme::Errors::ConfigurationError,
+        Readme::Errors::REJECT_PARAMS_ERROR
       )
     end
 
@@ -103,8 +131,8 @@ RSpec.describe Readme::Metrics do
       expect {
         Readme::Metrics.new(noop_app, options)
       }.to raise_error(
-        Readme::ConfigurationError,
-        "allow_only option must be an array of strings"
+        Readme::Errors::ConfigurationError,
+        Readme::Errors::ALLOW_ONLY_ERROR
       )
     end
 
@@ -113,8 +141,8 @@ RSpec.describe Readme::Metrics do
       expect {
         Readme::Metrics.new(noop_app, options)
       }.to raise_error(
-        Readme::ConfigurationError,
-        "buffer_length must be an Integer"
+        Readme::Errors::ConfigurationError,
+        Readme::Errors::BUFFER_LENGTH_ERROR
       )
     end
 
@@ -123,8 +151,8 @@ RSpec.describe Readme::Metrics do
       expect {
         Readme::Metrics.new(noop_app, options)
       }.to raise_error(
-        Readme::ConfigurationError,
-        "development option must be a boolean"
+        Readme::Errors::ConfigurationError,
+        Readme::Errors::DEVELOPMENT_ERROR
       )
     end
   end


### PR DESCRIPTION
## 🧰 What's being changed?

This commit adds some validation around user info block required by the
middleware.

One check runs at application boot and ensures that the block is not
nil.

The other checks occur at run time and ensure that if the block is not
configured properly, the application will not crash and log an error
instead. The request to the Readme API will be aborted and the response
will be passed on through the rest of the middleware stack.

## 🧪 Testing

The new checks are covered by the automated test suite.

### Without a block configured:

```ruby
$LOAD_PATH << File.expand_path("../../metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {"Content-Length" => "2"}, ["Ok"]]
  end
end

map "/api" do
  options = {api_key: "API_KEY"}
  use Readme::Metrics, options
  run ApiApp.new
end

```

```
/Users/anthony/Projects/metrics-sdks/packages/ruby/lib/readme/metrics.rb:18:in `initialize': Missing block argument. You must provide a block when configuring the (Readme::Errors::ConfigurationError)
middleware. The block must return a hash containing user info:
  use Readme::Metrics, options do |env|
    { id: "unique_id", label: "Your user label", email: "Your user email" }
  end
```

### With an improperly configured block (missing label value)

```ruby
$LOAD_PATH << File.expand_path("../../metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {"Content-Length" => "2"}, ["Ok"]]
  end
end

map "/api" do
  options = {api_key: "api_key"}
  use Readme::Metrics, options do |env|
    {id: "anthonym", email: "anthony@example.com"}
  end
  run ApiApp.new
end
```

Running a request produces the following log and the request to the client returns a 200:
![Screen Shot 2020-08-19 at 4 15 39 PM](https://user-images.githubusercontent.com/11845816/90685087-44964980-e237-11ea-8412-9db9b3e4460f.png)


