### PR TITLE
Support multiple JSON mime types

### DIFF
--- a/packages/ruby/lib/readme/har/response_serializer.rb
+++ b/packages/ruby/lib/readme/har/response_serializer.rb
@@ -4,6 +4,8 @@ require "readme/har/collection"
 module Readme
   module Har
     class ResponseSerializer
+      JSON_MIME_TYPES = ["application/json", "application/x-json", "text/json", "text/x-json", "+json"]
+
       def initialize(request, response, filter)
         @request = request
         @response = response
@@ -29,7 +31,7 @@ module Readme
       def content
         if response_body.nil?
           empty_content
-        elsif @response.content_type == "application/json"
+        elsif content_type_is_json?
           json_content
         else
           pass_through_content
@@ -43,7 +45,7 @@ module Readme
       def json_content
         parsed_body = JSON.parse(response_body)
 
-        {mimeType: "application/json",
+        {mimeType: @response.content_type,
          size: @response.content_length,
          text: Har::Collection.new(@filter, parsed_body).to_h.to_json}
       rescue
@@ -68,6 +70,10 @@ module Readme
         else
           @response.body.each.reduce(:+)
         end
+      end
+
+      def content_type_is_json?
+        JSON_MIME_TYPES.include? @response.content_type
       end
     end
   end

--- a/packages/ruby/spec/readme/har/response_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/response_serializer_spec.rb
@@ -103,6 +103,35 @@ RSpec.describe Readme::Har::ResponseSerializer do
       expect(json.dig(:content, :size)).to eq 0
       expect(json.dig(:content, :mimeType)).to eq ""
     end
+
+    it "handles multiple JSON mime types" do
+      json_mime_types = [
+        "application/json",
+        "application/x-json",
+        "text/json",
+        "text/x-json",
+        "+json"
+      ]
+      request = build_request
+      body = [{result: "value"}.to_json]
+
+      json_mime_types.each do |mime_type|
+        response = build_response(
+          status: 200,
+          content_type: mime_type,
+          body: body
+        )
+        serializer = Readme::Har::ResponseSerializer.new(
+          request,
+          response,
+          Filter.for
+        )
+        json = serializer.as_json
+
+        expect(json[:content][:text]).to eq body.first
+        expect(json[:content][:mimeType]).to eq mime_type
+      end
+    end
   end
 
   def build_request(overrides = {})


### PR DESCRIPTION
## 🧰 What's being changed?

This commit expands the content type check in the
Har::ResponseSerializer to accept multiple JSON mime types.

## 🧪 Testing

Using the following sample application:

```ruby
$LOAD_PATH << File.expand_path("../../metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [
      200,
      {"Content-Length" => "20", "Content-Type" => "application/x-json"},
      [{response: "value"}.to_json]
    ]
  end
end

map "/api" do
  options = {
    api_key: "api_key",
    buffer_length: 1
  }
  use Readme::Metrics, options do |env|
    {id: "anthonym", label: "Anthony M.", email: "anthony@example.com"}
  end
  run ApiApp.new
end
```

And the following curl command:

`curl 'http://username:password@localhost:9292/api/foo' -X POST`

A request was successfully added to the metrics dashboard with a newly added json mime type.

![Screen Shot 2020-08-20 at 11 10 38 AM](https://user-images.githubusercontent.com/11845816/90791050-c1c4cb80-e2d6-11ea-83ed-a13b1c4f87dd.png)

Automated test coverage was also expanded