### PR TITLE
Add support for form data

### DIFF
--- a/packages/ruby/lib/http_request.rb
+++ b/packages/ruby/lib/http_request.rb
@@ -37,6 +37,10 @@ class HttpRequest
     @request.content_type
   end
 
+  def form_data?
+    @request.form_data?
+  end
+
   def content_length
     @request.content_length.to_i
   end
@@ -55,6 +59,10 @@ class HttpRequest
     @request.body.rewind
 
     content
+  end
+
+  def parsed_form_data
+    @request.POST
   end
 
   private

--- a/packages/ruby/lib/readme/har/request_serializer.rb
+++ b/packages/ruby/lib/readme/har/request_serializer.rb
@@ -28,12 +28,21 @@ module Readme
       def postData
         if @request.content_type.nil?
           nil
+        elsif @request.form_data?
+          {
+            params: form_encoded_body,
+            mimeType: @request.content_type
+          }
         else
           {
             text: request_body,
             mimeType: @request.content_type
           }
         end
+      end
+
+      def form_encoded_body
+        Har::Collection.new(@filter, @request.parsed_form_data).to_a
       end
 
       def request_body

--- a/packages/ruby/spec/http_request_spec.rb
+++ b/packages/ruby/spec/http_request_spec.rb
@@ -93,6 +93,27 @@ RSpec.describe HttpRequest do
     end
   end
 
+  describe "#form_data?" do
+    it "is true for `application/x-www-form-urlencoded`" do
+      request = HttpRequest.new(
+        "CONTENT_TYPE" => "application/x-www-form-urlencoded"
+      )
+
+      expect(request).to be_form_data
+    end
+
+    it "is true for `multipart/form-data`" do
+      request = HttpRequest.new("CONTENT_TYPE" => "multipart/form-data")
+
+      expect(request).to be_form_data
+    end
+    it "is false for other MIME types" do
+      request = HttpRequest.new("CONTENT_TYPE" => "application/json")
+
+      expect(request).not_to be_form_data
+    end
+  end
+
   describe "#content_length" do
     it "gets the the value from the Rack CONTENT_LENGTH key" do
       request = HttpRequest.new("CONTENT_LENGTH" => "256")
@@ -141,6 +162,19 @@ RSpec.describe HttpRequest do
 
       expect(request.body).to eq "[BODY]"
       expect(request.body).to eq "[BODY]"
+    end
+  end
+
+  describe "#parsed_form_data" do
+    it "returns the parsed form-encoded body as a hash" do
+      env = {
+        "CONTENT_TYPE" => "application/x-www-form-urlencoded",
+        "rack.input" => Rack::Lint::InputWrapper.new(StringIO.new("first=1&second=2"))
+      }
+
+      request = HttpRequest.new(env)
+
+      expect(request.parsed_form_data).to eq({"first" => "1", "second" => "2"})
     end
   end
 end

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe Readme::Metrics do
         .with { |request| validate_json("readmeMetrics", request.body) }
     end
 
+    it "submits to the Readme API for POST requests with a url encoded body" do
+      post "/api/foo", {key: "value"}
+
+      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) }
+    end
+
     it "submits to the Readme API for POST requests with no body" do
       post "/api/foo"
 


### PR DESCRIPTION
## 🧰 What's being changed?

According to HAR, data submitted with `multipart/form-data` or
`application/x-www-form-urlencoded` MIME types should be formatted as
key-value pairs under a `request.postData.params` key rather than the
`request.postData.text` key we use for other request types like JSON.

Additionally, we want to parse the data and filter out keys based on the
user's preferences.

## 🧪 Testing

Create a sample Rack app like:

```ruby
# config.ru

$LOAD_PATH << File.expand_path("../path/to/metrics-sdks/packages/ruby/lib", __FILE__)
require "readme/metrics"

class ApiApp
  def call(env)
    [200, {"Content-Length" => "2"}, ["Ok"]]
  end
end

map "/api" do
  use Readme::Metrics, reject_params: ["reject"], buffer_length: 1, api_key: "YOUR_KEY_HERE" do
    { id: 1, label: "Joël", email: "user@example.com" }
  end
  run ApiApp.new
end
```

run it via:

```
$ rackup
```

and make a cURL request to it:

```
$ curl 'http://localhost:9292/api/foo' -X POST -d "reject=1&id=2&num=3"
```

Expect to see the request show up in the Readme dashboard with individual parameters. Also expect that the rejected parameter is filtered out.

![ReadMe 2020-08-20 15-08-17](https://user-images.githubusercontent.com/1006966/90814409-1415e480-e2f7-11ea-818a-cf52faaf73b9.jpg)

Contrast this with the way JSON requests come through as a single `-d` flag in the generated cURL command:

![ReadMe 2020-08-20 15-09-43](https://user-images.githubusercontent.com/1006966/90814512-390a5780-e2f7-11ea-972e-f1bc15d11610.jpg)
