### PR TITLE
Perform API request to ReadMe in a new thread

### DIFF
--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -48,7 +48,6 @@ module Readme
 
       if user_info_invalid?(user_info)
         Readme::Metrics.logger.error Errors.bad_block_message(user_info)
-        return [status, headers, body]
       else
         payload = Payload.new(har, user_info, development: @development)
         @@request_queue.push(payload.to_json)

--- a/packages/ruby/lib/readme/request_queue.rb
+++ b/packages/ruby/lib/readme/request_queue.rb
@@ -15,12 +15,14 @@ module Readme
 
       if ready_to_send?
         payloads = @queue.slice!(0, @buffer_length)
-        HTTParty.post(
-          Readme::Metrics::ENDPOINT,
-          basic_auth: {username: @api_key, password: ""},
-          headers: {"Content-Type" => "application/json"},
-          body: to_json(payloads)
-        )
+        Thread.new do
+          HTTParty.post(
+            Readme::Metrics::ENDPOINT,
+            basic_auth: {username: @api_key, password: ""},
+            headers: {"Content-Type" => "application/json"},
+            body: to_json(payloads)
+          )
+        end
       end
     end
 

--- a/packages/ruby/spec/readme/request_queue_spec.rb
+++ b/packages/ruby/spec/readme/request_queue_spec.rb
@@ -2,6 +2,10 @@ require "readme/request_queue"
 require "webmock/rspec"
 
 RSpec.describe Readme::RequestQueue do
+  before do
+    allow(Thread).to receive(:new).and_yield
+  end
+
   describe "#push" do
     it "adds a value to the queue" do
       queue = Readme::RequestQueue.new("key", 10)


### PR DESCRIPTION
## 🧰 What's being changed?

This commit updates the behavior of the middleware to perform
non-blocking requests to the ReadMe API. When the request queue is full,
the request to ReadMe is performed in a new thread. The application's
response is passed through straight away.

In tests that make API requests, we had to stub the `Thread` class to ensure tests are run
synchronously and deterministically.

## 🧪 Testing

On Mac OS you can install the Network Link Conditioner to simulate slow network conditions:
https://developer.apple.com/download/more/?name=network%20link

1. Throttle network speed
2. Boot up a rack app with metrics middleware configured
3. Make some requests to the middleware
4. The rack app should response instantly despite the slow network
5. The request to readme should take some time to complete due to slow network conditions
