### PR TITLE
Don't send request on OPTIONS

### DIFF
--- a/packages/ruby/lib/http_request.rb
+++ b/packages/ruby/lib/http_request.rb
@@ -45,6 +45,10 @@ class HttpRequest
     @request.content_length.to_i
   end
 
+  def options?
+    @request.request_method == "OPTIONS"
+  end
+
   def headers
     @request
       .each_header

--- a/packages/ruby/lib/readme/har/serializer.rb
+++ b/packages/ruby/lib/readme/har/serializer.rb
@@ -1,5 +1,4 @@
 require "rack"
-require "http_request"
 require "readme/metrics"
 require "readme/har/request_serializer"
 require "readme/har/response_serializer"
@@ -10,8 +9,8 @@ module Readme
     class Serializer
       HAR_VERSION = "1.2"
 
-      def initialize(env, response, start_time, end_time, filter)
-        @http_request = HttpRequest.new(env)
+      def initialize(request, response, start_time, end_time, filter)
+        @http_request = request
         @response = response
         @start_time = start_time
         @end_time = end_time

--- a/packages/ruby/spec/http_request_spec.rb
+++ b/packages/ruby/spec/http_request_spec.rb
@@ -177,4 +177,22 @@ RSpec.describe HttpRequest do
       expect(request.parsed_form_data).to eq({"first" => "1", "second" => "2"})
     end
   end
+
+  describe "#options" do
+    it "returns true for an OPTIONS request" do
+      env = {"REQUEST_METHOD" => "OPTIONS"}
+
+      request = HttpRequest.new(env)
+
+      expect(request).to be_options
+    end
+
+    it "returns false for non-OPTIONS requests" do
+      env = {"REQUEST_METHOD" => "POST"}
+
+      request = HttpRequest.new(env)
+
+      expect(request).to_not be_options
+    end
+  end
 end

--- a/packages/ruby/spec/readme/har/serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/serializer_spec.rb
@@ -17,13 +17,10 @@ RSpec.describe Readme::Har::Serializer do
         cookies: {"cookie1" => "value1"},
         http_version: "HTTP/1.1"
       )
-      allow(HttpRequest).to receive(:new).and_return(http_request)
-
-      env = double(:env)
       start_time = Time.now
       end_time = start_time + 1
       har = Readme::Har::Serializer.new(
-        env,
+        http_request,
         double(:rack_response),
         start_time,
         end_time,

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -138,6 +138,13 @@ RSpec.describe Readme::Metrics do
       expect(last_response.status).to eq 200
     end
 
+    it "doesn't send a request to Readme with an OPTIONS request" do
+      options "api/foo"
+
+      expect(WebMock).to_not have_requested(:post, Readme::Metrics::ENDPOINT)
+      expect(last_response.status).to eq 200
+    end
+
     def app
       options = {api_key: "API KEY", development: true, buffer_length: 1}
       app = Readme::Metrics.new(noop_app, options) { |env|


### PR DESCRIPTION
## 🧰 What's being changed?

This commit updates the behavior of the middleware to skip processing
OPTIONS requests.

## 🧪 Testing

A new test was added to the test suite to ensure a request is not made to the ReadMe API. This was also tested manually using a rack application and this curl command:

`curl -i -X OPTIONS localhost:9292/api`

No corresponding item shows up in the dashboard.