### PR TITLE
Provide default values when Content-Length is absent

### DIFF
--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -47,7 +47,7 @@ You may only specify either `reject_params` or `allow_only` keys, not both.
 ### Rails
 
 ```ruby
-# application.rb
+# config/environments/development.rb or config/environments/production.rb
 require "readme/metrics"
 
 options = {
@@ -100,5 +100,3 @@ end
 ## License
 
 [View our license here](https://github.com/readmeio/metrics-sdks/tree/master/packages/ruby/LICENSE)
-
-

--- a/packages/ruby/lib/http_response.rb
+++ b/packages/ruby/lib/http_response.rb
@@ -1,3 +1,4 @@
+require "rack"
 require "rack/response"
 require "content_type_helper"
 
@@ -6,5 +7,37 @@ class HttpResponse < SimpleDelegator
 
   def self.from_parts(status, headers, body)
     new(Rack::Response.new(body, status, headers))
+  end
+
+  def body
+    if raw_body.respond_to?(:rewind)
+      raw_body.rewind
+      content = raw_body.each.reduce("", :+)
+      raw_body.rewind
+
+      content
+    else
+      raw_body.each.reduce("", :+)
+    end
+  end
+
+  def content_length
+    if empty_body_status?
+      0
+    elsif !headers["Content-Length"]
+      body.bytesize
+    else
+      headers["Content-Length"].to_i
+    end
+  end
+
+  private
+
+  def raw_body
+    __getobj__.body
+  end
+
+  def empty_body_status?
+    Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i)
   end
 end

--- a/packages/ruby/lib/readme/har/response_serializer.rb
+++ b/packages/ruby/lib/readme/har/response_serializer.rb
@@ -27,7 +27,7 @@ module Readme
       private
 
       def content
-        if response_body.nil?
+        if @response.body.empty?
           empty_content
         elsif @response.json?
           json_content
@@ -41,33 +41,23 @@ module Readme
       end
 
       def json_content
-        parsed_body = JSON.parse(response_body)
+        parsed_body = JSON.parse(@response.body)
 
-        {mimeType: @response.content_type,
-         size: @response.content_length,
-         text: Har::Collection.new(@filter, parsed_body).to_h.to_json}
+        {
+          mimeType: @response.content_type,
+          size: @response.content_length,
+          text: Har::Collection.new(@filter, parsed_body).to_h.to_json
+        }
       rescue
         pass_through_content
       end
 
       def pass_through_content
-        {mimeType: @response.content_type,
-         size: @response.content_length,
-         text: response_body}
-      end
-
-      def response_body
-        if @response.body.nil?
-          nil
-        elsif @response.body.respond_to?(:rewind)
-          @response.body.rewind
-          body = @response.body.each.reduce(:+)
-          @response.body.rewind
-
-          body
-        else
-          @response.body.each.reduce(:+)
-        end
+        {
+          mimeType: @response.content_type,
+          size: @response.content_length,
+          text: @response.body
+        }
       end
     end
   end

--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -41,9 +41,9 @@ module Readme
       start_time = Time.now
       status, headers, body = @app.call(env)
       end_time = Time.now
-      response = HttpResponse.from_parts(status, headers, body)
 
       begin
+        response = HttpResponse.from_parts(status, headers, body)
         process_response(
           response: response,
           env: env,

--- a/packages/ruby/spec/http_response_spec.rb
+++ b/packages/ruby/spec/http_response_spec.rb
@@ -1,0 +1,67 @@
+require "http_response"
+
+RSpec.describe HttpResponse do
+  describe "#body" do
+    it "returns an empty string when the body is nil" do
+      response = HttpResponse.from_parts(200, {}, nil)
+
+      expect(response.body).to eq ""
+    end
+
+    it "returns an empty string when the body is an empty array" do
+      response = HttpResponse.from_parts(200, {}, [])
+
+      expect(response.body).to eq ""
+    end
+
+    it "concatenates the body when it is an array of strings" do
+      response = HttpResponse.from_parts(200, {}, ["body1", "body2"])
+
+      expect(response.body).to eq "body1body2"
+    end
+
+    it "concatenates the body when it is StringIO" do
+      body = "BODY"
+      response = HttpResponse.from_parts(200, {}, StringIO.new(body))
+
+      expect(response.body).to eq body
+    end
+
+    it "can be read safely multiple times" do
+      body = "BODY"
+      response = HttpResponse.from_parts(200, {}, StringIO.new(body))
+
+      expect(response.body).to eq body
+      expect(response.body).to eq body
+    end
+  end
+
+  describe "#content_length" do
+    it "returns 0 for a response with an empty body status" do
+      response = HttpResponse.from_parts(
+        204,
+        {"Content-Length" => 53},
+        StringIO.new("BODY")
+      )
+
+      expect(response.content_length).to eq 0
+    end
+
+    it "returns the body's bytesize when Content-Length header is missing" do
+      body = "BODY"
+      response = HttpResponse.from_parts(200, {}, StringIO.new(body))
+
+      expect(response.content_length).to eq body.bytesize
+    end
+
+    it "returns the the value of the Content-Length header when present" do
+      response = HttpResponse.from_parts(
+        200,
+        {"Content-Length" => 53},
+        StringIO.new("BODY")
+      )
+
+      expect(response.content_length).to eq 53
+    end
+  end
+end

--- a/packages/ruby/spec/readme/har/response_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/response_serializer_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       response = build_response(
         status: 200,
         headers: {"X-Custom" => "custom", "reject" => "reject"},
-        location: nil,
-        body: StringIO.new("OK")
+        location: nil
       )
 
       serializer = Readme::Har::ResponseSerializer.new(
@@ -55,7 +54,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       response = build_response(
         content_type: "application/json",
         json?: true,
-        body: StringIO.new({reject: "reject", keep: "keep"}.to_json)
+        body: {reject: "reject", keep: "keep"}.to_json
       )
 
       serializer = Readme::Har::ResponseSerializer.new(
@@ -75,7 +74,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       response = build_response(
         content_type: "application/json",
         json?: true,
-        body: StringIO.new("NOT JSON")
+        body: "NOT JSON"
       )
 
       serializer = Readme::Har::ResponseSerializer.new(
@@ -92,7 +91,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
 
     it "handles responses without a body" do
       request = build_request
-      response = build_response(status: 204, content_type: nil, body: nil)
+      response = build_response(status: 204, content_type: nil, body: "")
 
       serializer = Readme::Har::ResponseSerializer.new(
         request,
@@ -123,7 +122,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       json?: false,
       content_length: 2,
       location: nil,
-      body: StringIO.new("OK")
+      body: "OK"
     }
 
     double(:response, defaults.merge(overrides))


### PR DESCRIPTION
## 🧰 What's being changed?

The Content-Length header is not included by default starting in Rails
5. This commit adds some new functionality to the HttpResponse class
so that we can calculate the content length if the header is not present.

Commit that removes the middleware: https://github.com/rails/rails/commit/56903585a099ab67a7acfaaef0a02db8fe80c450

## 🧪 Testing

Automated tests were added to cover this new behavior.
