### PR TITLE
Don't submit non-filterable bodies

### DIFF
--- a/packages/ruby/lib/content_type_helper.rb
+++ b/packages/ruby/lib/content_type_helper.rb
@@ -1,0 +1,15 @@
+module ContentTypeHelper
+  # Assumes the includer has a `content_type` method defined.
+
+  JSON_MIME_TYPES = [
+    "application/json",
+    "application/x-json",
+    "text/json",
+    "text/x-json",
+    "+json"
+  ]
+
+  def json?
+    JSON_MIME_TYPES.include? content_type
+  end
+end

--- a/packages/ruby/lib/http_request.rb
+++ b/packages/ruby/lib/http_request.rb
@@ -1,7 +1,10 @@
 require "rack"
 require "rack/request"
+require "content_type_helper"
 
 class HttpRequest
+  include ContentTypeHelper
+
   HTTP_NON_HEADERS = [
     Rack::HTTP_COOKIE,
     Rack::HTTP_VERSION,

--- a/packages/ruby/lib/http_response.rb
+++ b/packages/ruby/lib/http_response.rb
@@ -1,0 +1,10 @@
+require "rack/response"
+require "content_type_helper"
+
+class HttpResponse < SimpleDelegator
+  include ContentTypeHelper
+
+  def self.from_parts(status, headers, body)
+    new(Rack::Response.new(body, status, headers))
+  end
+end

--- a/packages/ruby/lib/readme/filter.rb
+++ b/packages/ruby/lib/readme/filter.rb
@@ -19,6 +19,10 @@ class Filter
     def filter(hash)
       hash.select { |key, _value| @filter_values.include?(key) }
     end
+
+    def pass_through?
+      false
+    end
   end
 
   class RejectParams
@@ -29,11 +33,19 @@ class Filter
     def filter(hash)
       hash.reject { |key, _value| @filter_values.include?(key) }
     end
+
+    def pass_through?
+      false
+    end
   end
 
   class None
     def filter(hash)
       hash
+    end
+
+    def pass_through?
+      true
     end
   end
 

--- a/packages/ruby/lib/readme/har/response_serializer.rb
+++ b/packages/ruby/lib/readme/har/response_serializer.rb
@@ -4,8 +4,6 @@ require "readme/har/collection"
 module Readme
   module Har
     class ResponseSerializer
-      JSON_MIME_TYPES = ["application/json", "application/x-json", "text/json", "text/x-json", "+json"]
-
       def initialize(request, response, filter)
         @request = request
         @response = response
@@ -31,7 +29,7 @@ module Readme
       def content
         if response_body.nil?
           empty_content
-        elsif content_type_is_json?
+        elsif @response.json?
           json_content
         else
           pass_through_content
@@ -70,10 +68,6 @@ module Readme
         else
           @response.body.each.reduce(:+)
         end
-      end
-
-      def content_type_is_json?
-        JSON_MIME_TYPES.include? @response.content_type
       end
     end
   end

--- a/packages/ruby/spec/content_type_helper_spec.rb
+++ b/packages/ruby/spec/content_type_helper_spec.rb
@@ -1,0 +1,28 @@
+require "content_type_helper"
+
+RSpec.describe ContentTypeHelper do
+  describe "#json?" do
+    it "is true for all various JSON types" do
+      ContentTypeHelper::JSON_MIME_TYPES.each do |mime|
+        request = FakeRequest.new(mime)
+        expect(request).to be_json
+      end
+    end
+
+    it "is false for non-json types" do
+      request = FakeRequest.new("text/plain")
+
+      expect(request).not_to be_json
+    end
+  end
+
+  class FakeRequest
+    include ContentTypeHelper
+
+    attr_reader :content_type
+
+    def initialize(content_type)
+      @content_type = content_type
+    end
+  end
+end

--- a/packages/ruby/spec/readme/filter_spec.rb
+++ b/packages/ruby/spec/readme/filter_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Filter::RejectParams do
       expect(result.keys).to eq ["keep"]
     end
   end
+
+  describe "#pass_through?" do
+    it "is false" do
+      filter = Filter::RejectParams.new([])
+
+      expect(filter).not_to be_pass_through
+    end
+  end
 end
 
 RSpec.describe Filter::AllowOnly do
@@ -45,6 +53,14 @@ RSpec.describe Filter::AllowOnly do
       expect(result.keys).to eq ["keep"]
     end
   end
+
+  describe "#pass_through?" do
+    it "is false" do
+      filter = Filter::AllowOnly.new([])
+
+      expect(filter).not_to be_pass_through
+    end
+  end
 end
 
 RSpec.describe Filter::None do
@@ -54,6 +70,14 @@ RSpec.describe Filter::None do
       result = Filter::None.new.filter(hash)
 
       expect(result.keys).to match_array ["keep", "reject"]
+    end
+  end
+
+  describe "#pass_through?" do
+    it "is true" do
+      filter = Filter::None.new
+
+      expect(filter).to be_pass_through
     end
   end
 end

--- a/packages/ruby/spec/readme/har/response_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/response_serializer_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       request = build_request
       response = build_response(
         content_type: "application/json",
+        json?: true,
         body: StringIO.new({reject: "reject", keep: "keep"}.to_json)
       )
 
@@ -73,6 +74,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       request = build_request
       response = build_response(
         content_type: "application/json",
+        json?: true,
         body: StringIO.new("NOT JSON")
       )
 
@@ -103,35 +105,6 @@ RSpec.describe Readme::Har::ResponseSerializer do
       expect(json.dig(:content, :size)).to eq 0
       expect(json.dig(:content, :mimeType)).to eq ""
     end
-
-    it "handles multiple JSON mime types" do
-      json_mime_types = [
-        "application/json",
-        "application/x-json",
-        "text/json",
-        "text/x-json",
-        "+json"
-      ]
-      request = build_request
-      body = [{result: "value"}.to_json]
-
-      json_mime_types.each do |mime_type|
-        response = build_response(
-          status: 200,
-          content_type: mime_type,
-          body: body
-        )
-        serializer = Readme::Har::ResponseSerializer.new(
-          request,
-          response,
-          Filter.for
-        )
-        json = serializer.as_json
-
-        expect(json[:content][:text]).to eq body.first
-        expect(json[:content][:mimeType]).to eq mime_type
-      end
-    end
   end
 
   def build_request(overrides = {})
@@ -147,6 +120,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       status: 200,
       headers: {"X-Default" => "default"},
       content_type: "text/plain",
+      json?: false,
       content_length: 2,
       location: nil,
       body: StringIO.new("OK")


### PR DESCRIPTION
## 🧰 What's being changed?

When given `allow_only` or `reject` parameters, we want to make sure
that the request and response bodies are properly filtered. In order to
do that, we need to be able to parse them. Currently we only support
parsing JSON and form-encoded bodies. If bodies come in as other content
types _and_ a filter is configured, we should not submit the request to
the Readme API because it might contain sensitive data.

If no filter is set, it is safe to just pass-through any bodies to the
Readme API regardless of content type.

Testing this behavior was rather annoying as I had to create new
instances of both app and middleware for each test in order to get
custom response bodies and middleware configurations desired. To make
this nicer I ended up creating a bunch of testing helpers. I also
created two test app classes based on content returned: `JsonApp` and
`TextApp`.

The checking we do around content-types has to happen for both the
request and the response so I pulled it out into a mixin that can be
included into both. Also, as part of this I created an `HttpResponse`
class that decorates `Rack::Request` and includes the mixin.

## 🧪 Testing

Create a simple rack app that returns text/plain content and has a reject or allow-only parameter set. When you make a request to it, you should see an error in the logs:

![Monosnap 2020-08-27 10-49-18](https://user-images.githubusercontent.com/1006966/91458362-6f922600-e853-11ea-80d3-5165ba9f7b72.jpg)

Try various combinations of `reject_params`, `allow_only`, text response bodies, and text request bodies.