### PR TITLE
Don't pass-through requests that fail to parse

### DIFF
--- a/packages/ruby/lib/readme/har/request_serializer.rb
+++ b/packages/ruby/lib/readme/har/request_serializer.rb
@@ -46,9 +46,21 @@ module Readme
       end
 
       def request_body
+        if @filter.pass_through?
+          pass_through_body
+        else
+          # Only JSON allowed for non-pass-through situations. It will raise
+          # if the body can't be parsed as JSON, aborting the request.
+          json_body
+        end
+      end
+
+      def json_body
         parsed_body = JSON.parse(@request.body)
         Har::Collection.new(@filter, parsed_body).to_h.to_json
-      rescue
+      end
+
+      def pass_through_body
         @request.body
       end
     end

--- a/packages/ruby/spec/readme/har/request_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/request_serializer_spec.rb
@@ -93,6 +93,26 @@ RSpec.describe Readme::Har::RequestSerializer do
           {name: "other", value: "2"}]
       )
     end
+
+    context "when the content type is wrong" do
+      it "does a pass-through if no filter is set" do
+        http_request = build_http_request(json?: true, body: "not json")
+        filter = double(:filter, pass_through?: true, filter: [])
+        serializer = Readme::Har::RequestSerializer.new(http_request, filter)
+
+        json = serializer.as_json
+
+        expect(json.dig(:postData, :text)).to eq http_request.body
+      end
+
+      it "raises if there is a filter set" do
+        http_request = build_http_request(json?: true, body: "not json")
+        filter = double(:filter, pass_through?: false, filter: [])
+        serializer = Readme::Har::RequestSerializer.new(http_request, filter)
+
+        expect { serializer.as_json }.to raise_error(JSON::ParserError)
+      end
+    end
   end
 
   # if overriding `url` to have query parameters make sure to also override


### PR DESCRIPTION
## 🧰 What's being changed?

While `Metrics` checks that requests have the right content-type for the
filters in place, it is possible for requests to lie about their
content.

If the filter is a "pass-through", then we don't care about the
content type. In fact, we don't want to parse it even if it is JSON
because we'd just be turning it back into a string.

On the other hand, if we can't successfully parse JSON for a
non-"pass-through" filter, we let it raise. The most likely thing that
has happened is that either the request has lied about it having JSON
content or the JSON being submitted is malformed. Either way, this is
catastrophic as we have no way of filtering out sensitive parameters.

`Metrics` has a top-level rescue that will catch this error and cleanly
abort the attempt to log the request to Readme.io.

## 🧪 Testing

To test manually, create a local app with the middleware configured with an allow/reject list. Make a request to it using a content-type of `application/json` and a body that is not valid JSON.

```
curl 'http://localhost:9292/api/foo' -X POST -d "not json" -H 'Content-Type: application/json'
```

expect the request not to get logged to Readme

Additionally, you can try with an app where the middleware **doesn't** have an allow/reject list configured. In that case, the bad JSON request _should_ get submitted to Readme since we don't need to parse it.
