### PR TITLE
Log an error if we abort the request to ReadMe

### DIFF
--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -50,7 +50,8 @@ module Readme
           start_time: start_time,
           end_time: end_time
         )
-      rescue
+      rescue => e
+        Readme::Metrics.logger.warn "The following error occured when trying to log to the ReadMe metrics API: #{e.message}. Request not logged."
         [status, headers, body]
       end
 


### PR DESCRIPTION
## 🧰 What's being changed?

When something goes wrong in the middleware, we rescue and just return
to the next middleware in the chain.

This commit adds some logging in that case so that users can better
understand why some requests aren't being submitted to the ReadMe API.
This might be due to a bug in this middleware (in which case this error
will allow users to create better bug reports), or it might be due to a
malformed body (in which case surfacing that to the user is helpful).

## 🧪 Testing

Create a rack app and set up the readme middleware with an allow/reject parameter config. Then make a request that has a content type of `application/json` but whose body is not JSON:

```
curl 'http://localhost:9292/api/foo' -X POST -d "not json" -H 'Content-Type: application/json'
```

Check your logs, you should see an error informing you why the request was not logged to ReadMe:

![Monosnap 2020-08-27 15-48-34](https://user-images.githubusercontent.com/1006966/91488144-d841c880-e87c-11ea-8ad0-c49b6104d38c.jpg)

