### PR TITLE
fix: updating the php sdk to support guzzle 7

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,7 +19,7 @@ jobs:
           - laravel: 7.*
           - laravel: 6.*
 
-    name: build (${{ matrix.php }} w/ Laravel ${{ matrix.laravel }}  @${{ matrix.dependency-version }})
+    name: build (${{ matrix.php }} w/ Laravel ${{ matrix.laravel }} @${{ matrix.dependency-version }})
 
     steps:
       - uses: actions/checkout@v2.3.1
@@ -28,7 +28,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}--php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,14 +13,13 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.2, 7.3, 7.4]
-        guzzle: [6.*, 7.*]
         laravel: [6.*, 7.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 7.*
           - laravel: 6.*
 
-    name: build (${{ matrix.php }} w/ Laravel ${{ matrix.laravel }} and Guzzle ${{ matrix.guzzle }} @${{ matrix.dependency-version }})
+    name: build (${{ matrix.php }} w/ Laravel ${{ matrix.laravel }}  @${{ matrix.dependency-version }})
 
     steps:
       - uses: actions/checkout@v2.3.1
@@ -29,7 +28,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}-guzzle-${{ matrix.guzzle }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          key: dependencies-laravel-${{ matrix.laravel }}--php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -39,7 +38,6 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-          composer require "guzzlehttp/guzzle:${{ matrix.guzzle }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Check code standards

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,13 +13,14 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.2, 7.3, 7.4]
+        guzzle: [6.*, 7.*]
         laravel: [6.*, 7.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 7.*
           - laravel: 6.*
 
-    name: build (${{ matrix.php }} w/ Laravel ${{ matrix.laravel }} @${{ matrix.dependency-version }})
+    name: build (${{ matrix.php }} w/ Laravel ${{ matrix.laravel }} and Guzzle ${{ matrix.guzzle }} @${{ matrix.dependency-version }})
 
     steps:
       - uses: actions/checkout@v2.3.1
@@ -28,7 +29,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          key: dependencies-laravel-${{ matrix.laravel }}-guzzle-${{ matrix.guzzle }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -38,6 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer require "guzzlehttp/guzzle:${{ matrix.guzzle }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Check code standards

--- a/packages/php/composer.json
+++ b/packages/php/composer.json
@@ -17,7 +17,7 @@
     "php": "^7.2",
     "illuminate/http": "^6.8 | ^7.0",
     "illuminate/support": "^6.8 | ^7.0",
-    "guzzlehttp/guzzle": "^6.4",
+    "guzzlehttp/guzzle": "^6.4 | ^7.0",
     "ocramius/package-versions": "^1.4",
     "ramsey/uuid": "^3.7 | ^4.0",
     "composer/composer": "^1.10"
@@ -26,7 +26,7 @@
     "phpunit/phpunit": "^8.5",
     "squizlabs/php_codesniffer": "^3.5",
     "mockery/mockery": "^1.3",
-    "vimeo/psalm": "^3.12"
+    "vimeo/psalm": "^3.14"
   },
   "extra": {
     "laravel": {
@@ -53,7 +53,8 @@
   },
   "autoload": {
     "psr-4": {
-      "ReadMe\\": "src/"
+      "ReadMe\\": "src/",
+      "ReadMe\\Tests\\Fixtures\\": "tests/fixtures"
     }
   },
   "autoload-dev": {

--- a/packages/php/composer.json
+++ b/packages/php/composer.json
@@ -17,10 +17,10 @@
     "php": "^7.2",
     "illuminate/http": "^6.8 | ^7.0",
     "illuminate/support": "^6.8 | ^7.0",
-    "guzzlehttp/guzzle": "^6.4 | ^7.0",
     "ocramius/package-versions": "^1.4",
     "ramsey/uuid": "^3.7 | ^4.0",
-    "composer/composer": "^1.10"
+    "composer/composer": "^1.10",
+    "guzzlehttp/guzzle": "^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",

--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -102,6 +102,7 @@ class Metrics
             'timeout' => $curl_timeout,
         ]);
 
+        /** @psalm-suppress DeprecatedClass */
         $this->package_version = Versions::getVersion(self::PACKAGE_NAME);
         $this->cache_dir = Factory::createConfig()->get('cache-dir');
 

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -4,7 +4,6 @@ namespace ReadMe\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Middleware;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -244,7 +244,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         // Exceptions **should** be thrown under development mode!
         if ($development_mode) {
             $this->expectException(ServerException::class);
-            $this->expectExceptionMessageMatches('/(500 Internal Server Error)/');
+            $this->expectExceptionMessageMatches('/500 Internal Server Error/');
         }
 
         $handlers = $this->getMockHandlers(
@@ -703,7 +703,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
     public function testProjectBaseUrlFailsInDevelopmentModeIfItCantTalkToReadMe(): void
     {
         $this->expectException(MetricsException::class);
-        $this->expectExceptionMessageMatches('/(500 Internal Server Error)/');
+        $this->expectExceptionMessageMatches('/500 Internal Server Error/');
 
         $handlers = $this->getMockHandlers(
             new \GuzzleHttp\Psr7\Response(200),

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -244,7 +244,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         // Exceptions **should** be thrown under development mode!
         if ($development_mode) {
             $this->expectException(ServerException::class);
-            $this->expectExceptionMessageMatches('/(Server error: 500|500 Internal Server Error)/');
+            $this->expectExceptionMessageMatches('/(500 Internal Server Error)/');
         }
 
         $handlers = $this->getMockHandlers(
@@ -703,7 +703,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
     public function testProjectBaseUrlFailsInDevelopmentModeIfItCantTalkToReadMe(): void
     {
         $this->expectException(MetricsException::class);
-        $this->expectExceptionMessageMatches('/(Server error: 500|500 Internal Server Error)/');
+        $this->expectExceptionMessageMatches('/(500 Internal Server Error)/');
 
         $handlers = $this->getMockHandlers(
             new \GuzzleHttp\Psr7\Response(200),

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -244,7 +244,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         // Exceptions **should** be thrown under development mode!
         if ($development_mode) {
             $this->expectException(ServerException::class);
-            $this->expectExceptionMessageMatches('/500 Internal Server Error/');
+            $this->expectExceptionMessageMatches('/(Server error: 500|500 Internal Server Error)/');
         }
 
         $handlers = $this->getMockHandlers(

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -703,7 +703,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
     public function testProjectBaseUrlFailsInDevelopmentModeIfItCantTalkToReadMe(): void
     {
         $this->expectException(MetricsException::class);
-        $this->expectExceptionMessageMatches('/500 Internal Server Error/');
+        $this->expectExceptionMessageMatches('/(Server error: 500|500 Internal Server Error)/');
 
         $handlers = $this->getMockHandlers(
             new \GuzzleHttp\Psr7\Response(200),


### PR DESCRIPTION
## 🧰 What's being changed?

Updates the PHP SDK to be able to support Guzzle 7, dropping Guzzle 6 in the process.