### PR TITLE
Submit empty bodies even with filters

### DIFF
--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -86,11 +86,11 @@ module Readme
     end
 
     def parseable_response?(response)
-      response.json?
+      response.body.empty? || response.json?
     end
 
     def parseable_request?(request)
-      request.json? || request.form_data?
+      request.body.empty? || request.json? || request.form_data?
     end
 
     def validate_options(options)


### PR DESCRIPTION
## 🧰 What's being changed?

If the request or response body is empty, we don't  need to filter it so
it's OK do do a pass-through regardless of the content-type.


## 🧪 Testing

Create a rack app that returns an empty body, configure it with a reject parameter, and try to make a request to it. Expect to see the request show up in the Readme dashboard.
