### PR TITLE
Filter parameters case-insensitively

### DIFF
--- a/packages/ruby/lib/readme/filter.rb
+++ b/packages/ruby/lib/readme/filter.rb
@@ -13,11 +13,11 @@ class Filter
 
   class AllowOnly
     def initialize(filter_values)
-      @filter_values = filter_values
+      @filter_values = filter_values.map(&:downcase)
     end
 
     def filter(hash)
-      hash.select { |key, _value| @filter_values.include?(key) }
+      hash.select { |key, _value| @filter_values.include?(key.downcase) }
     end
 
     def pass_through?
@@ -27,11 +27,11 @@ class Filter
 
   class RejectParams
     def initialize(filter_values)
-      @filter_values = filter_values
+      @filter_values = filter_values.map(&:downcase)
     end
 
     def filter(hash)
-      hash.reject { |key, _value| @filter_values.include?(key) }
+      hash.reject { |key, _value| @filter_values.include?(key.downcase) }
     end
 
     def pass_through?

--- a/packages/ruby/spec/readme/filter_spec.rb
+++ b/packages/ruby/spec/readme/filter_spec.rb
@@ -28,10 +28,10 @@ end
 RSpec.describe Filter::RejectParams do
   describe "#filter" do
     it "returns the given hash without the given filter values" do
-      hash = {"reject" => "rejected", "keep" => "kept"}
+      hash = {"reject" => "rejected", "REJECT" => "rejected", "keep" => "kept"}
       result = Filter::RejectParams.new(["reject"]).filter(hash)
 
-      expect(result.keys).to eq ["keep"]
+      expect(result.keys).to match_array(["keep"])
     end
   end
 
@@ -47,10 +47,10 @@ end
 RSpec.describe Filter::AllowOnly do
   describe "#filter" do
     it "returns the given hash with only the given filter values" do
-      hash = {"reject" => "rejected", "keep" => "kept"}
+      hash = {"reject" => "rejected", "keep" => "kept", "KEEP" => "kept"}
       result = Filter::AllowOnly.new(["keep"]).filter(hash)
 
-      expect(result.keys).to eq ["keep"]
+      expect(result.keys).to match_array(["keep", "KEEP"])
     end
   end
 


### PR DESCRIPTION
## 🧰 What's being changed?

HTTP headers are not case-sensitive so they might show up differently
that the user expected when setting up allow-only or reject parameters.
If a user configures `reject_params: ["authorization"]`, we want to
reject the HTTP `Authorization` header no matter what case it comes in
as.

## 🧪 Testing

Configure a rack app with `reject_params: ["authorization"]`, then make a request to the app with an `Authorization` header. Expect to see the request show up in the Readme dashboard without the header.

```
curl http://localhost:9292/api/foo -H 'Authorization: Basic U2luYXRyYSBVc2VyOkFQSV9LRVk='
```

![ReadMe 2020-08-28 17-30-42](https://user-images.githubusercontent.com/1006966/91616733-4d340180-e954-11ea-8443-f25ec2cc17df.jpg)

