### PR TITLE
Send content-type and content-length to Readme

### DIFF
--- a/packages/ruby/lib/http_request.rb
+++ b/packages/ruby/lib/http_request.rb
@@ -58,6 +58,7 @@ class HttpRequest
       .select { |key, _| http_header?(key) }
       .to_h
       .transform_keys { |header| normalize_header_name(header) }
+      .merge unprefixed_headers
   end
 
   def body
@@ -87,5 +88,12 @@ class HttpRequest
   # `"HTTP_CONTENT_TYPE" => "application/json"`.
   def normalize_header_name(header)
     header.delete_prefix("HTTP_").split("_").map(&:capitalize).join("-")
+  end
+
+  # These special headers are explicitly _not_ prefixed with HTTP_ in the Rack
+  # env so we need to add them in manually
+  def unprefixed_headers
+    {"Content-Type" => @request.content_type,
+     "Content-Length" => @request.content_length}.compact
   end
 end

--- a/packages/ruby/spec/http_request_spec.rb
+++ b/packages/ruby/spec/http_request_spec.rb
@@ -129,18 +129,25 @@ RSpec.describe HttpRequest do
   end
 
   describe "#headers" do
-    it "is the normalized Rack HTTP_ keys minus a few non-header ones" do
+    it "is the normalized Rack HTTP_ keys minus a few non-header ones plus content type and length" do
       env = {
         "HTTP_COOKIE" => "cookie1=value1; cookie2=value2",
         "HTTP_VERSION" => "HTTP/1.1",
         "HTTP_X_CUSTOM" => "custom",
         "HTTP_ACCEPT" => "text/plain",
         "HTTP_PORT" => "8080",
-        "HTTP_HOST" => "example.com"
+        "HTTP_HOST" => "example.com",
+        "CONTENT_TYPE" => "application/json",
+        "CONTENT_LENGTH" => "10"
       }
       request = HttpRequest.new(env)
 
-      expect(request.headers).to eq({"X-Custom" => "custom", "Accept" => "text/plain"})
+      expect(request.headers).to eq(
+        {"X-Custom" => "custom",
+         "Accept" => "text/plain",
+         "Content-Type" => "application/json",
+         "Content-Length" => "10"}
+      )
     end
   end
 


### PR DESCRIPTION
## 🧰 What's being changed?

Previously, we were submitting all the Rack env values prefixed with
`HTTP_` as headers to the Readme API. However, per the [Rack
spec](https://github.com/rack/rack/blob/master/SPEC.rdoc),
`CONTENT_TYPE` and `CONTENT_LENGTH` should not be prefixed with `HTTP_`
so we were missing out on them.

> The environment must not contain the keys HTTP_CONTENT_TYPE or
HTTP_CONTENT_LENGTH (use the versions without HTTP_).

This commit manually adds those headers into our list of headers.

## 🧪 Testing

Make a request to a configured Rack app and expect to see the content-length and content-type headers show up in Readme dashboard.
