### PR TITLE
fix(python): add fallback in case content-length isn't available

### DIFF
--- a/packages/python/readme_metrics/MetricsMiddleware.py
+++ b/packages/python/readme_metrics/MetricsMiddleware.py
@@ -65,7 +65,11 @@ class MetricsMiddleware:
                 #
                 # For more info: https://stackoverflow.com/a/13106009/643951
 
-                content_length = int(environ.get("CONTENT_LENGTH", 0))
+                # the environment variable CONTENT_LENGTH may be empty or missing
+                try:
+                    content_length = int(environ.get('CONTENT_LENGTH', 0))
+                except (ValueError):
+                    content_length = 0
                 content_body = environ["wsgi.input"].read(content_length)
 
                 environ["wsgi.input"].close()

--- a/packages/python/readme_metrics/MetricsMiddleware.py
+++ b/packages/python/readme_metrics/MetricsMiddleware.py
@@ -65,7 +65,7 @@ class MetricsMiddleware:
                 #
                 # For more info: https://stackoverflow.com/a/13106009/643951
 
-                content_length = int(environ["CONTENT_LENGTH"])
+                content_length = int(environ.get("CONTENT_LENGTH", 0))
                 content_body = environ["wsgi.input"].read(content_length)
 
                 environ["wsgi.input"].close()

--- a/packages/python/readme_metrics/MetricsMiddleware.py
+++ b/packages/python/readme_metrics/MetricsMiddleware.py
@@ -67,7 +67,7 @@ class MetricsMiddleware:
 
                 # the environment variable CONTENT_LENGTH may be empty or missing
                 try:
-                    content_length = int(environ.get('CONTENT_LENGTH', 0))
+                    content_length = int(environ.get("CONTENT_LENGTH", 0))
                 except (ValueError):
                     content_length = 0
                 content_body = environ["wsgi.input"].read(content_length)


### PR DESCRIPTION
## 🧰 What's being changed?

When creating a test app with https://github.com/readmeio/flask-metrics-example, I ran into this error:
```
Traceback (most recent call last):
  File "~/flask-starter/venv/lib/python3.7/site-packages/readme_metrics/MetricsMiddleware.py", line 68, in __call__
    content_length = int(environ["CONTENT_LENGTH"])
KeyError: 'CONTENT_LENGTH'
```

Per [PEP 3333 definition](https://www.python.org/dev/peps/pep-3333/#id4:~:text=The%20contents%20of%20any%20Content%2DLength%20fields%20in%20the%20HTTP%20request.%20May%20be%20empty%20or%20absent) of `CONTENT_LENGTH`:
> The contents of any `Content-Length` fields in the HTTP request. May be empty or absent.


### TODO
- [ ] Tests

## 🧪 Testing

Set up https://github.com/readmeio/flask-metrics-example and observe the error.
