### PR TITLE
Fix: add back fields for package name and metrics api prefix

### DIFF
--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -15,6 +15,8 @@ class Metrics:
     This is the internal central controller classinvoked by the WSGI middleware. It
     handles the creation, queueing, and submission of the requests.
     """
+    PACKAGE_NAME: str = 'readme/metrics'
+    METRICS_API: str = 'https://metrics.readme.io'
 
     def __init__(self, config: MetricsApiConfig):
         """

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -15,8 +15,9 @@ class Metrics:
     This is the internal central controller classinvoked by the WSGI middleware. It
     handles the creation, queueing, and submission of the requests.
     """
-    PACKAGE_NAME: str = 'readme/metrics'
-    METRICS_API: str = 'https://metrics.readme.io'
+
+    PACKAGE_NAME: str = "readme/metrics"
+    METRICS_API: str = "https://metrics.readme.io"
 
     def __init__(self, config: MetricsApiConfig):
         """

--- a/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
+++ b/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
@@ -11,6 +11,8 @@ from readme_metrics.Metrics import Metrics
 # for this, I'm not exactly sure how to test the __call__ function
 # possible options I considered was making a mock server inside this test case
 # connected to the middleware somehow
+
+
 class MockServer:
     def __init__(self):
         # Not working when I tried the first time, but might as well write it
@@ -45,6 +47,7 @@ def mockMiddlewareConfig():
         lambda req: {"id": "123", "label": "testuser", "email": "user@email.com"},
         buffer_length=1,
     )
+
 
 # Verify that metrics has fields for metrics API and package name
 assert Metrics.METRICS_API != None

--- a/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
+++ b/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
@@ -6,6 +6,7 @@ from .fixtures import Environ
 
 from readme_metrics import MetricsApiConfig
 from readme_metrics import MetricsMiddleware
+from readme_metrics.Metrics import Metrics
 
 # for this, I'm not exactly sure how to test the __call__ function
 # possible options I considered was making a mock server inside this test case
@@ -45,6 +46,9 @@ def mockMiddlewareConfig():
         buffer_length=1,
     )
 
+# Verify that metrics has fields for metrics API and package name
+assert Metrics.METRICS_API != None
+assert Metrics.PACKAGE_NAME != None
 
 # Mock callback for handling middleware response
 class MetricsCoreMock:


### PR DESCRIPTION
## 🧰 What's being changed?
- Required fields appear to have been erroneously removed in [#53](https://github.com/readmeio/metrics-sdks/pull/53). This PR adds back those values.

## 🧪 Testing
- Added unit tests to ensure the fields are present 
