### PR TITLE
Add an option to use res in payload

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -20,7 +20,7 @@ Just add the middleware to [Express](https://expressjs.com/), and that's it!
 ```javascript
 const readme = require('readmeio');
 
-app.use(readme.metrics('<<apiKey>>', req => ({
+app.use(readme.metrics('<<apiKey>>', (req, res) => ({
   id: req.<userId>,
   label: req.<userNameToShowInDashboard>,
   email: req.<userEmailAddress>,

--- a/packages/node/lib/construct-payload.js
+++ b/packages/node/lib/construct-payload.js
@@ -5,7 +5,7 @@ const { name, version } = require('../package.json');
 
 module.exports = (req, res, group, options = {}, { logId, startedDateTime }) => ({
   _id: logId,
-  group: group(req),
+  group: group(req, res),
   clientIPAddress: req.ip,
   development: options.development,
   request: {


### PR DESCRIPTION
implements readmeio/metrics-sdks#154

## 🧰 What's being changed?

https://github.com/readmeio/metrics-sdks/issues/154
Provide access to the response object so that information could be set from `res.locals` or anything else stored in the response.

## 🧪 Testing

There were no existing tests for the group options. All other tests are running okay.
