### PR TITLE
feat: implementing request timeouts in the node sdk

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -61,7 +61,8 @@ app.use(readme.metrics('', req => ({
 | bufferLength | **default: 10** By default, we only send logs to ReadMe after 10 requests are made. Depending on the usage of your API it make make sense to send logs more or less frequently |
 | blacklist | **optional** An array of keys from your API requests and responses headers and bodies that you wish to blacklist from sending to ReadMe.<br /><br />If you configure a blacklist, it will override any whitelist configuration. |
 | whitelist | **optional** An array of keys from your API requests and responses headers and bodies that you only wish to send to ReadMe. |
-| baseLogUrl | **optional** This is the base URL for your ReadMe project. Normally this would be `https://projectName.readme.io` or `https://docs.yourdomain.com`, however if this value is not supplied, a request to the ReadMe API will be made once a day to retrieve it. This data is cached into `node_modules/.cache/readmeio`.
+| baseLogUrl | **optional** This is the base URL for your ReadMe project. Normally this would be `https://projectName.readme.io` or `https://docs.yourdomain.com`, however if this value is not supplied, a request to the ReadMe API will be made once a day to retrieve it. This data is cached into `node_modules/.cache/readmeio`. |
+| timeout | **optional** The amount of milliseconds to wait for a ReadMe Metrics call to complete. Default is 2000ms. |
 
 ### Limitations
 - Currently only supports JSON request bodies. Adding a whitelist/blacklist for non-JSON bodies will not work (unless they're added to `req.body`) the same way that `body-parser` does it. The properties will be passed into [`postData`](http://www.softwareishard.com/blog/har-12-spec/#postData) as a `params` array.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -57,12 +57,11 @@ app.use(readme.metrics('', req => ({
 
 | Option | Use |
 | :--- | :--- |
-| development | **default: false** If true, the log will be separate from normal production logs. This is great for separating staging or test data from data coming from customers |
-| bufferLength | **default: 10** By default, we only send logs to ReadMe after 10 requests are made. Depending on the usage of your API it make make sense to send logs more or less frequently |
+| development | **default: false** If true, the log will be separate from normal production logs. This is great for separating staging or test data from data coming from customers. |
+| bufferLength | **default: 10** By default, we only send logs to ReadMe after 10 requests are made. Depending on the usage of your API it make make sense to send logs more or less frequently. |
 | blacklist | **optional** An array of keys from your API requests and responses headers and bodies that you wish to blacklist from sending to ReadMe.<br /><br />If you configure a blacklist, it will override any whitelist configuration. |
 | whitelist | **optional** An array of keys from your API requests and responses headers and bodies that you only wish to send to ReadMe. |
 | baseLogUrl | **optional** This is the base URL for your ReadMe project. Normally this would be `https://projectName.readme.io` or `https://docs.yourdomain.com`, however if this value is not supplied, a request to the ReadMe API will be made once a day to retrieve it. This data is cached into `node_modules/.cache/readmeio`. |
-| timeout | **optional** The amount of milliseconds to wait for a ReadMe Metrics call to complete. Default is 2000ms. |
 
 ### Limitations
 - Currently only supports JSON request bodies. Adding a whitelist/blacklist for non-JSON bodies will not work (unless they're added to `req.body`) the same way that `body-parser` does it. The properties will be passed into [`postData`](http://www.softwareishard.com/blog/har-12-spec/#postData) as a `params` array.

--- a/packages/node/__tests__/index.test.js
+++ b/packages/node/__tests__/index.test.js
@@ -161,32 +161,7 @@ describe('#metrics', () => {
   });
 
   describe('#timeout', () => {
-    it.only('should silently fail metrics requests if they take longer than the timeout', () => {
-      const apiMock = getReadMeApiMock(1);
-      const mock = nock(config.host, {
-        reqheaders: {
-          'Content-Type': 'application/json',
-          'User-Agent': `${pkg.name}/${pkg.version}`,
-        },
-      })
-        .post('/v1/request')
-        .basicAuth({ user: apiKey })
-        .delay(500)
-        .reply(200);
-
-      const app = express();
-      app.use(middleware.metrics(apiKey, () => group, { timeout: 100 }));
-      app.get('/test', (req, res) => res.sendStatus(200));
-
-      return request(app)
-        .get('/test')
-        .expect(200)
-        // .expect(res => expect(res).toHaveDocumentationHeader())
-        .then(() => {
-          apiMock.done();
-          mock.done();
-        });
-    });
+    it.todo('should silently fail metrics requests if they take longer than the timeout');
 
     it.todo('should silently fail baseLogUrl requests if they take longer than the timeout');
   });

--- a/packages/node/config/default.json
+++ b/packages/node/config/default.json
@@ -1,5 +1,6 @@
 {
   "host": "https://metrics.readme.io",
   "readmeApiUrl": "https://dash.readme.io/api",
-  "bufferLength": 1
+  "bufferLength": 1,
+  "timeout": 2000
 }

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -97,7 +97,7 @@ module.exports.metrics = (apiKey, group, options = {}) => {
   if (!group) throw new Error('You must provide a grouping function');
 
   const bufferLength = options.bufferLength || config.bufferLength;
-  const requestTimeout = options.timeout || config.timeout;
+  const requestTimeout = config.timeout;
   const encodedApiKey = Buffer.from(`${apiKey}:`).toString('base64');
   let baseLogUrl = options.baseLogUrl || undefined;
   let queue = [];

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1983,6 +1983,14 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -4291,6 +4299,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -9388,6 +9401,14 @@
       "dev": true,
       "requires": {
         "readable-stream": "3"
+      }
+    },
+    "timeout-signal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-1.1.0.tgz",
+      "integrity": "sha512-fuWY4tM1njcHCiOB7XkTmP0EOxzBkPbuQwPN+ZCzM6G0Tj4fMVgEffG/OPgiNUX48o+FhQEa2Oh4qjEDBCy5WQ==",
+      "requires": {
+        "abort-controller": "^3.0.0"
       }
     },
     "tmpl": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -25,6 +25,7 @@
     "flat-cache": "^3.0.4",
     "lodash": "^4.17.15",
     "node-fetch": "^2.6.0",
+    "timeout-signal": "^1.1.0",
     "uuid": "^8.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🧰 What's being changed?

This implements request timeouts in the Node SDK.

## 🧪 Testing

Due to some issues with [nock](https://www.npmjs.com/package/nock) `.delay()` not delaying responses as expected, this work is currently untested. The `timeout-signal` approach used here has been verified to be functional though with this code:

```js
const timeoutSignal = require("timeout-signal");
const fetch = require("node-fetch");
fetch('https://httpbin.org/delay/4', { signal: timeoutSignal(3000) }).then((response) => {
  console.log(response.status);      
}).catch(error => {
  if (error.message === "The user aborted a request.") {
    console.log('Request timed out!');
  }
})
```

Once the unified testing framework (https://github.com/readmeio/metrics-sdks/pull/90) is merged in, I'll revisit properly testing this work.