### PR TITLE
ci: disable dependabot on ruby and python deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,17 +22,17 @@ updates:
       prefix: chore(deps)
       prefix-development: chore(deps-dev)
 
-  - package-ecosystem: bundler
-    directory: "/packages/ruby"
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
-    labels:
-      - scope:dependency
-      - area:ruby
-    commit-message:
-      prefix: chore(deps)
-      prefix-development: chore(deps-dev)
+#   - package-ecosystem: bundler
+#     directory: "/packages/ruby"
+#     schedule:
+#       interval: monthly
+#     open-pull-requests-limit: 10
+#     labels:
+#       - scope:dependency
+#       - area:ruby
+#     commit-message:
+#       prefix: chore(deps)
+#       prefix-development: chore(deps-dev)
 
   - package-ecosystem: composer
     directory: "/packages/php"
@@ -46,14 +46,14 @@ updates:
       prefix: chore(deps)
       prefix-development: chore(deps-dev)
 
-  - package-ecosystem: pip
-    directory: "/packages/python"
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
-    labels:
-      - scope:dependency
-      - area:python
-    commit-message:
-      prefix: chore(deps)
-      prefix-development: chore(deps-dev)
+#   - package-ecosystem: pip
+#     directory: "/packages/python"
+#     schedule:
+#       interval: monthly
+#     open-pull-requests-limit: 10
+#     labels:
+#       - scope:dependency
+#       - area:python
+#     commit-message:
+#       prefix: chore(deps)
+#       prefix-development: chore(deps-dev)


### PR DESCRIPTION
## 🧰 What's being changed?

Disabling Dependabot updates on Ruby and Python deps for now until we have someone on the team that can manage those libraries. Right now I've been flying blind on them.
