### PR TITLE
feat(node): send a redacted string rather than omitting values

### DIFF
--- a/packages/node/__tests__/lib/construct-payload.test.js
+++ b/packages/node/__tests__/lib/construct-payload.test.js
@@ -64,7 +64,10 @@ describe('constructPayload()', () => {
         expect(isValidUUIDV4(body._id)).toBe(true);
         expect(typeof body.request.log.entries[0].request).toBe('object');
         expect(typeof body.request.log.entries[0].response).toBe('object');
-        expect(body.request.log.entries[0].request.postData).toStrictEqual({});
+        expect(body.request.log.entries[0].request.postData).toStrictEqual({
+          mimeType: 'application/json',
+          text: '{"password":"[REDACTED 6]"}',
+        });
       });
   });
 

--- a/packages/node/__tests__/lib/process-request.test.js
+++ b/packages/node/__tests__/lib/process-request.test.js
@@ -32,9 +32,11 @@ describe('processRequest()', () => {
 
         return request(app)
           .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
+          .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
+            expect(body.postData.text).toBe(
+              '{"password":"[REDACTED 6]","apiKey":"[REDACTED 3]","another":"Hello world"}'
+            );
           });
       });
 
@@ -43,9 +45,9 @@ describe('processRequest()', () => {
 
         return request(app)
           .post('/')
-          .send({ a: { b: { c: 1 } } })
+          .send({ a: { b: { c: {} } } })
           .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"a":{"b":{}}}');
+            expect(body.postData.text).toBe('{"a":{"b":{"c":"[REDACTED]"}}}');
           });
       });
 
@@ -54,9 +56,9 @@ describe('processRequest()', () => {
 
         return request(app)
           .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
+          .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"password":"123456","apiKey":"abcdef"}');
+            expect(body.postData.text).toBe('{"password":"123456","apiKey":"abc","another":"[REDACTED 11]"}');
           });
       });
 
@@ -67,7 +69,7 @@ describe('processRequest()', () => {
           .post('/')
           .send({ a: { b: { c: 1 } }, d: 2 })
           .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"a":{"b":{"c":1}}}');
+            expect(body.postData.text).toBe('{"a":{"b":{"c":1}},"d":"[REDACTED]"}');
           });
       });
 
@@ -76,9 +78,11 @@ describe('processRequest()', () => {
 
         return request(app)
           .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
+          .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
+            expect(body.postData.text).toBe(
+              '{"password":"[REDACTED 6]","apiKey":"[REDACTED 3]","another":"Hello world"}'
+            );
           });
       });
     });
@@ -91,10 +95,15 @@ describe('processRequest()', () => {
           .post('/')
           .set('a', '1')
           .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([
-              { name: 'a', value: '1' },
-              { name: 'content-length', value: '0' },
-            ]);
+            expect(body.headers).toStrictEqual(
+              expect.arrayContaining([
+                { name: 'host', value: '[REDACTED 15]' },
+                { name: 'accept-encoding', value: '[REDACTED 13]' },
+                { name: 'a', value: '1' },
+                { name: 'connection', value: '[REDACTED 5]' },
+                { name: 'content-length', value: '0' },
+              ])
+            );
           });
       });
 
@@ -105,7 +114,15 @@ describe('processRequest()', () => {
           .post('/')
           .set('a', '1')
           .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([{ name: 'a', value: '1' }]);
+            expect(body.headers).toStrictEqual(
+              expect.arrayContaining([
+                { name: 'host', value: '[REDACTED 15]' },
+                { name: 'accept-encoding', value: '[REDACTED 13]' },
+                { name: 'a', value: '1' },
+                { name: 'connection', value: '[REDACTED 5]' },
+                { name: 'content-length', value: '[REDACTED 1]' },
+              ])
+            );
           });
       });
     });
@@ -118,14 +135,22 @@ describe('processRequest()', () => {
 
         return request(app)
           .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
+          .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .set('a', '1')
           .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([
-              { name: 'content-type', value: 'application/json' },
-              { name: 'a', value: '1' },
-            ]);
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
+            expect(body.headers).toStrictEqual(
+              expect.arrayContaining([
+                { name: 'host', value: '[REDACTED 15]' },
+                { name: 'accept-encoding', value: '[REDACTED 13]' },
+                { name: 'content-type', value: 'application/json' },
+                { name: 'a', value: '1' },
+                { name: 'content-length', value: '[REDACTED 2]' },
+                { name: 'connection', value: '[REDACTED 5]' },
+              ])
+            );
+            expect(body.postData.text).toBe(
+              '{"password":"[REDACTED 6]","apiKey":"[REDACTED 3]","another":"Hello world"}'
+            );
           });
       });
 
@@ -136,14 +161,22 @@ describe('processRequest()', () => {
 
         return request(app)
           .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
+          .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .set('a', '1')
           .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([
-              { name: 'a', value: '1' },
-              { name: 'content-type', value: 'application/json' },
-            ]);
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
+            expect(body.headers).toStrictEqual(
+              expect.arrayContaining([
+                { name: 'host', value: '[REDACTED 15]' },
+                { name: 'accept-encoding', value: '[REDACTED 13]' },
+                { name: 'content-type', value: 'application/json' },
+                { name: 'a', value: '1' },
+                { name: 'content-length', value: '[REDACTED 2]' },
+                { name: 'connection', value: '[REDACTED 5]' },
+              ])
+            );
+            expect(body.postData.text).toBe(
+              '{"password":"[REDACTED 6]","apiKey":"[REDACTED 3]","another":"Hello world"}'
+            );
           });
       });
 
@@ -155,38 +188,42 @@ describe('processRequest()', () => {
 
         return request(app)
           .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
+          .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .set('a', '1')
           .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([
-              { name: 'content-type', value: 'application/json' },
-              { name: 'a', value: '1' },
-            ]);
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
+            expect(body.headers).toStrictEqual(
+              expect.arrayContaining([
+                { name: 'host', value: '[REDACTED 15]' },
+                { name: 'accept-encoding', value: '[REDACTED 13]' },
+                { name: 'content-type', value: 'application/json' },
+                { name: 'a', value: '1' },
+                { name: 'content-length', value: '[REDACTED 2]' },
+                { name: 'connection', value: '[REDACTED 5]' },
+              ])
+            );
+            expect(body.postData.text).toBe(
+              '{"password":"[REDACTED 6]","apiKey":"[REDACTED 3]","another":"Hello world"}'
+            );
           });
       });
     });
 
+    /*
+     * These tests are for the legacy blacklist/whitelist properties that mirrors allowlist/denylist behavior.
+     * Rather than reimplementing each test again here, it should be appropriate to just test the base case as
+     * The behavior here is assumed to use the same code paths as those used by the new properties.
+     */
     describe('deprecated blacklist/whitelist', () => {
       it('should strip blacklisted properties', () => {
         const app = createApp({ blacklist: ['password', 'apiKey'] });
 
         return request(app)
           .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
+          .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
-          });
-      });
-
-      it('should strip blacklisted nested properties', () => {
-        const app = createApp({ blacklist: ['a.b.c'] });
-
-        return request(app)
-          .post('/')
-          .send({ a: { b: { c: 1 } } })
-          .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"a":{"b":{}}}');
+            expect(body.postData.text).toBe(
+              '{"password":"[REDACTED 6]","apiKey":"[REDACTED 3]","another":"Hello world"}'
+            );
           });
       });
 
@@ -195,115 +232,9 @@ describe('processRequest()', () => {
 
         return request(app)
           .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
+          .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"password":"123456","apiKey":"abcdef"}');
-          });
-      });
-
-      it('should only send whitelisted nested properties', () => {
-        const app = createApp({ whitelist: ['a.b.c'] });
-
-        return request(app)
-          .post('/')
-          .send({ a: { b: { c: 1 } }, d: 2 })
-          .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"a":{"b":{"c":1}}}');
-          });
-      });
-
-      it('should ignore whitelist if blacklist is present', () => {
-        const app = createApp({ blacklist: ['password', 'apiKey'], whitelist: ['password', 'apiKey'] });
-
-        return request(app)
-          .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
-          .expect(({ body }) => {
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
-          });
-      });
-    });
-
-    describe('blacklist/whitelist in headers', () => {
-      it('should strip blacklisted properties', () => {
-        const app = createApp({ blacklist: ['host', 'accept-encoding', 'user-agent', 'connection'] });
-
-        return request(app)
-          .post('/')
-          .set('a', '1')
-          .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([
-              { name: 'a', value: '1' },
-              { name: 'content-length', value: '0' },
-            ]);
-          });
-      });
-
-      it('should only send whitelisted properties', () => {
-        const app = createApp({ whitelist: ['a'] });
-
-        return request(app)
-          .post('/')
-          .set('a', '1')
-          .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([{ name: 'a', value: '1' }]);
-          });
-      });
-    });
-
-    describe('blacklist/whitelist in body and headers', () => {
-      it('should strip blacklisted properties in body and headers', () => {
-        const app = createApp({
-          blacklist: ['host', 'accept-encoding', 'user-agent', 'connection', 'content-length', 'password', 'apiKey'],
-        });
-
-        return request(app)
-          .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
-          .set('a', '1')
-          .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([
-              { name: 'content-type', value: 'application/json' },
-              { name: 'a', value: '1' },
-            ]);
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
-          });
-      });
-
-      it('should only send whitelisted nested properties in body and headers', () => {
-        const app = createApp({
-          whitelist: ['a', 'another', 'content-type'],
-        });
-
-        return request(app)
-          .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
-          .set('a', '1')
-          .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([
-              { name: 'a', value: '1' },
-              { name: 'content-type', value: 'application/json' },
-            ]);
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
-          });
-      });
-
-      it('should ignore whitelist if there are blacklisted properties in headers and body', () => {
-        const app = createApp({
-          blacklist: ['host', 'accept-encoding', 'user-agent', 'connection', 'content-length', 'password', 'apiKey'],
-          whitelist: ['host', 'accept-encoding', 'user-agent', 'connection', 'content-length', 'password', 'apiKey'],
-        });
-
-        return request(app)
-          .post('/')
-          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
-          .set('a', '1')
-          .expect(({ body }) => {
-            expect(body.headers).toStrictEqual([
-              { name: 'content-type', value: 'application/json' },
-              { name: 'a', value: '1' },
-            ]);
-            expect(body.postData.text).toBe('{"another":"Hello world"}');
+            expect(body.postData.text).toBe('{"password":"123456","apiKey":"abc","another":"[REDACTED 11]"}');
           });
       });
     });

--- a/packages/node/lib/process-request.js
+++ b/packages/node/lib/process-request.js
@@ -1,22 +1,75 @@
 const url = require('url');
-const removeProperties = require('lodash/omit');
-const removeOtherProperties = require('lodash/pick');
+const get = require('lodash/get');
+const set = require('lodash/set');
+const pick = require('lodash/pick');
+const merge = require('lodash/merge');
 const contentType = require('content-type');
 
 const objectToArray = require('./object-to-array');
+
+/**
+ * @param {Any} value the value to be redacted
+ * @returns A redacted string potentially containing the length of the original value, if it was a string
+ */
+function redactValue(value) {
+  return `[REDACTED${typeof value === 'string' ? ` ${value.length}` : ''}]`;
+}
+
+/**
+ * @param {Object} obj The data object that is operated upon
+ * @param {String[]} redactedPaths a list of paths that point values which should be redacted
+ * @returns An object with the redacted values
+ */
+function redactProperties(obj, redactedPaths = []) {
+  const nextObj = { ...obj };
+  return redactedPaths.reduce((acc, path) => {
+    const value = get(acc, path);
+    if (value !== undefined) set(acc, path, redactValue(value));
+    return acc;
+  }, nextObj);
+}
+
+/**
+ * @param {Object} obj The data object that is operated upon
+ * @param {Function} cb A callback that is invoked for each value found, the return value being the next value that is set in the returned object
+ * @returns An object with the replaced values
+ */
+function replaceEach(obj, cb) {
+  return Object.keys(obj).reduce((acc, key) => {
+    const value = obj[key];
+    if (typeof value === 'object' && value !== null) {
+      acc[key] = replaceEach(value, cb);
+    } else if (value !== undefined) {
+      acc[key] = cb(value);
+    }
+    return acc;
+  }, {});
+}
+
+/**
+ *
+ * @param {Object} obj The data object with fields to redact
+ * @param {Array} nonRedactedPaths A list of all object paths that shouldn't be redacted
+ * @returns A merged objects that is entirely redacted except for the values of the nonRedactedPaths
+ */
+function redactOtherProperties(obj, nonRedactedPaths) {
+  const allowedFields = pick(obj, nonRedactedPaths);
+  const redactedFields = replaceEach(obj, redactValue);
+  return merge(redactedFields, allowedFields);
+}
 
 module.exports = (req, options = {}) => {
   const denylist = options.denylist || options.blacklist;
   const allowlist = options.allowlist || options.whitelist;
 
   if (denylist) {
-    req.body = removeProperties(req.body, denylist);
-    req.headers = removeProperties(req.headers, denylist);
+    req.body = redactProperties(req.body, denylist);
+    req.headers = redactProperties(req.headers, denylist);
   }
 
   if (allowlist && !denylist) {
-    req.body = removeOtherProperties(req.body, allowlist);
-    req.headers = removeOtherProperties(req.headers, allowlist);
+    req.body = redactOtherProperties(req.body, allowlist);
+    req.headers = redactOtherProperties(req.headers, allowlist);
   }
 
   const postData = {};


### PR DESCRIPTION
## 🧰 What's being changed?

[RM-1405](https://linear.app/readme-io/issue/RM-1405/node) - send a redacted string rather than omitting values for deny/allowlist

## 🧪 Testing

Sending a request via the node SDK where a denylist path has been set, should now redact that value, rather than omitting it from the request.
