### PR TITLE
feat(ruby) redact sensitive fields, rather filter them out entirely

### DIFF
--- a/packages/ruby/Gemfile.lock
+++ b/packages/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    readme-metrics (0.2.0)
+    readme-metrics (1.0.0)
       httparty (~> 0.18)
 
 GEM
@@ -21,7 +21,7 @@ GEM
       addressable (>= 2.4)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0512)
+    mime-types-data (3.2021.0225)
     multi_xml (0.6.0)
     parallel (1.19.2)
     parser (2.7.1.4)

--- a/packages/ruby/lib/readme/filter.rb
+++ b/packages/ruby/lib/readme/filter.rb
@@ -14,7 +14,7 @@ class Filter
   def self.redact(rejected_params)
     rejected_params.each_with_object({}) do |(k, v), hash|
       # If it's a string then return the length of the redacted field
-      hash[k.to_str] = "[REDACTED#{v.instance_of?(String) ? " #{v.length}" : ""}]"
+      hash[k.to_str] = "[REDACTED#{v.is_a?(String) ? " #{v.length}" : ""}]"
     end
   end
 

--- a/packages/ruby/lib/readme/filter.rb
+++ b/packages/ruby/lib/readme/filter.rb
@@ -25,11 +25,8 @@ class Filter
 
     def filter(hash)
       allowed_fields = @allowed_fields.map(&:downcase)
-      # Select all fields that are allowed
-      allowed_params = hash.select { |key, _value| allowed_fields.include?(key.downcase) }
-      # If a field is not in the allowed fields reject it
-      rejected_params = hash.reject { |key, _value| allowed_fields.include?(key.downcase) }
-      # Merge the result together
+      allowed_params, rejected_params = hash.partition { |key, _value| allowed_fields.include?(key.downcase) }.map(&:to_h)
+
       allowed_params.merge(Filter.redact(rejected_params))
     end
 
@@ -45,10 +42,7 @@ class Filter
 
     def filter(hash)
       rejected_fields = @rejected_fields.map(&:downcase)
-      # Reject all items in the rejected fields
-      allowed_params = hash.reject { |key, _value| rejected_fields.include?(key.downcase) }
-      # Get all the rejected fields
-      rejected_params = hash.select { |key, _value| rejected_fields.include?(key.downcase) }
+      rejected_params, allowed_params = hash.partition { |key, _value| rejected_fields.include?(key.downcase) }.map(&:to_h)
 
       allowed_params.merge(Filter.redact(rejected_params))
     end

--- a/packages/ruby/lib/readme/filter.rb
+++ b/packages/ruby/lib/readme/filter.rb
@@ -11,13 +11,26 @@ class Filter
     end
   end
 
+  def self.redact(rejected_params)
+    rejected_params.each_with_object({}) do |(k, v), hash|
+      # If it's a string then return the length of the redacted field
+      hash[k.to_str] = "[REDACTED#{v.instance_of?(String) ? " #{v.length}" : ""}]"
+    end
+  end
+
   class AllowOnly
-    def initialize(filter_values)
-      @filter_values = filter_values.map(&:downcase)
+    def initialize(filter_fields)
+      @allowed_fields = filter_fields
     end
 
     def filter(hash)
-      hash.select { |key, _value| @filter_values.include?(key.downcase) }
+      allowed_fields = @allowed_fields.map(&:downcase)
+      # Select all fields that are allowed
+      allowed_params = hash.select { |key, _value| allowed_fields.include?(key.downcase) }
+      # If a field is not in the allowed fields reject it
+      rejected_params = hash.reject { |key, _value| allowed_fields.include?(key.downcase) }
+      # Merge the result together
+      allowed_params.merge(Filter.redact(rejected_params))
     end
 
     def pass_through?
@@ -26,12 +39,18 @@ class Filter
   end
 
   class RejectParams
-    def initialize(filter_values)
-      @filter_values = filter_values.map(&:downcase)
+    def initialize(filter_fields)
+      @rejected_fields = filter_fields
     end
 
     def filter(hash)
-      hash.reject { |key, _value| @filter_values.include?(key.downcase) }
+      rejected_fields = @rejected_fields.map(&:downcase)
+      # Reject all items in the rejected fields
+      allowed_params = hash.reject { |key, _value| rejected_fields.include?(key.downcase) }
+      # Get all the rejected fields
+      rejected_params = hash.select { |key, _value| rejected_fields.include?(key.downcase) }
+
+      allowed_params.merge(Filter.redact(rejected_params))
     end
 
     def pass_through?

--- a/packages/ruby/spec/readme/filter_spec.rb
+++ b/packages/ruby/spec/readme/filter_spec.rb
@@ -27,11 +27,11 @@ end
 
 RSpec.describe Filter::RejectParams do
   describe "#filter" do
-    it "returns the given hash without the given filter values" do
-      hash = {"reject" => "rejected", "REJECT" => "rejected", "keep" => "kept"}
-      result = Filter::RejectParams.new(["reject"]).filter(hash)
+    it "redacts the given hash given filter values" do
+      hash = {"keep" => "kept", "reject" => "aaa", "number" => 1, "hash" => {ok: "yes"}}
+      result = Filter::RejectParams.new(["reject", "number", "hash"]).filter(hash)
 
-      expect(result.keys).to match_array(["keep"])
+      expect(result).to match({"reject" => "[REDACTED 3]", "keep" => "kept", "hash" => "[REDACTED]", "number" => "[REDACTED]"})
     end
   end
 
@@ -50,7 +50,7 @@ RSpec.describe Filter::AllowOnly do
       hash = {"reject" => "rejected", "keep" => "kept", "KEEP" => "kept"}
       result = Filter::AllowOnly.new(["keep"]).filter(hash)
 
-      expect(result.keys).to match_array(["keep", "KEEP"])
+      expect(result).to match({"reject" => "[REDACTED 8]", "keep" => "kept", "KEEP" => "kept"})
     end
   end
 

--- a/packages/ruby/spec/readme/har/request_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/request_serializer_spec.rb
@@ -62,11 +62,11 @@ RSpec.describe Readme::Har::RequestSerializer do
       json = request.as_json
 
       request_body = JSON.parse(json.dig(:postData, :text))
-      expect(request_body.keys).to_not include "key1"
+      expect(request_body.keys).to include "key1"
       expect(request_body.keys).to include "key2"
 
-      request_headers = json[:headers].map { |pair| pair[:name] }
-      expect(request_headers).to_not include "Filtered-Header"
+      request_headers = json[:headers].to_h { |pair| [pair[:name], pair[:value]] }
+      expect(request_headers["Filtered-Header"]).to eq "[REDACTED 8]"
     end
 
     it "builds proper body when there is no response body" do
@@ -89,8 +89,11 @@ RSpec.describe Readme::Har::RequestSerializer do
       expect(json[:postData]).not_to have_key(:text)
       expect(json.dig(:postData, :mimeType)).to eq http_request.content_type
       expect(json.dig(:postData, :params)).to match_array(
-        [{name: "item", value: "1"},
-          {name: "other", value: "2"}]
+        [
+          {name: "item", value: "1"},
+          {name: "other", value: "2"},
+          {name: "reject", value: "[REDACTED 1]"}
+        ]
       )
     end
 

--- a/packages/ruby/spec/readme/har/response_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/response_serializer_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Readme::Har::ResponseSerializer do
       expect(json[:httpVersion]).to eq request.http_version
       expect(json[:headers]).to match_array(
         [
-          {name: "X-Custom", value: "custom"}
+          {name: "X-Custom", value: "custom"},
+          {name: "reject", value: "[REDACTED 6]"}
         ]
       )
       expect(json[:headersSize]).to eq(-1)
@@ -41,7 +42,8 @@ RSpec.describe Readme::Har::ResponseSerializer do
       expect(json[:redirectURL]).to eq ""
       expect(json[:cookies]).to match_array(
         [
-          {name: "cookie1", value: "value1"}
+          {name: "cookie1", value: "value1"},
+          {name: "reject", value: "[REDACTED 6]"}
         ]
       )
       expect(json.dig(:content, :text)).to eq "OK"
@@ -64,7 +66,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       )
       json = serializer.as_json
 
-      expect(json.dig(:content, :text)).to eq({keep: "keep"}.to_json)
+      expect(json.dig(:content, :text)).to eq({keep: "keep", reject: "[REDACTED 6]"}.to_json)
       expect(json.dig(:content, :size)).to eq response.content_length
       expect(json.dig(:content, :mimeType)).to eq "application/json"
     end

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Readme::Metrics do
       expect(last_response.status).to eq 200
     end
 
-    it "is not submitted to Readme with  reject_params configured" do
+    it "is not submitted to Readme with reject_params configured" do
       def app
         text_app_with_middleware(buffer_length: 1, reject_params: ["reject"])
       end
@@ -247,7 +247,7 @@ RSpec.describe Readme::Metrics do
       expect(last_response.status).to eq 200
     end
 
-    it "is submitted to Readme with  reject_params configured for empty bodies" do
+    it "is submitted to Readme with reject_params configured for empty bodies" do
       def app
         empty_app_with_middleware(buffer_length: 1, reject_params: ["reject"])
       end
@@ -258,7 +258,7 @@ RSpec.describe Readme::Metrics do
       expect(last_response.status).to eq 204
     end
 
-    it "is submitted to Readme with  allow_only configured for empty bodies" do
+    it "is submitted to Readme with allow_only configured for empty bodies" do
       def app
         empty_app_with_middleware(buffer_length: 1, allow_only: ["allowed"])
       end

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Readme::Metrics do
 
   context "in a multi-threaded environment" do
     it "doesn't wait for the HTTP request to Readme to finish" do
-      readme_request_completion_time = 2 # seconds
+      readme_request_completion_time = 1 # seconds
       allow(HTTParty).to receive(:post) do
         sleep readme_request_completion_time
       end
@@ -51,52 +51,59 @@ RSpec.describe Readme::Metrics do
       header "Content-Type", "application/json"
       post "/api/foo", {key: "value"}.to_json
 
-      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
-        .with { |request| validate_json("readmeMetrics", request.body) }
+      expect(a_request(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) })
+        .to have_been_made.once
     end
 
     it "submits to the Readme API for POST requests with a url encoded body" do
       post "/api/foo", {key: "value"}
 
-      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
-        .with { |request| validate_json("readmeMetrics", request.body) }
+      expect(a_request(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) })
+        .to have_been_made.once
     end
 
     it "submits to the Readme API for POST requests with no body" do
       post "/api/foo"
 
-      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
-        .with { |request| validate_json("readmeMetrics", request.body) }
+      expect(a_request(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) })
+        .to have_been_made.once
     end
 
     it "submits to the Readme API for GET requests" do
       get "/api/foo"
 
-      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
-        .with { |request| validate_json("readmeMetrics", request.body) }
+      expect(a_request(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) })
+        .to have_been_made.once
     end
 
     it "submits to the Readme API for PUT requests with a JSON body" do
       header "Content-Type", "application/json"
       put "/api/foo", {key: "value"}.to_json
 
-      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
-        .with { |request| validate_json("readmeMetrics", request.body) }
+      expect(a_request(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) })
+        .to have_been_made.once
     end
 
     it "submits to the Readme API for PATCH requests with a JSON body" do
       header "Content-Type", "application/json"
       patch "/api/foo", {key: "value"}.to_json
 
-      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
-        .with { |request| validate_json("readmeMetrics", request.body) }
+      expect(a_request(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) })
+        .to have_been_made.once
     end
 
     it "submits to the Readme API for DELETE requests" do
       delete "/api/foo"
 
-      expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
-        .with { |request| validate_json("readmeMetrics", request.body) }
+      expect(a_request(:post, Readme::Metrics::ENDPOINT)
+        .with { |request| validate_json("readmeMetrics", request.body) })
+        .to have_been_made.once
     end
 
     it "returns a response when the middleware raises an error" do

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Readme::Metrics do
 
   context "in a multi-threaded environment" do
     it "doesn't wait for the HTTP request to Readme to finish" do
-      readme_request_completion_time = 1 # seconds
+      readme_request_completion_time = 2 # seconds
       allow(HTTParty).to receive(:post) do
         sleep readme_request_completion_time
       end


### PR DESCRIPTION
## 🧰 What's being changed?

[RM-1406](https://linear.app/readme-io/issue/RM-1406/ruby): Redact fields rather than filtering them out

## 🧪 Testing

To manually QA, use the Ruby SDK to send a request
