### PR TITLE
Python SDK version 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.envrc
 .vscode/
 node_modules/
 packages/*/node_modules/

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -15,7 +15,7 @@ pip install readme-metrics
 
 ## Usage
 
-Just include the `MetricsMiddleware` into your API!
+Just include the `MetricsMiddleware` in any WSGI app!
 
 ```python
 from readme_metrics import MetricsApiConfig, MetricsMiddleware
@@ -25,8 +25,8 @@ app = Flask(__name__)
 app.wsgi_app = MetricsMiddleware(
     app.wsgi_app,
     MetricsApiConfig(
-        '<<apiKey>>',
-        lambda req: {
+        api_key='<<your-readme-api-key>>',
+        grouping_function=lambda req: {
             'api_key': 'unique api_key of the user',
             'label': 'label for us to show for this user (ie email, project name, user name, etc)',
             'email': 'email address for user'
@@ -39,25 +39,25 @@ app.wsgi_app = MetricsMiddleware(
 
 There are a few options you can pass in to change how the logs are sent to ReadMe. These can be passed in `MetricsApiConfig`.
 
-Ex)
-
 ```python
 MetricsApiConfig(
-    '<<apiKey>>',
-    lambda req: {
+    api_key='<<your-readme-api-key>>',
+    grouping_function=lambda req: {
         'api_key': 'unique api_key of the user',
         'label': 'label for us to show for this user (ie email, project name, user name, etc)',
         'email': 'email address for user'
     },
     buffer_length=1,
-    denylist=['credit_card'] # Prevents credit_card in the request from being sent to readme
+    denylist=['password'] # Prevents a request or response's "password" field from being sent to ReadMe
 )
 ```
 
-| Option             | Use                                                                                                                                                                                                                           |
-| :----------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| development_mode   | **default: false** If true, the log will be separate from normal production logs. This is great for separating staging or test data from data coming from customers                                                           |
-| denylist           | **optional** An array of keys from your API requests and responses headers and bodies that you wish to denylist from sending to ReadMe.<br /><br />If you configure a denylist, it will override any allowlist configuration. |
-| allowlist          | **optional** An array of keys from your API requests and responses headers and bodies that you only wish to send to ReadMe.                                                                                                   |
-| buffer_length      | **default: 10** Sets the number of API calls that should be recieved before the requests are sent to ReadMe                                                                                                                   |
-| allowed_http_hosts | A list of allowed http hosts for sending data to the ReadMe API.                                                                                                                                                              |
+| Option                 | Use                                                |
+| :--------------------- | :------------------------------------------------- |
+| development_mode       | **default: false** If true, the log will be separate from normal production logs. This is great for separating staging or test data from data coming from customers. |
+| background_worker_mode | **default: true** If true, requests to the ReadMe API will be made in a background thread. If false, the ReadMe API request will be made synchronously in the main thread, potentially slowing down your HTTP service. |
+| denylist               | **optional** An array of keys from your API requests and responses headers and bodies that are blocked from being sent to ReadMe. Both the request and response will be checked for these keys, in their HTTP headers, form fields, URL parameters, and JSON request/response bodies. JSON is only checked at the top level, so a nested field will still be sent even if its key matches one of the keys in `denylist`.<br /><br />If you configure a denylist, it will override any allowlist configuration. |
+| allowlist              | **optional** An array of keys from your API requests and responses headers and bodies that you only wish to send to ReadMe. All other semantics match `denylist`. Like `denylist`, only the top level of JSON request/response bodies are filtered. If this option is configured, **only** the whitelisted properties will be sent. |
+| buffer_length          | **default: 10** Sets the number of API calls that should be recieved before the requests are sent to ReadMe. |
+| allowed_http_hosts     | A list of HTTP hosts which should be logged to ReadMe. If this is present, a request will only be sent to ReadMe if its Host header matches one of the allowed hosts. |
+| timeout                | Timeout (in seconds) for calls back to the ReadMe Metrics API. Default 3 seconds. |

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -17,7 +17,6 @@ class Metrics:
     """
 
     PACKAGE_NAME: str = "readme/metrics"
-    METRICS_API: str = "https://metrics.readme.io"
 
     def __init__(self, config: MetricsApiConfig):
         """
@@ -64,7 +63,7 @@ class Metrics:
         version = importlib.import_module(__package__).__version__
 
         readme_result = requests.post(
-            self.METRICS_API + "/request",
+            self.config.METRICS_API + "/request",
             auth=(self.config.README_API_KEY, ""),
             data=payload,
             headers={

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -69,7 +69,9 @@ class Metrics:
             args = (self.config, self.queue)
             for _ in range(math.ceil(self.queue.qsize() / self.config.BUFFER_LENGTH)):
                 if self.config.IS_BACKGROUND_MODE:
-                    thread = threading.Thread(target=publish_batch, daemon=True, args=args)
+                    thread = threading.Thread(
+                        target=publish_batch, daemon=True, args=args
+                    )
                     thread.start()
                 else:
                     publish_batch(*args)

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -5,32 +5,29 @@ class MetricsApiConfig:
     """ReadMe Metrics API configuration object
 
     Attributes:
-        README_API_KEY (str): (required) Your ReadMe API key
-        GROUPING_FUNCTION (lambda): (required) Grouping function to construct an
+        README_API_KEY (str) Your ReadMe API key
+        GROUPING_FUNCTION (lambda): Grouping function to construct an
             identity object. It receives the current request as a parameter, and must
             return a dictionary containing at least an "id" field, and optionally
             "label" and "email" fields.
 
             The main purpose of the identity object is to identify the API's caller.
-        BUFFER_LENGTH (int, optional): Number of requests to buffer before sending data
+        BUFFER_LENGTH (int): Number of requests to buffer before sending data
             to ReadMe. Defaults to 10.
-        IS_DEVELOPMENT_MODE (bool, optional): Determines whether you are running in
+        IS_DEVELOPMENT_MODE (bool): Determines whether you are running in
             development mode. Defaults to False.
-        IS_BACKGROUND_MODE (bool, optional):  Determines whether to issue the call to
+        IS_BACKGROUND_MODE (bool):  Determines whether to issue the call to
             the ReadMe API in a background thread. Defaults to True.
-        DENYLIST (List[str], optional): An array of headers and JSON body properties to
+        DENYLIST (List[str]): An array of headers and JSON body properties to
             skip sending to ReadMe.
 
             If you configure a denylist, it will override any allowlist configuration.
-        ALLOWLIST (List[str], optional): An array of headers and JSON body properties to
+        ALLOWLIST (List[str]): An array of headers and JSON body properties to
             send to ReadMe.
 
             If this option is configured, ONLY the allowlisted properties will be sent.
-        BLACKLIST (List[str], optional): Deprecated, prefer using an denylist.
-        WHITELIST (List[str], optional): Deprecated, prefer using an allowlist.
-        ALLOWED_HTTP_HOSTS (List[str] (optional)): A list of allowed http hosts for sending
+        ALLOWED_HTTP_HOSTS (List[str]): A list of allowed http hosts for sending
             data to the ReadMe API.
-
     """
 
     README_API_KEY: str = None

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -28,6 +28,7 @@ class MetricsApiConfig:
             If this option is configured, ONLY the allowlisted properties will be sent.
         ALLOWED_HTTP_HOSTS (List[str]): A list of allowed http hosts for sending
             data to the ReadMe API.
+        METRICS_API (str): Base URL of the ReadMe metrics API.
     """
 
     README_API_KEY: str = None
@@ -38,6 +39,7 @@ class MetricsApiConfig:
     DENYLIST: List[str] = []
     ALLOWLIST: List[str] = []
     ALLOWED_HTTP_HOSTS: List[str] = []
+    METRICS_API: str = "https://metrics.readme.io"
 
     def __init__(
         self,

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -31,6 +31,7 @@ class MetricsApiConfig:
         ALLOWED_HTTP_HOSTS (List[str]): A list of allowed http hosts for sending
             data to the ReadMe API.
         METRICS_API (str): Base URL of the ReadMe metrics API.
+        METRICS_API_TIMEOUT (int): Timeout (in seconds) for metrics API calls.
         LOGGER (logging.Logger): Logger used by all classes and methods in the
             readme_metrics packge. Defaults to a basic console logger with log level
             CRITICAL.
@@ -48,6 +49,7 @@ class MetricsApiConfig:
     ALLOWLIST: List[str] = []
     ALLOWED_HTTP_HOSTS: List[str] = []
     METRICS_API: str = "https://metrics.readme.io"
+    METRICS_API_TIMEOUT: int = 3
 
     def __init__(
         self,

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -80,20 +80,27 @@ class MetricsApiConfig:
                 development mode. Defaults to False.
             background_worker_mode (bool, optional): Determines whether to issue the
                 call to the ReadMe API in a background thread. Defaults to True.
-            denylist (List[str], optional): An array of headers and JSON body
-                properties to skip sending to ReadMe. Defaults to None.
+            denylist (List[str], optional): An array of keys from your API requests and
+                responses headers and bodies that are blocked from being sent to ReadMe.
+                Both the request and response will be checked for these keys, in their
+                HTTP headers, form fields, URL parameters, and JSON request/response
+                bodies. JSON is only checked at the top level, so a nested field will
+                still be sent even if its key matches one of the keys in `denylist`.
+                Defaults to None.
 
                 If you configure a denylist, it will override any allowlist
                 configuration.
             allowlist (List[str], optional): An array of headers and JSON body
-                properties to send to ReadMe. Defaults to None.
+                properties to send to ReadMe. Similar semantics to `denylist`; defaults
+                to None.
 
                 If this option is configured, ONLY the whitelisted properties will be
                 sent.
             blacklist (List[str], optional): Deprecated, prefer denylist.
             whitelist (List[str], optional): Deprecated, prefer allowlist.
-            allowed_http_hosts (List[str], optional): A list of allowed http hosts for sending data
-                to the ReadMe API.
+            allowed_http_hosts (List[str], optional): A list of HTTP hosts which should be
+                logged to ReadMe. If this is present, requests will only be sent to ReadMe
+                whose Host header matches one of the allowed hosts.
         """
         self.README_API_KEY = api_key
         self.GROUPING_FUNCTION = grouping_function

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -63,6 +63,7 @@ class MetricsApiConfig:
         blacklist: List[str] = None,
         whitelist: List[str] = None,
         allowed_http_hosts: List[str] = None,
+        timeout: int = 3,
     ):
         """Initializes an instance of the MetricsApiConfig object
 
@@ -101,6 +102,8 @@ class MetricsApiConfig:
             allowed_http_hosts (List[str], optional): A list of HTTP hosts which should be
                 logged to ReadMe. If this is present, requests will only be sent to ReadMe
                 whose Host header matches one of the allowed hosts.
+            timeout (int): Timeout (in seconds) for calls back to the ReadMe Metrics API.
+                Default 3 seconds.
         """
         self.README_API_KEY = api_key
         self.GROUPING_FUNCTION = grouping_function
@@ -110,4 +113,5 @@ class MetricsApiConfig:
         self.DENYLIST = denylist or blacklist or []
         self.ALLOWLIST = allowlist or whitelist or []
         self.ALLOWED_HTTP_HOSTS = allowed_http_hosts
+        self.METRICS_API_TIMEOUT = timeout
         self.LOGGER = util_build_logger()

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -1,5 +1,7 @@
 from typing import List, Any, Callable
 
+from readme_metrics.util import util_build_logger
+
 
 class MetricsApiConfig:
     """ReadMe Metrics API configuration object
@@ -29,6 +31,12 @@ class MetricsApiConfig:
         ALLOWED_HTTP_HOSTS (List[str]): A list of allowed http hosts for sending
             data to the ReadMe API.
         METRICS_API (str): Base URL of the ReadMe metrics API.
+        LOGGER (logging.Logger): Logger used by all classes and methods in the
+            readme_metrics packge. Defaults to a basic console logger with log level
+            CRITICAL.
+
+            You can adjust logging settings by manipulating LOGGER, or you can replace
+            LOGGER entirely with your application's Logger.
     """
 
     README_API_KEY: str = None
@@ -93,3 +101,4 @@ class MetricsApiConfig:
         self.DENYLIST = denylist or blacklist or []
         self.ALLOWLIST = allowlist or whitelist or []
         self.ALLOWED_HTTP_HOSTS = allowed_http_hosts
+        self.LOGGER = util_build_logger()

--- a/packages/python/readme_metrics/MetricsMiddleware.py
+++ b/packages/python/readme_metrics/MetricsMiddleware.py
@@ -86,13 +86,9 @@ class MetricsMiddleware:
                 res_ctype = ""
                 res_clength = 0
 
-                htype = next(
-                    (h for h in response_headers if h[0] == "Content-Type"), None
-                )
+                htype = next((h for h in response_headers if h[0] == "Content-Type"), None)
 
-                hlength = next(
-                    (h for h in response_headers if h[0] == "Content-Length"), None
-                )
+                hlength = next((h for h in response_headers if h[0] == "Content-Length"), None)
 
                 if htype and hlength:
                     res_ctype = htype[1]
@@ -108,12 +104,7 @@ class MetricsMiddleware:
                 )
 
                 # Send off data to be queued (and processed) by ReadMe if allowed
-                if self.config.ALLOWED_HTTP_HOSTS:
-                    if environ["HTTP_HOST"] in self.config.ALLOWED_HTTP_HOSTS:
-                        self.metrics_core.process(req, res)
-                else:
-                    # If the allowed_http_hosts has not been set (None by default), send off the data to be queued
-                    self.metrics_core.process(req, res)
+                self.metrics_core.process(req, res)
 
                 yield data
 

--- a/packages/python/readme_metrics/MetricsMiddleware.py
+++ b/packages/python/readme_metrics/MetricsMiddleware.py
@@ -86,9 +86,13 @@ class MetricsMiddleware:
                 res_ctype = ""
                 res_clength = 0
 
-                htype = next((h for h in response_headers if h[0] == "Content-Type"), None)
+                htype = next(
+                    (h for h in response_headers if h[0] == "Content-Type"), None
+                )
 
-                hlength = next((h for h in response_headers if h[0] == "Content-Length"), None)
+                hlength = next(
+                    (h for h in response_headers if h[0] == "Content-Length"), None
+                )
 
                 if htype and hlength:
                     res_ctype = htype[1]

--- a/packages/python/readme_metrics/__init__.py
+++ b/packages/python/readme_metrics/__init__.py
@@ -1,4 +1,4 @@
 from readme_metrics.MetricsApiConfig import MetricsApiConfig
 from readme_metrics.MetricsMiddleware import MetricsMiddleware
 
-__version__ = "1.0.6"
+__version__ = "1.1.0"

--- a/packages/python/readme_metrics/publisher.py
+++ b/packages/python/readme_metrics/publisher.py
@@ -22,13 +22,6 @@ def publish_batch(config, queue):
 
         version = importlib.import_module(__package__).__version__
         url = config.METRICS_API + "/request"
-        config.LOGGER.debug(f"url = {url}")
-        config.LOGGER.debug(f'auth = {config.README_API_KEY}, ""')
-        config.LOGGER.debug(f"Content-Type: application/json")
-        config.LOGGER.debug(f"User-Agent: readme-metrics-python@{version}")
-        import pprint
-
-        pprint.pprint(result_list)
 
         readme_result = requests.post(
             url,

--- a/packages/python/readme_metrics/publisher.py
+++ b/packages/python/readme_metrics/publisher.py
@@ -1,0 +1,47 @@
+import importlib
+import logging
+import math
+from queue import Empty, Queue
+import time
+
+import requests
+
+
+def publish_batch(config, queue):
+    result_list = []
+    try:
+        try:
+            while not queue.empty() and len(result_list) < config.batch_size:
+                payload = queue.get_nowait()
+                result_list.append(payload)
+        except Empty:
+            pass
+
+        if len(result_list) == 0:
+            return
+
+        version = importlib.import_module(__package__).__version__
+        url = config.METRICS_API + "/request"
+        readme_result = requests.post(
+            url,
+            auth=(config.README_API_KEY, ""),
+            data=result_list,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": f"readme-metrics-python@{version}",
+            },
+            timeout=1,
+        )
+        config.logger.info(
+            f"POST to {url} with {len(result_list)} items returned {readme_result.status_code}"
+        )
+        if not readme_result.ok:
+            config.logger.exception(readme_result.text)
+            raise Exception(f"POST to {url} returned {readme_result.status_code}")
+    except Exception as e:
+        # Errors in the Metrics SDK should never cause the application to
+        # throw an error. Log it but don't re-raise.
+        config.logger.exception(e)
+    finally:
+        for _ in result_list:
+            queue.task_done()

--- a/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
+++ b/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
@@ -49,10 +49,6 @@ def mockMiddlewareConfig():
     )
 
 
-# Verify that metrics has fields for metrics API and package name
-assert Metrics.METRICS_API != None
-assert Metrics.PACKAGE_NAME != None
-
 # Mock callback for handling middleware response
 class MetricsCoreMock:
     def process(self, req, res):

--- a/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
+++ b/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # pylint: disable=import-error
 import requests
 import json
 

--- a/packages/python/readme_metrics/tests/PayloadBuilder_test.py
+++ b/packages/python/readme_metrics/tests/PayloadBuilder_test.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # pylint: disable=import-error
 import requests
 import json
 
@@ -113,7 +113,7 @@ class TestPayloadBuilder:
         text = data["request"]["log"]["entries"][0]["request"]["text"]
 
         assert "ok" in text
-        assert not "password" in text
+        assert "password" not in text
 
     def testAllowlist(self):
         config = self.mockMiddlewareConfig(allowlist=["ok"])
@@ -131,7 +131,7 @@ class TestPayloadBuilder:
         text = data["request"]["log"]["entries"][0]["request"]["text"]
 
         assert "ok" in text
-        assert not "password" in text
+        assert "password" not in text
 
     def testDeprecatedBlackListed(self):
 
@@ -151,7 +151,7 @@ class TestPayloadBuilder:
         text = data["request"]["log"]["entries"][0]["request"]["text"]
 
         assert "ok" in text
-        assert not "password" in text
+        assert "password" not in text
 
     def testDeprecatedWhiteListed(self):
         config = self.mockMiddlewareConfig(whitelist=["ok"])
@@ -169,7 +169,7 @@ class TestPayloadBuilder:
         text = data["request"]["log"]["entries"][0]["request"]["text"]
 
         assert "ok" in text
-        assert not "password" in text
+        assert "password" not in text
 
     def testGroupingFunction(self):
         config = self.mockMiddlewareConfig(

--- a/packages/python/readme_metrics/tests/util_test.py
+++ b/packages/python/readme_metrics/tests/util_test.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # pylint: disable=import-error
 from readme_metrics import util
 
 

--- a/packages/python/readme_metrics/util.py
+++ b/packages/python/readme_metrics/util.py
@@ -1,6 +1,20 @@
+import logging
+from logging import Formatter, StreamHandler
+
+
 def util_exclude_keys(dict, keys):
     return {x: dict[x] for x in dict if x not in keys}
 
 
 def util_filter_keys(dict, keys):
     return {x: dict[x] for x in dict.keys() & keys}
+
+
+def util_build_logger():
+    logger = logging.getLogger(__package__)
+    logger.setLevel(logging.CRITICAL)
+    formatter = Formatter(fmt="%(asctime)s [%(levelname)s] %(message)s")
+    handler = StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger


### PR DESCRIPTION
## 🧰 What's being changed?

This is mostly refactoring, code cleanup, and maintainability improvements, in preparation for larger changes coming later this week.
• Fix RM-1310: Improve our ability to debug the Python SDK by adding a logger and by creating a place to override the Metrics API URL (so ReadMe engineers can test against their local Metrics installation)
• Fix RM-1314: batching prevents the last few requests from reaching our server; the new `atexit_handler` function allows us to flush any remaining logs before the process shuts down.
• Refactored the code for making the ReadMe API post; moved it to its own file.
• Added a timeout parameter for API calls, so that the client doesn't wait forever if the API is unresponsive.

I've also bumped the version to 1.1.0.

Roadmap for changes coming over the next few days:
• Version 1.1.0: this release, mostly refactoring and maintainability
• Version 1.2.0: add support for the new style of redacted fields—instead of disappearing from the payload entirely, they'll be sent as `[REDACTED]`, or for strings, `[REDACTEDnn]` (_nn_ = length of the redacted string)
• Version 2.0.0: add new adapters for Flask and Django so that clients can call the grouping function from within their application context (instead of running in WSGI middleware), which will make this a lot more usable for more substantial applications.

## 🧪 Testing

Tested on [a branch](https://github.com/readmeio/metrics-test-python/tree/update-wsgi-for-v1.1) of the new [metrics-test-python](https://github.com/readmeio/metrics-test-python/tree/update-wsgi-for-v1.1) service, which I had written earlier this month.