### PR TITLE
Python Metrics client libraries for Django and Flask

### DIFF
--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -1,50 +1,143 @@
 # readme-metrics
 
-Track your API metrics within ReadMe.
+Track your API metrics within ReadMe. For your convenience there are 3 different implementations in this package: middleware for Django, an extension for Flask, or WSGI middleware that can work with any other framework built on WSGI.
 
 [![PyPi](https://img.shields.io/pypi/v/readme-metrics)](https://pypi.org/project/readme-metrics/)
 [![Build](https://github.com/readmeio/metrics-sdks/workflows/python/badge.svg)](https://github.com/readmeio/metrics-sdks)
 
 [![](https://d3vv6lp55qjaqc.cloudfront.net/items/1M3C3j0I0s0j3T362344/Untitled-2.png)](https://readme.io)
 
-## Installation
 
-For the basic WSGI middleware implementation:
+## Django middleware installation and usage
+
+### Installation
+
+Install the Django variant of the package:
+```
+pip install readme-metrics[Django]
+```
+
+### Usage
+
+First you'll need to write a "grouping function" to inform ReadMe of the user or API key holder that is responsible for the current request. The grouping function receives the Django `request` object as input, and should return a data structure describing the current user or API key. A basic grouping function would look like this:
+
+```python
+def grouping_function(request):
+    # You can lookup your user here, pull it off the request object, etc.
+    return {
+        "api_key": "unique api_key of the user",
+        "label": "label for us to show for this user (ie email, project name, user name, etc)",
+        "email": "email address for user"
+    }
+```
+
+Second, once you have written a grouping function, add a `README_METRICS_CONFIG` setting using the `MetricsApiConfig` helper object:
+
+```python
+from readme_metrics import MetricsApiConfig
+README_METRICS_CONFIG = MetricsApiConfig(
+    api_key="Your-ReadMe-API-Key-Goes-Here",
+    grouping_function="module.path.to.your.grouping_function"
+)
+```
+
+Finally, also in your `settings.py` configuration file, add our `MetricsMiddleware` to your list of middleware:
+
+```python
+MIDDLEWARE = [
+    ...,
+    "readme_metrics.django.MetricsMiddleware",
+    ...
+]
+```
+
+
+
+## Flask extension installation and usage
+
+### Installation
+
+Install the Flask variant of the package:
+```
+pip install readme-metrics[Flask]
+```
+
+### Usage
+
+First you'll need to write a "grouping function" to inform ReadMe of the user or API key holder that is responsible for the current request. The grouping function receives the current Flask `Request` object as input, and should return a data structure describing the current user or API key. A basic grouping function would look like this:
+
+```python
+def grouping_function(request):
+    # You can lookup your user here, pull it off the request object, etc.
+    return {
+        "api_key": "unique api_key of the user",
+        "label": "label for us to show for this user (ie email, project name, user name, etc)",
+        "email": "email address for user"
+    }
+```
+
+Second, once you have written a grouping function, set up the extension wherever you create your Flask app.
+
+```python
+from flask import Flask
+from readme_metrics import MetricsApiConfig
+from readme_metrics.flask_readme import ReadMeMetrics
+
+# You already have code to create a Flask app...
+app = Flask("Your-App-Name")
+
+# Just add code to create the ReadMeMetrics extension and connect it to your app.
+metrics_extension = ReadMeMetrics(
+    MetricsApiConfig(
+        api_key="Your-ReadMe-API-Key-Goes-Here",
+        grouping_function=module.path.to.grouping_function
+    )
+)
+metrics_extension.init_app(app)
+
+```
+
+
+## WSGI middleware installation and usage
+
+### Installation
+
+Install the basic package:
 ```
 pip install readme-metrics
 ```
 
-If you're using Flask:
+### Usage
+
+First you'll need to write a "grouping function" to inform ReadMe of the user or API key holder that is responsible for the current request. The grouping function receives the WSGI `Request` object as input, and should return a data structure describing the current user or API key. A basic grouping function would look like this:
+
+```python
+def grouping_function(request):
+    return {
+        "api_key": "unique api_key of the user",
+        "label": "label for us to show for this user (ie email, project name, user name, etc)",
+        "email": "email address for user"
+    }
 ```
-pip install readme-metrics[flask]
-```
 
-
-## Usage
-
-<!-- TODO update docs for Flask -->
-
-Just include the `MetricsMiddleware` into your API!
+Then, wherever you initialize your WSGI app, you can wrap it with our middleware wrapper:
 
 ```python
 from readme_metrics import MetricsApiConfig, MetricsMiddleware
 
-app = Flask(__name__)
-
-app.wsgi_app = MetricsMiddleware(
-    app.wsgi_app,
+wsgi_app_with_metrics = MetricsMiddleware(
+    original_wsgi_app,
     MetricsApiConfig(
         api_key='<<your-readme-api-key>>',
-        grouping_function=lambda req: {
-            'api_key': 'unique api_key of the user',
-            'label': 'label for us to show for this user (ie email, project name, user name, etc)',
-            'email': 'email address for user'
-        },
+        grouping_function=module.path.to.grouping_function
     )
 )
 ```
 
-### Configuration Options
+Finally, configure your WSGI app server to execute `wsgi_app_with_metrics` instead of `original_wsgi_app`. (Instructions for this vary depending on the WSGI app server you're using and how it's configured.)
+
+
+## Configuration Options
 
 There are a few options you can pass in to change how the logs are sent to ReadMe. These can be passed in `MetricsApiConfig`.
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -9,13 +9,22 @@ Track your API metrics within ReadMe.
 
 ## Installation
 
+For the basic WSGI middleware implementation:
 ```
 pip install readme-metrics
 ```
 
+If you're using Flask:
+```
+pip install readme-metrics[flask]
+```
+
+
 ## Usage
 
-Just include the `MetricsMiddleware` in any WSGI app!
+<!-- TODO update docs for Flask -->
+
+Just include the `MetricsMiddleware` into your API!
 
 ```python
 from readme_metrics import MetricsApiConfig, MetricsMiddleware

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -6,8 +6,6 @@ import requests
 import json
 import importlib
 
-from werkzeug import Request
-
 from readme_metrics import MetricsApiConfig
 from readme_metrics.publisher import publish_batch
 from readme_metrics.PayloadBuilder import PayloadBuilder
@@ -42,11 +40,11 @@ class Metrics:
 
         atexit.register(self.exit_handler)
 
-    def process(self, request: Request, response: ResponseInfoWrapper) -> None:
+    def process(self, request, response: ResponseInfoWrapper) -> None:
         """Enqueues a request/response combination to be submitted the API.
 
         Args:
-            request (Request): Request object
+            request (Request): Request object from your WSGI server
             response (ResponseInfoWrapper): Response object
         """
         if not self.host_allowed(request.environ["HTTP_HOST"]):
@@ -69,9 +67,7 @@ class Metrics:
             args = (self.config, self.queue)
             for _ in range(math.ceil(self.queue.qsize() / self.config.BUFFER_LENGTH)):
                 if self.config.IS_BACKGROUND_MODE:
-                    thread = threading.Thread(
-                        target=publish_batch, daemon=True, args=args
-                    )
+                    thread = threading.Thread(target=publish_batch, daemon=True, args=args)
                     thread.start()
                 else:
                     publish_batch(*args)

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -67,7 +67,9 @@ class Metrics:
             args = (self.config, self.queue)
             for _ in range(math.ceil(self.queue.qsize() / self.config.BUFFER_LENGTH)):
                 if self.config.IS_BACKGROUND_MODE:
-                    thread = threading.Thread(target=publish_batch, daemon=True, args=args)
+                    thread = threading.Thread(
+                        target=publish_batch, daemon=True, args=args
+                    )
                     thread.start()
                 else:
                     publish_batch(*args)

--- a/packages/python/readme_metrics/MetricsMiddleware.py
+++ b/packages/python/readme_metrics/MetricsMiddleware.py
@@ -87,9 +87,13 @@ class MetricsMiddleware:
                 res_ctype = ""
                 res_clength = 0
 
-                htype = next((h for h in response_headers if h[0] == "Content-Type"), None)
+                htype = next(
+                    (h for h in response_headers if h[0] == "Content-Type"), None
+                )
 
-                hlength = next((h for h in response_headers if h[0] == "Content-Length"), None)
+                hlength = next(
+                    (h for h in response_headers if h[0] == "Content-Length"), None
+                )
 
                 if htype and hlength:
                     res_ctype = htype[1]

--- a/packages/python/readme_metrics/MetricsMiddleware.py
+++ b/packages/python/readme_metrics/MetricsMiddleware.py
@@ -1,10 +1,11 @@
+import io
+import time
+import datetime
+
 from readme_metrics.Metrics import Metrics
 from readme_metrics.MetricsApiConfig import MetricsApiConfig
 from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
 from werkzeug import Request
-import io
-import time
-import datetime
 
 
 class MetricsMiddleware:
@@ -86,13 +87,9 @@ class MetricsMiddleware:
                 res_ctype = ""
                 res_clength = 0
 
-                htype = next(
-                    (h for h in response_headers if h[0] == "Content-Type"), None
-                )
+                htype = next((h for h in response_headers if h[0] == "Content-Type"), None)
 
-                hlength = next(
-                    (h for h in response_headers if h[0] == "Content-Length"), None
-                )
+                hlength = next((h for h in response_headers if h[0] == "Content-Length"), None)
 
                 if htype and hlength:
                     res_ctype = htype[1]

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -162,7 +162,9 @@ class PayloadBuilder:
             # works for Django, and possibly other request objects too
             result = request.environ["QUERY_STRING"]
         else:
-            raise Exception("Don't know how to retrieve query string from this type of request")
+            raise Exception(
+                "Don't know how to retrieve query string from this type of request"
+            )
 
         if isinstance(result, bytes):
             result = result.decode("utf-8")

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -52,7 +52,6 @@ class PayloadBuilder:
         Args:
             request: Request information to use, either a `werkzeug.Request`
                 or a `django.core.handlers.wsgi.WSGIRequest`.
-                TODO: Implement for `django.core.handlers.asgi.ASGIRequest` too?
             response (ResponseInfoWrapper): Response information to use
 
         Returns:
@@ -95,7 +94,6 @@ class PayloadBuilder:
         Args:
             request (Request): Request object containing the request information, either
                 a `werkzeug.Request` or a `django.core.handlers.wsgi.WSGIRequest`.
-                TODO: Implement for `django.core.handlers.asgi.ASGIRequest` too?
 
         Returns:
             dict: Wrapped request payload
@@ -146,7 +144,6 @@ class PayloadBuilder:
             },
         }
 
-    # TODO document, returns a str (not bytes)
     def _get_query_string(self, request):
         """Helper function to get the query string for a request, translating fields from
         either a Werkzeug Request object or a Django WSGIRequest object.
@@ -154,7 +151,6 @@ class PayloadBuilder:
         Args:
             request (Request): Request object containing the request information, either
                 a `werkzeug.Request` or a `django.core.handlers.wsgi.WSGIRequest`.
-                TODO: Implement for `django.core.handlers.asgi.ASGIRequest` too?
 
         Returns:
             str: Query string, for example "field1=value1&field2=value2"
@@ -181,7 +177,6 @@ class PayloadBuilder:
         Args:
             request (Request): Request object containing the request information, either
                 a `werkzeug.Request` or a `django.core.handlers.wsgi.WSGIRequest`.
-                TODO: Implement for `django.core.handlers.asgi.ASGIRequest` too?
 
         Returns:
             str: Query string, for example "https://api.example.local:8080/v1/userinfo"
@@ -222,7 +217,7 @@ class PayloadBuilder:
             try:
                 body = body.decode("utf-8")
             except UnicodeDecodeError:
-                return {"text": "[ERROR: NOT VALID UTF-8]"}
+                return {"text": "[NOT VALID UTF-8]"}
 
         if not isinstance(body, str):
             # We don't know how to process this body. If it's safe to encode as

--- a/packages/python/readme_metrics/django.py
+++ b/packages/python/readme_metrics/django.py
@@ -9,15 +9,15 @@ from readme_metrics import MetricsApiConfig
 
 
 class MetricsMiddleware:
-    def __init__(self, get_response):
+    def __init__(self, get_response, config=None):
         self.get_response = get_response
-        self.config = settings.README_METRICS_CONFIG
+        self.config = config or settings.README_METRICS_CONFIG
         assert isinstance(self.config, MetricsApiConfig)
         self.metrics_core = Metrics(self.config)
 
     def __call__(self, request):
         try:
-            request.rm_start_dt = str(datetime.now())
+            request.rm_start_dt = str(datetime.utcnow())
             request.rm_start_ts = int(time.time() * 1000)
             if request.headers["Content-Length"] or request.body:
                 request.rm_content_length = request.headers["Content-Length"] or "0"

--- a/packages/python/readme_metrics/django.py
+++ b/packages/python/readme_metrics/django.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+import time
+
+from django.conf import settings
+
+from readme_metrics.Metrics import Metrics
+from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
+from readme_metrics import MetricsApiConfig
+
+
+class MetricsMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.config = settings.README_METRICS_CONFIG
+        assert isinstance(self.config, MetricsApiConfig)
+        self.metrics_core = Metrics(self.config)
+
+    def __call__(self, request):
+        try:
+            request.rm_start_dt = str(datetime.now())
+            request.rm_start_ts = int(time.time() * 1000)
+            if request.headers["Content-Length"] or request.body:
+                request.rm_content_length = request.headers["Content-Length"] or "0"
+                request.rm_body = request.body or ""
+        except Exception as e:
+            # Errors in the Metrics SDK should never cause the application to
+            # throw an error. Log it but don't re-raise.
+            self.config.LOGGER.exception(e)
+
+        response = self.get_response(request)
+
+        try:
+            try:
+                body = response.content.decode("utf-8")
+            except UnicodeDecodeError:
+                body = "[NOT VALID UTF-8]"
+            response_info = ResponseInfoWrapper(
+                response.headers,
+                response.status_code,
+                content_type=None,
+                content_length=None,
+                body=body,
+            )
+            self.metrics_core.process(request, response_info)
+        except Exception as e:
+            # Errors in the Metrics SDK should never cause the application to
+            # throw an error. Log it but don't re-raise.
+            self.config.LOGGER.exception(e)
+        finally:
+            return response

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -26,7 +26,7 @@ class ReadMeMetrics:
 
     def before_request(self):
         try:
-            request.rm_start_dt = str(datetime.now())
+            request.rm_start_dt = str(datetime.utcnow())
             request.rm_start_ts = int(time.time() * 1000)
             if "Content-Length" in request.headers or request.data:
                 request.rm_content_length = request.headers["Content-Length"] or "0"

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -20,7 +20,9 @@ class ReadMeMetrics:
             self.init_app(app)
 
     def init_app(self, app: Flask):
-        self.config.LOGGER.info(f"Configuring {app.name} hooks to call ReadMeMetrics extension functions")
+        self.config.LOGGER.info(
+            f"Configuring {app.name} hooks to call ReadMeMetrics extension functions"
+        )
         app.before_request(self.before_request)
         app.after_request(self.after_request)
 

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -20,9 +20,7 @@ class ReadMeMetrics:
             self.init_app(app)
 
     def init_app(self, app: Flask):
-        self.config.LOGGER.info(
-            f"Configuring {app.name} hooks to call ReadMeMetrics extension functions"
-        )
+        self.config.LOGGER.info(f"Configuring {app.name} hooks to call ReadMeMetrics extension functions")
         app.before_request(self.before_request)
         app.after_request(self.after_request)
 
@@ -30,9 +28,9 @@ class ReadMeMetrics:
         try:
             request.rm_start_dt = str(datetime.now())
             request.rm_start_ts = int(time.time() * 1000)
-            # TODO when applicable (on POST?), set
-            # req.rm_content_length = content_length
-            # req.rm_body = content_body
+            if "Content-Length" in request.headers or request.data:
+                request.rm_content_length = request.headers["Content-Length"] or "0"
+                request.rm_body = request.data or ""
         except Exception as e:
             # Errors in the Metrics SDK should never cause the application to
             # throw an error. Log it but don't re-raise.
@@ -45,7 +43,7 @@ class ReadMeMetrics:
                 response.status,
                 content_type=None,
                 content_length=None,
-                body=response.data.decode("utf-8"),  # TODO what about non-utf8?
+                body=response.data,
             )
             self.metrics_core.process(request, response_info)
         except Exception as e:

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+import time
+
+from flask import Flask, request
+
+from readme_metrics import MetricsApiConfig
+from readme_metrics.Metrics import Metrics
+from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
+
+
+# Guidelines for Flask extensions are available at:
+#     https://flask.palletsprojects.com/en/2.0.x/extensiondev/
+
+
+class ReadMeMetrics:
+    def __init__(self, config: MetricsApiConfig, app: Flask = None):
+        self.config = config
+        self.metrics_core = Metrics(config)
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app: Flask):
+        self.config.LOGGER.info(
+            f"Configuring {app.name} hooks to call ReadMeMetrics extension functions"
+        )
+        app.before_request(self.before_request)
+        app.after_request(self.after_request)
+
+    def before_request(self):
+        try:
+            request.rm_start_dt = str(datetime.now())
+            request.rm_start_ts = int(time.time() * 1000)
+            # TODO when applicable (on POST?), set
+            # req.rm_content_length = content_length
+            # req.rm_body = content_body
+        except Exception as e:
+            # Errors in the Metrics SDK should never cause the application to
+            # throw an error. Log it but don't re-raise.
+            self.config.LOGGER.exception(e)
+
+    def after_request(self, response):
+        try:
+            response_info = ResponseInfoWrapper(
+                response.headers,
+                response.status,
+                content_type=None,
+                content_length=None,
+                body=response.data.decode("utf-8"),  # TODO what about non-utf8?
+            )
+            self.metrics_core.process(request, response_info)
+        except Exception as e:
+            # Errors in the Metrics SDK should never cause the application to
+            # throw an error. Log it but don't re-raise.
+            self.config.LOGGER.exception(e)
+        finally:
+            return response

--- a/packages/python/readme_metrics/tests/django_test.py
+++ b/packages/python/readme_metrics/tests/django_test.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta
+import time
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+from readme_metrics import MetricsApiConfig
+from readme_metrics.django import MetricsMiddleware
+from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
+
+
+mock_config = MetricsApiConfig(
+    "README_API_KEY",
+    lambda req: {"id": "123", "label": "testuser", "email": "user@email.com"},
+    buffer_length=1000,
+)
+
+
+# from django.conf import settings
+# from django.test import TestCase
+# from django.test.utils import override_settings
+import os
+
+
+class TestDjangoMiddleware:
+    def test(self):
+        response = Mock()
+        response.headers = {"X-Header": "X Value!"}
+        get_response = Mock(return_value=response)
+
+        middleware = MetricsMiddleware(get_response, config=mock_config)
+        assert middleware.get_response == get_response
+        middleware.metrics_core = Mock()
+
+        # the middleware should call get_response(request)
+        request = Mock()
+        middleware(request)
+        get_response.assert_called_once_with(request)
+
+        # the middleware should set request.rm_start_dt to roughly the current
+        # datetime
+        assert hasattr(request, "rm_start_dt")
+        req_start_dt = datetime.strptime(request.rm_start_dt, "%Y-%m-%d %H:%M:%S.%f")
+        current_dt = datetime.utcnow()
+        assert abs(current_dt - req_start_dt) < timedelta(seconds=1)
+
+        # the middleware should set request.rm_start_ts to roughly the current
+        # unix timestamp, in milliseconds
+        assert hasattr(request, "rm_start_ts")
+        req_start_millis = request.rm_start_ts
+        current_millis = time.time() * 1000.0
+        assert abs(current_millis - req_start_millis) < 1000.00
+
+        # ensure that the middleware called metrics_core.process() with the
+        # current request, and a ResponseInfoWrapper with properties matching
+        # the current response
+        middleware.metrics_core.process.assert_called_once()
+        call_args = middleware.metrics_core.process.call_args
+        assert len(call_args[0]) == 2
+        assert call_args[0][0] == request
+        assert isinstance(call_args[0][1], ResponseInfoWrapper)
+        assert call_args[0][1].headers.get("X-Header") == "X Value!"

--- a/packages/python/readme_metrics/tests/django_test.py
+++ b/packages/python/readme_metrics/tests/django_test.py
@@ -16,9 +16,6 @@ mock_config = MetricsApiConfig(
 )
 
 
-# from django.conf import settings
-# from django.test import TestCase
-# from django.test.utils import override_settings
 import os
 
 

--- a/packages/python/readme_metrics/tests/flask_test.py
+++ b/packages/python/readme_metrics/tests/flask_test.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timedelta
+import time
+from unittest.mock import Mock, MagicMock
+from werkzeug.datastructures import EnvironHeaders
+
+from flask import Flask, request
+import pytest
+from readme_metrics import MetricsApiConfig
+from readme_metrics.flask_readme import ReadMeMetrics
+from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
+
+
+mock_config = MetricsApiConfig(
+    "README_API_KEY",
+    lambda req: {"id": "123", "label": "testuser", "email": "user@email.com"},
+    buffer_length=1000,
+)
+
+
+class TestFlaskExtension:
+    def setUp(self):
+        pass
+
+    def testInit(self):
+        # the extension should register itself with the Flask application
+        # provided to the constructor
+        app = Mock()
+        extension = ReadMeMetrics(config=mock_config, app=app)
+        app.before_request.assert_called_with(extension.before_request)
+        app.after_request.assert_called_with(extension.after_request)
+
+    def testBeforeRequest(self):
+        app = Flask(__name__)
+        extension = ReadMeMetrics(config=mock_config, app=app)
+        with app.test_request_context("/"):
+            extension.before_request()
+
+            # ensure that before_request has set request.rm_start_dt to
+            # roughly the current datetime
+            assert hasattr(request, "rm_start_dt")
+            req_start_dt = datetime.strptime(request.rm_start_dt, "%Y-%m-%d %H:%M:%S.%f")
+            current_dt = datetime.utcnow()
+            assert abs(current_dt - req_start_dt) < timedelta(seconds=1)
+
+            # ensure that before_request has set request.rm_start_ts to
+            # roughly the current unix timestamp, in milliseconds
+            assert hasattr(request, "rm_start_ts")
+            req_start_millis = request.rm_start_ts
+            current_millis = time.time() * 1000.0
+            assert abs(current_millis - req_start_millis) < 1000.00
+
+    def testAfterRequest(self):
+        app = Flask(__name__)
+        print("hello")
+        extension = ReadMeMetrics(config=mock_config, app=app)
+        extension.metrics_core = Mock()
+
+        response = Mock()
+        response.headers = {"X-Header": "X Value!"}
+
+        # simulate processing the entire request
+        with app.test_request_context("/"):
+            extension.before_request()
+            extension.after_request(response)
+
+        # ensure that we called metrics_core.process() with the current request,
+        # and a ResponseInfoWrapper matching the current response
+        extension.metrics_core.process.assert_called_once()
+        call_args = extension.metrics_core.process.call_args
+        assert len(call_args[0]) == 2
+        assert call_args[0][0] == request
+        assert isinstance(call_args[0][1], ResponseInfoWrapper)
+        assert call_args[0][1].headers.get("X-Header") == "X Value!"

--- a/packages/python/readme_metrics/tests/flask_test.py
+++ b/packages/python/readme_metrics/tests/flask_test.py
@@ -38,7 +38,9 @@ class TestFlaskExtension:
             # ensure that before_request has set request.rm_start_dt to
             # roughly the current datetime
             assert hasattr(request, "rm_start_dt")
-            req_start_dt = datetime.strptime(request.rm_start_dt, "%Y-%m-%d %H:%M:%S.%f")
+            req_start_dt = datetime.strptime(
+                request.rm_start_dt, "%Y-%m-%d %H:%M:%S.%f"
+            )
             current_dt = datetime.utcnow()
             assert abs(current_dt - req_start_dt) < timedelta(seconds=1)
 

--- a/packages/python/requirements.txt
+++ b/packages/python/requirements.txt
@@ -1,4 +1,7 @@
 black==20.8b1
+Django==3.2.5
+Flask==2.0.1
+pytest-mock==3.6.1
 pytest==6.2.2
 requests==2.25.1
-Werkzeug==1.0.1
+Werkzeug==2.0.1

--- a/packages/python/setup.py
+++ b/packages/python/setup.py
@@ -16,5 +16,6 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/readmeio/metrics-sdks/tree/main/packages/python",
     packages=["readme_metrics"],
-    install_requires=["werkzeug", "requests"],
+    install_requires=["Werkzeug", "requests"],
+    extras_require={"Flask": ["Flask"]},
 )

--- a/packages/python/setup.py
+++ b/packages/python/setup.py
@@ -16,6 +16,6 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/readmeio/metrics-sdks/tree/main/packages/python",
     packages=["readme_metrics"],
-    install_requires=["Werkzeug", "requests"],
-    extras_require={"Flask": ["Flask"]},
+    install_requires=["requests"],
+    extras_require={"Flask": ["Flask"], "Django": ["Django"]},
 )


### PR DESCRIPTION
## 🧰 What's being changed?

Django and Flask are the two most common frameworks for writing web applications and APIs in Python. Our first Python client was WSGI middleware, which technically worked with both Django and Flask, but its usefulness was rather limited.

When a user integrated their app with our first Python client, the app's `grouping_function` would run in the context of the WSGI middleware, not in the Django or Flask app context. This meant that the grouping function would not have access to any of the data that the app learned about the user while processing the request. For example, if the request contained a session cookie for authentication, the app might have looked up the cookie value in a database, and noted the user account in a request-local variable. But that variable wouldn't be available to other WSGI middleware, so the grouping function would need to repeat this lookup. This made it very difficult to integrate the metrics SDK with actual live Python software.

This PR includes two new adapters for our metrics middleware: a Flask extension and a Django middleware. Both are in use in toy servers in the [metrics-test-python](https://github.com/readmeio/metrics-test-python) project. That project now has 3 different app servers inside it, which you can access by running one of these commands: `python run.py wsgi`, `python run.py flask`, or `python run.py django`. I have those running locally so I can walk you through that if you're interested.

A Flask developer could install the Flask extension and connect it to their Flask server (`app`) with code like this:

```python
from readme_metrics import MetricsApiConfig
from readme_metrics.flask_readme import ReadMeMetrics
metrics_config = MetricsApiConfig(
    app.config["README_API_KEY"],
    grouping_function,  # pointer to the grouping function that they've written elsewhere
)
metrics_extension = ReadMeMetrics(metrics_config)
metrics_extension.init_app(app)
```

[Flask example in metrics-test-python](https://github.com/readmeio/metrics-test-python/blob/main/test_server/flask/__init__.py#L36)

And they could install the Django middleware by writing a grouping function and then adding these lines to their Django `settings.py` config (example):

```python
MIDDLEWARE = [
    ...,
    "readme_metrics.django.MetricsMiddleware",
    ...
]

README_METRICS_CONFIG = MetricsApiConfig(
    README_API_KEY,
    "module.path.to.grouping_function"
)
```

[Django example in metrics-test-python](https://github.com/readmeio/metrics-test-python/blob/main/test_server/django/config/settings.py#L57)

When we release this, we should increment the PyPi package version to 2.0.0.

## 🧪 Testing

I wrote toy Flask and Django apps in `metrics-test-python` and tested there. Also wrote some basic unit tests for the Django and Python adapters. As discussed earlier, more test coverage would be a good idea, but isn't absolutely necessary at the moment.