### PR TITLE
feat(python): documented way to skip logging a request

### DIFF
--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -24,11 +24,16 @@ First you'll need to write a "grouping function" to inform ReadMe of the user or
 ```python
 def grouping_function(request):
     # You can lookup your user here, pull it off the request object, etc.
-    return {
-        "api_key": "unique api_key of the user",
-        "label": "label for us to show for this user (ie email, project name, user name, etc)",
-        "email": "email address for user"
-    }
+    # Your grouping function should None if you don't want the request to be
+    # logged, and otherwise return a structure like the one below.
+    if user_is_authenticated:
+        return {
+            "api_key": "unique api_key of the user",
+            "label": "label for us to show for this user (ie email, project name, user name, etc)",
+            "email": "email address for user"
+        }
+    else:
+        return None
 ```
 
 Second, once you have written a grouping function, add a `README_METRICS_CONFIG` setting using the `MetricsApiConfig` helper object:
@@ -69,11 +74,16 @@ First you'll need to write a "grouping function" to inform ReadMe of the user or
 ```python
 def grouping_function(request):
     # You can lookup your user here, pull it off the request object, etc.
-    return {
-        "api_key": "unique api_key of the user",
-        "label": "label for us to show for this user (ie email, project name, user name, etc)",
-        "email": "email address for user"
-    }
+    # Your grouping function should None if you don't want the request to be
+    # logged, and otherwise return a structure like the one below.
+    if user_is_authenticated:
+        return {
+            "api_key": "unique api_key of the user",
+            "label": "label for us to show for this user (ie email, project name, user name, etc)",
+            "email": "email address for user"
+        }
+    else:
+        return None
 ```
 
 Second, once you have written a grouping function, set up the extension wherever you create your Flask app.
@@ -113,11 +123,17 @@ First you'll need to write a "grouping function" to inform ReadMe of the user or
 
 ```python
 def grouping_function(request):
-    return {
-        "api_key": "unique api_key of the user",
-        "label": "label for us to show for this user (ie email, project name, user name, etc)",
-        "email": "email address for user"
-    }
+    # You can lookup your user here, pull it off the request object, etc.
+    # Your grouping function should None if you don't want the request to be
+    # logged, and otherwise return a structure like the one below.
+    if user_is_authenticated:
+        return {
+            "api_key": "unique api_key of the user",
+            "label": "label for us to show for this user (ie email, project name, user name, etc)",
+            "email": "email address for user"
+        }
+    else:
+        return None
 ```
 
 Then, wherever you initialize your WSGI app, you can wrap it with our middleware wrapper:

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -124,8 +124,8 @@ First you'll need to write a "grouping function" to inform ReadMe of the user or
 ```python
 def grouping_function(request):
     # You can lookup your user here, pull it off the request object, etc.
-    # Your grouping function should None if you don't want the request to be
-    # logged, and otherwise return a structure like the one below.
+    # Your grouping function should return None if you don't want the request
+    # to be logged, and otherwise return a structure like the one below.
     if user_is_authenticated:
         return {
             "api_key": "unique api_key of the user",

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -24,8 +24,8 @@ First you'll need to write a "grouping function" to inform ReadMe of the user or
 ```python
 def grouping_function(request):
     # You can lookup your user here, pull it off the request object, etc.
-    # Your grouping function should None if you don't want the request to be
-    # logged, and otherwise return a structure like the one below.
+    # Your grouping function should return None if you don't want the request
+    # to be logged, and otherwise return a structure like the one below.
     if user_is_authenticated:
         return {
             "api_key": "unique api_key of the user",

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -74,8 +74,8 @@ First you'll need to write a "grouping function" to inform ReadMe of the user or
 ```python
 def grouping_function(request):
     # You can lookup your user here, pull it off the request object, etc.
-    # Your grouping function should None if you don't want the request to be
-    # logged, and otherwise return a structure like the one below.
+    # Your grouping function should return None if you don't want the request
+    # to be logged, and otherwise return a structure like the one below.
     if user_is_authenticated:
         return {
             "api_key": "unique api_key of the user",

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -58,6 +58,9 @@ class PayloadBuilder:
             dict: Payload object (ready to be serialized and sent to ReadMe)
         """
         group = self.grouping_function(request)
+        if group is None:
+            return None
+
         if "api_key" in group:
             group["id"] = group["api_key"]
             del group["api_key"]

--- a/packages/python/readme_metrics/tests/PayloadBuilder_test.py
+++ b/packages/python/readme_metrics/tests/PayloadBuilder_test.py
@@ -207,6 +207,22 @@ class TestPayloadBuilder:
         assert group["email"] == "flavor@spam.musubi"
         assert group["label"] == "Spam Musubi"
 
+    def testGroupingFunctionNone(self):
+        # PayloadBuilder should return None if the grouping_function returns
+        # None (which means not to log the request).
+        config = self.mockMiddlewareConfig(grouping_function=lambda req: None)
+
+        responseObjectString = "{ 'responseObject': 'value' }"
+        environ = Environ.MockEnviron().getEnvironForRequest(b"", "POST")
+        app = MockApplication(responseObjectString)
+        metrics = MetricsCoreMock()
+        middleware = MetricsMiddleware(app, config)
+        middleware.metrics_core = metrics
+        next(middleware(environ, app.mockStartResponse))
+        payload_builder = self.createPayload(config)
+        payload = payload_builder(metrics.req, metrics.res)
+        assert payload is None
+
     def testDeprecatedIDField(self):
         config = self.mockMiddlewareConfig(
             grouping_function=lambda req: {


### PR DESCRIPTION
## 🧰 What's being changed?

Give users a clear way to mark requests that shouldn't be logged to ReadMe. A grouping function can return `None` which is an indication that the log should not be captured and sent to ReadMe.

Added documentation to `README.md` and added the functionality to the Metrics core processor.

## 🧪 Testing

Added unit tests. Also tested with the metrics-test-python test server, see this commit: https://github.com/readmeio/metrics-test-python/commit/6484c2767fd524237d08352e10082a431d40de8a