### PR TITLE
feat(python): validate and clean up the result of the grouping function

### DIFF
--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -35,6 +35,7 @@ class Metrics:
             config.ALLOWLIST,
             config.IS_DEVELOPMENT_MODE,
             config.GROUPING_FUNCTION,
+            config.LOGGER,
         )
         self.queue = queue.Queue()
 

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -105,7 +105,7 @@ class PayloadBuilder:
         if "api_key" in group:
             # The public API for the grouping function now asks users to return
             # an "api_key", but our Metrics API expects an "id" field. Quietly
-            # update it to
+            # update it to "id".
             group["id"] = group["api_key"]
             del group["api_key"]
         elif "id" not in group:

--- a/packages/python/readme_metrics/tests/django_test.py
+++ b/packages/python/readme_metrics/tests/django_test.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import os
 import time
 from unittest.mock import Mock, MagicMock, patch
 
@@ -14,9 +15,6 @@ mock_config = MetricsApiConfig(
     lambda req: {"id": "123", "label": "testuser", "email": "user@email.com"},
     buffer_length=1000,
 )
-
-
-import os
 
 
 class TestDjangoMiddleware:

--- a/packages/python/readme_metrics/tests/redaction_test.py
+++ b/packages/python/readme_metrics/tests/redaction_test.py
@@ -1,6 +1,10 @@
+import logging
+
 import pytest  # pylint: disable=import-error
 from readme_metrics.PayloadBuilder import PayloadBuilder
 
+
+logger = logging.getLogger(__name__)
 
 allowlist = [
     "allowed_string",
@@ -73,13 +77,18 @@ def test_redaction_with_allowlist():
         allowlist=allowlist,
         development_mode=True,
         grouping_function=None,
+        logger=logger,
     )._redact_dict(mapping)
     assert allowlist_result == expected_allowlist_result
 
 
 def test_redaction_with_denylist():
     denylist_result = PayloadBuilder(
-        denylist=denylist, allowlist=None, development_mode=True, grouping_function=None
+        denylist=denylist,
+        allowlist=None,
+        development_mode=True,
+        grouping_function=None,
+        logger=logger,
     )._redact_dict(mapping)
     assert denylist_result == expected_denylist_result
 
@@ -87,6 +96,10 @@ def test_redaction_with_denylist():
 def test_redaction_with_both():
     # when both allowlist and denylist are present, denylist takes precedence
     denylist_result = PayloadBuilder(
-        denylist=denylist, allowlist=None, development_mode=True, grouping_function=None
+        denylist=denylist,
+        allowlist=None,
+        development_mode=True,
+        grouping_function=None,
+        logger=logger,
     )._redact_dict(mapping)
     assert denylist_result == expected_denylist_result


### PR DESCRIPTION
## 🧰 What's being changed?

PayloadBuilder now validates the output of the grouping function. If the output isn't a dict or doesn't include `api_key` or `id`, we log an error and don't send the request to ReadMe. If the output is missing other expected fields `email` and `label`, we log a warning but send the request anyway. And if the output includes any unexpected fields, we log a warning and remove them before sending the request to ReadMe.

Note that by default the logger is set to log level `CRITICAL` so users won't typically see these warnings and errors unless they modify the logger in the `MetricsApiConfig` object. I actually think that's fine—we want the metrics clients to be pretty transparent and not pollute our users' logs when they haven't opted in for that.

## 🧪 Testing

New unit tests.