### PR TITLE
Python metrics client starteddatetime rm 1315

### DIFF
--- a/packages/python/readme_metrics/MetricsMiddleware.py
+++ b/packages/python/readme_metrics/MetricsMiddleware.py
@@ -52,7 +52,7 @@ class MetricsMiddleware:
             return write
 
         try:
-            req.rm_start_dt = str(datetime.datetime.now())
+            req.rm_start_dt = str(datetime.datetime.utcnow())
             req.rm_start_ts = int(time.time() * 1000)
 
             if req.method == "POST":

--- a/packages/python/readme_metrics/__init__.py
+++ b/packages/python/readme_metrics/__init__.py
@@ -1,4 +1,4 @@
 from readme_metrics.MetricsApiConfig import MetricsApiConfig
 from readme_metrics.MetricsMiddleware import MetricsMiddleware
 
-__version__ = "1.2.0"
+__version__ = "2.0.0"


### PR DESCRIPTION
## 🧰 What's being changed?

My Mac is running in Pacific Time. When I ran our Python test app on my Mac, and it builds a payload for the Metrics API server, it sends local time in the payload's `startedDateTime` field. This is interpreted as UTC time by the API server, so times are displayed incorrectly in the web app.

(I had already addressed this in the Flask and Django adapters; this fix is just for the WSGI middleware implementation.)

This is the last commit for version 2.0, so I'm also bumping the package's version number!

## 🧪 Testing

Tested by running metrics-test-python locally.
