### PR TITLE
chore: docs for packaging Python + correct path to Python release version number

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -21,12 +21,18 @@ To publish a new version of the PHP package, after you mirror the codebase with 
 To publish a new version of the Ruby [package](https://rubygems.org/gems/readme-metrics/) bump the package version in `version.rb`, and then run `gem build readme-metrics` and `gem publish <BUILT_GEM>`.
 
 #### Python
+
+If you're not a maintainer of `readme-metrics` on [PyPI](https://pypi.org), [register for an account](https://pypi.org/account/register/), enable two-factor auth on your [account settings](https://pypi.org/manage/account/), and ask someone to add you as a maintainer.
+
+You may also want to create a `.pypirc` file in your home directory ([example](https://gist.github.com/RyanGWU82/893fb63e6d182f90ef227fd1fd4e9da5)).
+
+To publish a new version:
 1. `cd packages/python`
-2. Update `version` in `setup.py`
-3. Commit the changes to `setup.py` (and mirror that change).
+2. Update `version` in `readme_metrics/__init__.py`
+3. Commit the changes to `readme_metrics/__init__.py` (and mirror that change).
 4. `rm dist/*`
 5. `python3 setup.py sdist bdist_wheel`
+    * If you get errors about `invalid command 'bdist_wheel'`, install the wheel package: `pip3 install wheel`
 6. `python3 -m twine upload dist/*`
     * If you get errors about `twine` not being installed, install it with `pip3 install twine`.
     * On the first run you'll be asked to log into PyPi, so if you don't have access to `readme-metrics` there ask someone to hook you up with access.
-

--- a/packages/python/setup.py
+++ b/packages/python/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = importlib.import_module(__package__).__version__
+version = importlib.import_module("readme_metrics").__version__
 
 setup(
     name="readme-metrics",


### PR DESCRIPTION
Just docs and a minor fix required to use `setup.py` on my setup (Python 3.9 + setuptools 57.0.0).