### PR TITLE
feat(ruby): accept custom request queue as option

### DIFF
--- a/packages/ruby/lib/readme/metrics.rb
+++ b/packages/ruby/lib/readme/metrics.rb
@@ -34,7 +34,7 @@ module Readme
       @get_user_info = get_user_info
 
       buffer_length = options[:buffer_length] || DEFAULT_BUFFER_LENGTH
-      @@request_queue = Readme::RequestQueue.new(options[:api_key], buffer_length)
+      @@request_queue = options[:request_queue] || Readme::RequestQueue.new(options[:api_key], buffer_length)
       @@logger = options[:logger] || Logger.new($stdout)
     end
 

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe Readme::Metrics do
     expect(Readme::Metrics::VERSION).not_to be nil
   end
 
+  context "provided a custom request queue" do
+    let(:request_queue) { [] }
+
+    def app
+      empty_app_with_middleware({request_queue: request_queue})
+    end
+
+    it "pushes to the custom queue" do
+      post "/api/foo", "[BODY]"
+
+      expect(request_queue.size).to eq 1
+    end
+  end
+
   context "in a multi-threaded environment" do
     it "doesn't wait for the HTTP request to Readme to finish" do
       readme_request_completion_time = 1 # seconds


### PR DESCRIPTION
During testing, it can be helpful to see the current user block evaluated
correctly but not actually sent anywhere.

Providing a plain Array as the request queue can be helpful to ensure that
the a request may have been sent.

Providing an object with `push` that is a no-op can be a helpful /dev/null
sink, which permits the middleware to be always present, and not a special
case during testing.
