### PR TITLE
ci: pinning the version of python that's used in ci

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.x]
+        python-version: [3.7]
 
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
Python 3.10 seems to be causing issues with some of our deps in CI so I'm rolling it back down and pinning to Python 3.7 in CI.