### PR TITLE
feat: dropping support for PHP 7.3, extending support to PHP 8.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
         laravel: [6.*, 7.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
 

--- a/packages/php/composer.json
+++ b/packages/php/composer.json
@@ -14,7 +14,7 @@
     "readme"
   ],
   "require": {
-    "php": "^7.3 | ^7.4 | ^8.0",
+    "php": "^7.4 | ^8.0",
     "illuminate/http": "^6.8 | ^7.0 | ^8.0",
     "illuminate/support": "^6.8 | ^7.0 | ^8.0",
     "ocramius/package-versions": "^1.4",
@@ -25,8 +25,8 @@
   "require-dev": {
     "phpunit/phpunit": "^9.5",
     "mockery/mockery": "^1.4",
-    "vimeo/psalm": "dev-master",
-    "squizlabs/php_codesniffer": "dev-master"
+    "vimeo/psalm": "^4.13",
+    "squizlabs/php_codesniffer": "^3.6"
   },
   "extra": {
     "laravel": {


### PR DESCRIPTION
## 🧰 What's being changed?

PHP 7.3 loses support on the 6th so we're dropping it and also extending our support to PHP 8.1 which was released last month.

https://www.php.net/supported-versions.php

I'm also pinning our dependencies on `vimeo/psalm` and `squizlabs/php_codesniffer` to prevent issues in the future where changes hit their master/main branches that we haven't tested, causing CI failures.

## 🧬 Testing

* [ ] Tests still all pass?