### PR TITLE
Specify the uuid gem dependency

### DIFF
--- a/packages/ruby/Gemfile.lock
+++ b/packages/ruby/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     readme-metrics (2.0.0)
       httparty (~> 0.18)
+      uuid (~> 2.3.8)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/ruby/readme-metrics.gemspec
+++ b/packages/ruby/readme-metrics.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "httparty", "~> 0.18"
+  spec.add_runtime_dependency "uuid", "~> 2.3.8"
 end


### PR DESCRIPTION
## 🧰 What's being changed?

Add the uuid gem dependency to the library (by specifying the gem on the `.gemspec`).

## 🧬 Testing

Nothing much to test, just require the gem as part of the library.