### PR TITLE
chore: update gem to 2.0.1 and add os runtime dep

### DIFF
--- a/packages/ruby/Gemfile.lock
+++ b/packages/ruby/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    readme-metrics (2.0.0)
+    readme-metrics (2.0.1)
       httparty (~> 0.18)
+      os (~> 1.1.4)
       uuid (~> 2.3.8)
 
 GEM

--- a/packages/ruby/lib/readme/metrics/version.rb
+++ b/packages/ruby/lib/readme/metrics/version.rb
@@ -1,5 +1,5 @@
 module Readme
   class Metrics
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end

--- a/packages/ruby/readme-metrics.gemspec
+++ b/packages/ruby/readme-metrics.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "httparty", "~> 0.18"
   spec.add_runtime_dependency "uuid", "~> 2.3.8"
+  spec.add_runtime_dependency "os", "~> 1.1.4"
 end


### PR DESCRIPTION
## 🧰 What's being changed?

chore: update gem to 2.0.1 and add os runtime dep

## 🧬 Testing

Built and required the gem locally successfully. v2.0.1 has been released.
