### PR TITLE
fix: x-forwarded-proto header parsing

### DIFF
--- a/packages/node/__tests__/lib/process-request.test.ts
+++ b/packages/node/__tests__/lib/process-request.test.ts
@@ -402,6 +402,13 @@ test('#url protocol x-forwarded-proto', () =>
     // This regex is for supertest's random port numbers
     .expect(({ body }) => expect(body.url).toMatch(/^https/)));
 
+test('#url protocol x-forwarded-proto multiple', () =>
+  request(createApp())
+    .post('/')
+    .set('x-forwarded-proto', 'https,http')
+    // This regex is for supertest's random port numbers
+    .expect(({ body }) => expect(body.url).toMatch(/^https:\/\/127.0.0.1/)));
+
 test('#url-basepath', () =>
   request(createApp())
     .post('/test-base-path/a')

--- a/packages/node/src/lib/process-request.ts
+++ b/packages/node/src/lib/process-request.ts
@@ -178,12 +178,15 @@ export default function processRequest(
   const host = fixHeader(req.headers['x-forwarded-host']) || req.headers.host;
   // We use a fake host here because we rely on the host header which could be redacted.
   // We only ever use this reqUrl with the fake hostname for the pathname and querystring.
-  const reqUrl = new URL(req.url, `${protocol}://readme.io`);
+  const reqUrl = new URL(req.url, `https://readme.io`);
 
   const requestData = {
     method: req.method,
     url: url.format({
-      protocol,
+      // Handle cases where some reverse proxies put two protocols into x-forwarded-proto
+      // This line does the following: "https,http" -> "https"
+      // https://github.com/readmeio/metrics-sdks/issues/378
+      protocol: protocol.split(',')[0],
       host,
       pathname: reqUrl.pathname,
       // Search includes the leading questionmark, format assumes there isn't one, so we trim that off.


### PR DESCRIPTION
## 🧰 What's being changed?

Some reverse proxies put multiple protocols into x-forwarded-proto
which caused the `new URL()` constructor to fail. I removed the parsed
protocol from the URL constructor, since we're only using that with a
static hostname anyway.

Then in the instance where we do need the parsed protocol, I added some
logic to capture the first protocol if there's more than one.

Fixes: https://github.com/readmeio/metrics-sdks/issues/378

@ilias-t this is my first time editing this code in a while... is this the correct place for this? Or would it make more sense in the fixHeader function: https://github.com/readmeio/metrics-sdks/blob/main/packages/node/src/lib/process-request.ts#L21-L31=

This part in particular feels like it could contain this logic: https://github.com/readmeio/metrics-sdks/blob/main/packages/node/src/lib/process-request.ts#L26-L28=. When would the header be an array? I tried doing the following but the last one always took precedence:

```js
test.only('#url protocol x-forwarded-proto multiple', () =>
  request(createApp())
    .post('/')
    .set('x-forwarded-proto', 'http')
    .set('x-forwarded-proto', 'https')
    // This regex is for supertest's random port numbers
    .expect(({ body }) => expect(body.url).toMatch(/^https:\/\/127.0.0.1/)));
```

## 🧬 Testing
Does CI pass? ✅
