### PR TITLE
fix: python CI (upgrade black to 22.3.0) and node CI (pin node.js to 16.14.0)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,10 @@ jobs:
 
     strategy:
       matrix:
-       node-version: [12.x, 14.x, 16.x]
+        # node 16.14.2 ships with a buggy version of npm 🤷‍♂️
+        # https://github.com/nodejs/node/issues/42397
+        # TODO revert this back to 16.x when node pushes a new version
+        node-version: [12.x, 14.x, 16.14.0]
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -179,3 +179,24 @@ MetricsApiConfig(
 | buffer_length          | **default: 10** Sets the number of API calls that should be recieved before the requests are sent to ReadMe. |
 | allowed_http_hosts     | A list of HTTP hosts which should be logged to ReadMe. If this is present, a request will only be sent to ReadMe if its Host header matches one of the allowed hosts. |
 | timeout                | Timeout (in seconds) for calls back to the ReadMe Metrics API. Default 3 seconds. |
+
+## Development
+
+### Install dependencies:
+
+```sh
+# https://pypi.org/project/pipx/
+brew install pipx
+
+# https://virtualenv.pypa.io/en/latest/installation.html#via-pipx
+pipx install virtualenv
+# Create a virtual environment for dependencies to be installed into
+virtualenv venv
+
+# Go inside of the virtual environment
+# https://www.freecodecamp.org/news/how-to-manage-python-dependencies-using-virtual-environments/
+source ./venv/bin/activate
+
+# Then finally install dependencies
+pip install -r requirements.txt
+```

--- a/packages/python/requirements.txt
+++ b/packages/python/requirements.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black==22.3.0
 Django==3.2.12
 Flask==2.0.1
 pytest-mock==3.6.1


### PR DESCRIPTION
## 🧰 What's being changed?

Also added instructions for setting up a local python environment

https://github.com/psf/black/issues/2964#issuecomment-1080974737

## 🧬 Testing

Does CI pass? ✅
