### PR TITLE
fix(dotnet): update SDK to point to /v1/request 

### DIFF
--- a/packages/dotnet/Readme/ConstValues.cs
+++ b/packages/dotnet/Readme/ConstValues.cs
@@ -6,7 +6,6 @@
         public static readonly string version = "1.0.2";
         public static readonly int wait = 0;
         public static readonly string receive = null;
-        public static readonly string readmeApiEndpoints = "https://metrics.readme.io/request";
-        
+        public static readonly string readmeApiEndpoints = "https://metrics.readme.io/v1/request";
     }
 }

--- a/packages/dotnet/Readme/HarJsonTranslationLogics/ReadmeApiCaller.cs
+++ b/packages/dotnet/Readme/HarJsonTranslationLogics/ReadmeApiCaller.cs
@@ -27,6 +27,10 @@ namespace Readme.HarJsonTranslationLogics
                 string apiKey = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(_apiKey + ":"));
                 request.AddHeader("Authorization", apiKey);
                 request.AddParameter("application/json", _harJsonObject, ParameterType.RequestBody);
+                // TODO when we upgrade RestSharp to v1.0.7, this interface has been deprecated
+                // https://restsharp.dev/v107/#body-parameters=
+                // We should update this to:
+                // var response = await client.ExecuteAsync(request);
                 IRestResponse response = await client.ExecuteAsync(request);
                 return response.Content;
             }

--- a/packages/dotnet/ReadmeMetricsAPI3/Startup.cs
+++ b/packages/dotnet/ReadmeMetricsAPI3/Startup.cs
@@ -37,7 +37,7 @@ namespace ReadmeMetricsAPI3
                 //Or extract apikey from request body form or x-www-form-urlencoded by key as
                 // req.Form["key"];
 
-                context.Items["apiKey"] = context.Request.Headers["key"];
+                context.Items["apiKey"] = "apiKey";
                 context.Items["label"] = "username / company name";
                 context.Items["email"] = "email";
                 await next();

--- a/packages/dotnet/ReadmeMetricsAPI3/appsettings.json
+++ b/packages/dotnet/ReadmeMetricsAPI3/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
   "readme": {
-    "apiKey": "This is Readme API",
+    "apiKey": "This is your ReadMe API Key",
     "options": {
       "allowList": [],
       "denyList": [ "password", "secret", "private" ],

--- a/packages/dotnet/ReadmeMetricsAPI5/Startup.cs
+++ b/packages/dotnet/ReadmeMetricsAPI5/Startup.cs
@@ -37,7 +37,7 @@ namespace ReadmeMetricsAPI5
                 //Or extract apikey from request body form or x-www-form-urlencoded by key as
                 // req.Form["key"];
 
-                context.Items["apiKey"] = context.Request.Headers["key"];
+                context.Items["apiKey"] = "apiKey";
                 context.Items["label"] = "username / company name";
                 context.Items["email"] = "email";
                 await next();

--- a/packages/dotnet/ReadmeMetricsAPI5/appsettings.json
+++ b/packages/dotnet/ReadmeMetricsAPI5/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
   "readme": {
-    "apiKey": "This is Readme API",
+    "apiKey": "This is your ReadMe API Key",
     "options": {
       "allowList": [],
       "denyList": [ "password", "secret", "private" ],

--- a/packages/dotnet/ReadmeMetricsAPI6/Program.cs
+++ b/packages/dotnet/ReadmeMetricsAPI6/Program.cs
@@ -19,7 +19,7 @@ app.Use(async (context, next) =>
     //Or extract apikey from request body form or x-www-form-urlencoded by key as
     // context.Request.Form["key"];
 
-    context.Items["apiKey"] = context.Request.Headers["key"];
+    context.Items["apiKey"] = "apiKey";
     context.Items["label"] = "username / company name";
     context.Items["email"] = "email";
     await next();

--- a/packages/dotnet/ReadmeMetricsAPI6/ReadmeMetricsAPI6.csproj
+++ b/packages/dotnet/ReadmeMetricsAPI6/ReadmeMetricsAPI6.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RestSharp" Version="107.0.2" />
+    <PackageReference Include="RestSharp" Version="106.13.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/packages/dotnet/ReadmeMetricsAPI6/appsettings.json
+++ b/packages/dotnet/ReadmeMetricsAPI6/appsettings.json
@@ -8,7 +8,7 @@
   "AllowedHosts": "*",
 
   "readme": {
-    "apiKey": "This is Readme API",
+    "apiKey": "This is your ReadMe API Key",
     "options": {
       "allowList": [],
       "denyList": [ "password", "secret", "private" ],


### PR DESCRIPTION
## 🧰 What's being changed?
This is an updated API endpoint, we're deprecating the version-less one.

## 🧬 Testing

I've had to manually test this cos there are no automated tests for .net (yet!).
