### PR TITLE
ci: adding a new dependabot manifest for our node pkg

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,17 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - dependencies
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+
+  - package-ecosystem: npm
+    directory: "/packages/node"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
       - area:node
     commit-message:
       prefix: chore(deps)


### PR DESCRIPTION
## 🧰 What's being changed?

This adds a new Dependabot manifest for our Node SDK as Dependabot has been having issues lately properly apply changes to it.