### PR TITLE
fix: ensure all config files are included in the bundled output

### DIFF
--- a/packages/node/__tests__/config.test.ts
+++ b/packages/node/__tests__/config.test.ts
@@ -1,0 +1,8 @@
+import { access, constants } from 'fs';
+import { promisify } from 'util';
+import path from 'path';
+
+test('should have all config files in dist', () => {
+  const file = path.join(__dirname, '/../dist/src/config/localhost.json');
+  return expect(promisify(access)(file, constants.F_OK)).resolves.not.toThrow();
+});

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -9,5 +9,10 @@
     "resolveJsonModule": true,
     "baseUrl": "."
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*",
+    // We have to explicitly list these config files
+    // due to the dynamic require in certain envs
+    "src/config/*.json"
+  ]
 }


### PR DESCRIPTION
## 🧰 Changes

Have to be explicit about this because `include` by default only brings in
JS/TS files:

> If a glob pattern doesn’t include a file extension, then only files with
> supported extensions are included (e.g. .ts, .tsx, and .d.ts by default,
> with .js and .jsx if allowJs is set to true).

https://www.typescriptlang.org/tsconfig#include

## 🧬 QA & Testing
I tried to write an automated test for this but couldn't figure out the
best way to do it. In lieu of an automated test, you can run this from the root:

```sh
cd packages/node && npm run build && ls dist/src/config/localhost.json
```
