### PR TITLE
Datetime and development_mode boolean fixes - Flask - Python

### DIFF
--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -46,7 +46,7 @@ class PayloadBuilder:
         """
         self.denylist = denylist
         self.allowlist = allowlist
-        self.development_mode = "true" if development_mode else "false"
+        self.development_mode = development_mode
         self.grouping_function = grouping_function
         self.logger = logger
 

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -28,7 +28,7 @@ class ReadMeMetrics:
 
     def before_request(self):
         try:
-            request.rm_start_dt = str(datetime.utcnow())
+            request.rm_start_dt = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             request.rm_start_ts = int(time.time() * 1000)
             if "Content-Length" in request.headers or request.data:
                 request.rm_content_length = request.headers["Content-Length"] or "0"


### PR DESCRIPTION

## 🧰 Changes

development_mode is part of a dict being passed to json dump, this means the variable should still be a true Boolean until the json module converts it to JSON boolean representation. Currently, it is being set to a string value of "true" or "false" based on the passed boolean - this ends up inevitably causing errors when attempting to run the package.

For the datetime, the api seems to want it in zulu time format. Setting it to this format here rather than the traditional datetime to_string format.

