### PR TITLE
Added ignored content encoding parameter

### DIFF
--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -36,6 +36,7 @@ class Metrics:
             config.IS_DEVELOPMENT_MODE,
             config.GROUPING_FUNCTION,
             config.LOGGER,
+            config.IGNORED_CONTENT_ENCODING_TYPES,
         )
         self.queue = queue.Queue()
 

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -29,6 +29,8 @@ class MetricsApiConfig:
             send to ReadMe.
 
             If this option is configured, ONLY the allowlisted properties will be sent.
+        IGNORED_CONTENT_ENCODING_TYPES (List[str]): A list of content encoding types
+            readme should ignore.
         ALLOWED_HTTP_HOSTS (List[str]): A list of allowed http hosts for sending
             data to the ReadMe API.
         METRICS_API (str): Base URL of the ReadMe metrics API.
@@ -63,6 +65,7 @@ class MetricsApiConfig:
         denylist: List[str] = None,
         blacklist: List[str] = None,
         whitelist: List[str] = None,
+        ignored_content_encoding_types: List[str] = [],
         allowed_http_hosts: List[str] = None,
         timeout: int = 3,
     ):
@@ -104,6 +107,8 @@ class MetricsApiConfig:
                 sent.
             blacklist (List[str], optional): Deprecated, prefer denylist.
             whitelist (List[str], optional): Deprecated, prefer allowlist.
+            ignored_content_encoding_types (List[str]): A list of content encoding types
+            readme should ignore.
             allowed_http_hosts (List[str], optional): A list of HTTP hosts which should be
                 logged to ReadMe. If this is present, requests will only be sent to ReadMe
                 whose Host header matches one of the allowed hosts.
@@ -122,6 +127,7 @@ class MetricsApiConfig:
         self.IS_BACKGROUND_MODE = background_worker_mode
         self.DENYLIST = denylist or blacklist or []
         self.ALLOWLIST = allowlist or whitelist or []
+        self.IGNORED_CONTENT_ENCODING_TYPES = ignored_content_encoding_types
         self.ALLOWED_HTTP_HOSTS = allowed_http_hosts
         self.METRICS_API_TIMEOUT = timeout
         self.LOGGER = util_build_logger()

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -163,7 +163,7 @@ class PayloadBuilder:
             "httpVersion": request.environ["SERVER_PROTOCOL"],
             "headers": [{"name": k, "value": v} for (k, v) in headers.items()],
             "queryString": [{"name": k, "value": v} for (k, v) in params],
-            **post_data,
+            "postData": post_data,
         }
 
     def _build_response_payload(self, response: ResponseInfoWrapper) -> dict:

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -30,6 +30,9 @@ class ReadMeMetrics:
         try:
             request.rm_start_dt = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             request.rm_start_ts = int(time.time() * 1000)
+            content_encoding = getattr(request, "content_encoding", None)
+            if content_encoding in self.config.IGNORED_CONTENT_ENCODING_TYPES:
+                return
             if "Content-Length" in request.headers or request.data:
                 request.rm_content_length = request.headers["Content-Length"] or "0"
                 request.rm_body = request.data or ""

--- a/packages/python/readme_metrics/tests/PayloadBuilder_test.py
+++ b/packages/python/readme_metrics/tests/PayloadBuilder_test.py
@@ -68,6 +68,7 @@ class TestPayloadBuilder:
             config.IS_DEVELOPMENT_MODE,
             config.GROUPING_FUNCTION,
             config.LOGGER,
+            config.IGNORED_CONTENT_ENCODING_TYPES,
         )
 
     def getMetricData(self):

--- a/packages/python/readme_metrics/tests/redaction_test.py
+++ b/packages/python/readme_metrics/tests/redaction_test.py
@@ -78,6 +78,7 @@ def test_redaction_with_allowlist():
         development_mode=True,
         grouping_function=None,
         logger=logger,
+        ignored_content_encoding_types=[],
     )._redact_dict(mapping)
     assert allowlist_result == expected_allowlist_result
 
@@ -89,6 +90,7 @@ def test_redaction_with_denylist():
         development_mode=True,
         grouping_function=None,
         logger=logger,
+        ignored_content_encoding_types=[],
     )._redact_dict(mapping)
     assert denylist_result == expected_denylist_result
 
@@ -101,5 +103,6 @@ def test_redaction_with_both():
         development_mode=True,
         grouping_function=None,
         logger=logger,
+        ignored_content_encoding_types=[],
     )._redact_dict(mapping)
     assert denylist_result == expected_denylist_result

--- a/packages/python/setup.py
+++ b/packages/python/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="readme-metrics",
-    version="2.0.2",
+    version="2.0.3",
     author="ReadMe",
     author_email="support@readme.io",
     description="ReadMe API Metrics WSGI SDK",

--- a/packages/python/setup.py
+++ b/packages/python/setup.py
@@ -4,11 +4,11 @@ from setuptools import setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = importlib.import_module("readme_metrics").__version__
+# version = importlib.import_module("readme_metrics").__version__
 
 setup(
     name="readme-metrics",
-    version=version,
+    version="2.0.2",
     author="ReadMe",
     author_email="support@readme.io",
     description="ReadMe API Metrics WSGI SDK",


### PR DESCRIPTION
## 🧰 Changes

Added ignored_content_encoding_types parameter to the config and a check versus this in the pre_request lisener.

This is because certain compressed payload streams can have issues caused to them if they are read or copied in any way before the request is processed. 

