### PR TITLE
fix: pointing the php sdk at our `/v1/request` endpoint

### DIFF
--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -142,7 +142,7 @@ class Metrics
         // If not in development mode, all requests should be async.
         if (!$this->development_mode) {
             try {
-                $promise = $this->client->postAsync('/request', [
+                $promise = $this->client->postAsync('/v1/request', [
                     'headers' => $headers,
                     'json' => [$payload]
                 ]);
@@ -159,7 +159,7 @@ class Metrics
         }
 
         try {
-            $metrics_response = $this->client->post('/request', [
+            $metrics_response = $this->client->post('/v1/request', [
                 'headers' => $headers,
                 'json' => [$payload]
             ]);

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -143,7 +143,7 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
         $actual_request = array_shift($this->api_calls);
         $actual_request = $actual_request['request'];
 
-        $this->assertSame('/request', $actual_request->getRequestTarget());
+        $this->assertSame('/v1/request', $actual_request->getRequestTarget());
 
         $actual_payload = json_decode($actual_request->getBody(), true);
         $this->assertCount(1, $actual_payload);


### PR DESCRIPTION
## 🧰 Changes

Noticed this while walking through Metrics earlier today with @gratcliff but our PHP SDK is currently sending metrics to `/request` while all the others are to `/v1/request`.

## 🧬 QA & Testing

Here's the PHP test suite running, and failing, locally with the tests still pointing to the `/request` endpoint:

![Screen Shot 2022-07-19 at 4 31 17 PM](https://user-images.githubusercontent.com/33762/179865285-4d859526-9663-42cd-bcdc-216c7ad79ed4.png)

With tests updated to use `/v1/request`:

![Screen Shot 2022-07-19 at 4 32 05 PM](https://user-images.githubusercontent.com/33762/179865319-ed87c4e5-a052-4a1c-b8d1-05e5fc8eee12.png)