### PR TITLE
ci: cleaning up our monorepo splitting work to only split up the PHP SDK

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -14,6 +14,8 @@ This automatically happens via github action on pushes to main. We use [Deploy K
 
 ### Adding a new mirror
 
+> ℹ️ You only need to do this if the new package cannot be published from tagged releases or a monorepo structure (like PHP with Packagist).
+
 To add a new package (and a new mirrored repository), you have to generate a new SSH key, upload the public key to the mirrored repo and add the private key to the parent repo's secrets.
 
 1. Generating a new SSH key:
@@ -25,7 +27,7 @@ ssh-keygen -t ed25519 -C "$(git config user.email)" -f /tmp/new-ssh-key -N ""
 This will output a new key, associated with your email address to /tmp/new-ssh-key. The new key will have no passphrase because it will be used in a github action environment with no way to provide the passphrase.
 
 2. Upload this to our 1password account
-3. Add the public key portion to the "Deploy Keys" section in the mirror e.g. https://github.com/readmeio/metrics-sdks-node/settings/keys/new. Make sure you check "Allow write access" so it can push new code.
+3. Add the public key portion to the "Deploy Keys" section in the mirror e.g. https://github.com/readmeio/metrics-sdks-php/settings/keys/new. Make sure you check "Allow write access" so it can push new code.
 4. Add the private key portion to the "Actions secrets" section of the monorepo: https://github.com/readmeio/metrics-sdks/settings/secrets/actions/new
 5. Update `./bin/split.sh` and `./.github/workflows/split-monorepo.yml` to include the new mirror and SSH key.
 6. Update the main README.md to include information about the new package.

--- a/.github/workflows/split-monorepo.yml
+++ b/.github/workflows/split-monorepo.yml
@@ -18,10 +18,6 @@ jobs:
     - name: Split repository into git mirrors
       env:
         SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        METRICS_SDK_NODE_PRIVATE_KEY: ${{ secrets.METRICS_SDK_NODE_PRIVATE_KEY }}
         METRICS_SDK_PHP_PRIVATE_KEY: ${{ secrets.METRICS_SDK_PHP_PRIVATE_KEY }}
-        METRICS_SDK_PYTHON_PRIVATE_KEY: ${{ secrets.METRICS_SDK_PYTHON_PRIVATE_KEY }}
-        METRICS_SDK_RUBY_PRIVATE_KEY: ${{ secrets.METRICS_SDK_RUBY_PRIVATE_KEY }}
-        METRICS_SDK_DOTNET_PRIVATE_KEY: ${{ secrets.METRICS_SDK_DOTNET_PRIVATE_KEY }}
       run: ./bin/split.sh
       shell: bash

--- a/bin/split.sh
+++ b/bin/split.sh
@@ -34,20 +34,10 @@ function addSshKey() {
     fi
 }
 
-addSshKey sdks-node METRICS_SDK_NODE_PRIVATE_KEY
+# Because https://packagist.org/ works off by repository syncing, not published tags, in order to
+# publish the PHP SDK it cannot be contained within a monorepo so we need to split it off into a
+# read-only mirror we've got. Packagist then monitors this mirror for any changes and publishes
+# changes when we push code to it.
 addSshKey sdks-php METRICS_SDK_PHP_PRIVATE_KEY
-addSshKey sdks-python METRICS_SDK_PYTHON_PRIVATE_KEY
-addSshKey sdks-ruby METRICS_SDK_RUBY_PRIVATE_KEY
-addSshKey sdks-dotnet METRICS_SDK_DOTNET_PRIVATE_KEY
-
-remote sdks-node git@github.com:readmeio/metrics-sdks-node.git
 remote sdks-php git@github.com:readmeio/metrics-sdks-php.git
-remote sdks-python git@github.com:readmeio/metrics-sdks-python.git
-remote sdks-ruby git@github.com:readmeio/metrics-sdks-ruby.git
-remote sdks-dotnet git@github.com:readmeio/metrics-sdks-dotnet.git
-
-split 'packages/node' sdks-node
 split 'packages/php' sdks-php
-split 'packages/python' sdks-python
-split 'packages/ruby' sdks-ruby
-split 'packages/dotnet' sdks-dotnet


### PR DESCRIPTION
## 🧰 Changes

Because our PHP SDK is the only package of ours that cannot be published directly from this monorepo we don't need to mirror every SDK out to their own repositories.

After this is merged in I am going to **delete** the following repos:

* https://github.com/readmeio/metrics-sdks-dotnet
* https://github.com/readmeio/metrics-sdks-python
* https://github.com/readmeio/metrics-sdks-ruby

And because our Node SDK used to live at https://github.com/readmeio/metrics and was renamed to `metrics-sdks-node` I am going to **archive** https://github.com/readmeio/metrics-sdks-node.