### PR TITLE
feat(python): HAR consistency and overall cleanup

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version:
+          # https://endoflife.date/python
+          - 3.7 # EOL: June 27th, 2023
+          - 3.8 # EOL: October 14th, 2024
+          - 3.9 # EOL: October 5rd, 2025
+          - '3.10' # EOL: October 4rd, 2026
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,13 +26,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip3 install -r requirements.txt
+        run: make install
 
       - name: Check code standards
-        run: black --check .
+        run: make lint
 
       - name: Run tests
-        run: pytest
+        run: make test
 
   integration:
     runs-on: ubuntu-latest

--- a/packages/python/.pylintrc
+++ b/packages/python/.pylintrc
@@ -1,0 +1,25 @@
+[BASIC]
+good-names=
+    e,
+    # Metrics,
+    # MetricsApiConfig,
+    # MetricsMiddleware,
+    # PayloadBuilder,
+    # ResponseInfoWrapper,
+
+[FORMAT]
+max-line-length=120
+
+[MASTER]
+disable=
+    C0103, # invalid-name
+    C0114, # missing-module-docstring
+    C0115, # missing-class-docstring
+    C0116, # missing-function-docstring
+    C0207, # use-maxsplit-arg
+    C0301, # line-too-long
+    R0801, # duplicate-code
+    R0903, # too-few-public-methods
+    R0913, # too-many-arguments
+    W0201, # attribute-defined-outside-init
+    W0703, # broad-except

--- a/packages/python/.pylintrc
+++ b/packages/python/.pylintrc
@@ -3,7 +3,7 @@ max-line-length=100
 
 [MASTER]
 disable=
-    C0103, ; invalid-name
+    C0103, # invalid-name
     C0114, # missing-module-docstring
     C0115, # missing-class-docstring
     C0116, # missing-function-docstring

--- a/packages/python/.pylintrc
+++ b/packages/python/.pylintrc
@@ -1,23 +1,13 @@
-[BASIC]
-good-names=
-    e,
-    # Metrics,
-    # MetricsApiConfig,
-    # MetricsMiddleware,
-    # PayloadBuilder,
-    # ResponseInfoWrapper,
-
 [FORMAT]
-max-line-length=120
+max-line-length=100
 
 [MASTER]
 disable=
-    C0103, # invalid-name
+    C0103, ; invalid-name
     C0114, # missing-module-docstring
     C0115, # missing-class-docstring
     C0116, # missing-function-docstring
     C0207, # use-maxsplit-arg
-    C0301, # line-too-long
     R0801, # duplicate-code
     R0903, # too-few-public-methods
     R0913, # too-many-arguments

--- a/packages/python/Makefile
+++ b/packages/python/Makefile
@@ -2,7 +2,7 @@ install: # Install all dependencies
 	pip3 install -r requirements.txt
 
 lint: ## Run code standard checks
-	pylint --output-format=colorized readme_metrics/
+	pylint --output-format=colorized examples/ readme_metrics/
 	black --check .
 
 lint-fix: ## Run code formatting checks

--- a/packages/python/Makefile
+++ b/packages/python/Makefile
@@ -1,0 +1,15 @@
+install: # Install all dependencies
+	pip3 install -r requirements.txt
+
+lint: ## Run code standard checks
+	pylint --output-format=colorized readme_metrics/
+	black --check .
+
+lint-fix: ## Run code formatting checks
+	black .
+
+test: ## Run unit tests
+	pytest
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/packages/python/examples/flask/app.py
+++ b/packages/python/examples/flask/app.py
@@ -6,6 +6,7 @@ from readme_metrics.flask_readme import ReadMeMetrics
 app = Flask(__name__)
 
 
+# pylint: disable=W0613
 def grouping_function(request):
     return {
         # User's API Key
@@ -37,4 +38,4 @@ def hello_world():
 
 
 if __name__ == "__main__":
-    app.run(debug=False, host="127.0.0.1", port=os.getenv("PORT", 4000))
+    app.run(debug=False, host="127.0.0.1", port=os.getenv("PORT", "4000"))

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -2,9 +2,6 @@ import atexit
 import math
 import queue
 import threading
-import requests
-import json
-import importlib
 
 from readme_metrics import MetricsApiConfig
 from readme_metrics.publisher import publish_batch
@@ -59,7 +56,7 @@ class Metrics:
             # PayloadBuilder returns None when the grouping function returns
             # None (an indication that the request should not be logged.)
             self.config.LOGGER.debug(
-                f"Not enqueueing request, grouping function returned None"
+                "Not enqueueing request, grouping function returned None"
             )
             return
 
@@ -88,6 +85,6 @@ class Metrics:
     def host_allowed(self, host):
         if self.config.ALLOWED_HTTP_HOSTS:
             return host in self.config.ALLOWED_HTTP_HOSTS
-        else:
-            # If the allowed_http_hosts has not been set (None by default), send off the data to be queued
-            return True
+
+        # If `allowed_http_hosts`` has not been set (None by default), send off the data to be queued.
+        return True

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -11,8 +11,8 @@ from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
 
 class Metrics:
     """
-    This is the internal central controller class invoked by the ReadMe middleware. It
-    queues requests for submission. The submission is processed by readme_metrics.publisher.publish_batch().
+    This is the internal central controller class invoked by the ReadMe middleware. It queues
+    requests for submission for processing by `readme_metrics.publisher.publish_batch()`.
     """
 
     PACKAGE_NAME: str = "readme/metrics"
@@ -46,6 +46,7 @@ class Metrics:
             response (ResponseInfoWrapper): Response object
         """
         if not self.host_allowed(request.environ["HTTP_HOST"]):
+            # pylint: disable=C0301
             self.config.LOGGER.debug(
                 f"Not enqueueing request, host {request.environ['HTTP_HOST']} not in ALLOWED_HTTP_HOSTS"
             )
@@ -86,5 +87,6 @@ class Metrics:
         if self.config.ALLOWED_HTTP_HOSTS:
             return host in self.config.ALLOWED_HTTP_HOSTS
 
-        # If `allowed_http_hosts`` has not been set (None by default), send off the data to be queued.
+        # If `allowed_http_hosts`` has not been set (None by default), send off the data to be
+        # queued.
         return True

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-instance-attributes
 import importlib
 from typing import List, Any, Callable
 

--- a/packages/python/readme_metrics/MetricsMiddleware.py
+++ b/packages/python/readme_metrics/MetricsMiddleware.py
@@ -1,11 +1,13 @@
+# pylint: disable=too-many-locals
 import io
 import time
 import datetime
 
+from werkzeug import Request
+
 from readme_metrics.Metrics import Metrics
 from readme_metrics.MetricsApiConfig import MetricsApiConfig
 from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
-from werkzeug import Request
 
 
 class MetricsMiddleware:
@@ -69,7 +71,7 @@ class MetricsMiddleware:
                 # the environment variable CONTENT_LENGTH may be empty or missing
                 try:
                     content_length = int(environ.get("CONTENT_LENGTH", 0))
-                except (ValueError):
+                except ValueError:
                     content_length = 0
                 content_body = environ["wsgi.input"].read(content_length)
 

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -123,6 +123,7 @@ class PayloadBuilder:
                 )
         extra_fields = set(group.keys()).difference(["id", "email", "label"])
         if extra_fields:
+            # pylint: disable=C0301
             self.logger.warning(
                 "Grouping function included unexpected field(s) in response: %s; discarding those fields and logging request anyway",
                 extra_fields,

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -1,10 +1,12 @@
 from collections.abc import Mapping
+import importlib
 import json
 from json import JSONDecodeError
 from logging import Logger
-import sys
+import os
+import platform
 import time
-import importlib
+
 from typing import List, Optional
 from urllib import parse
 import uuid
@@ -74,9 +76,9 @@ class PayloadBuilder:
             "request": {
                 "log": {
                     "creator": {
-                        "name": __name__,
+                        "name": "readme-metrics (python)",
                         "version": importlib.import_module(__package__).__version__,
-                        "comment": sys.version,
+                        "comment": self._get_har_creator_comment(),
                     },
                     "entries": [
                         {
@@ -92,6 +94,17 @@ class PayloadBuilder:
         }
 
         return payload
+
+    def _get_har_creator_comment(self):
+        # arm64-darwin21.3.0/3.8.9
+        return (
+            platform.machine()
+            + "-"
+            + platform.system().lower()
+            + os.uname().release
+            + "/"
+            + platform.python_version()
+        )
 
     def _validate_group(self, group: Optional[dict]):
         if group is None:

--- a/packages/python/readme_metrics/django.py
+++ b/packages/python/readme_metrics/django.py
@@ -46,5 +46,5 @@ class MetricsMiddleware:
             # Errors in the Metrics SDK should never cause the application to
             # throw an error. Log it but don't re-raise.
             self.config.LOGGER.exception(e)
-        finally:
-            return response
+
+        return response

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -52,5 +52,5 @@ class ReadMeMetrics:
             # Errors in the Metrics SDK should never cause the application to
             # throw an error. Log it but don't re-raise.
             self.config.LOGGER.exception(e)
-        finally:
-            return response
+
+        return response

--- a/packages/python/readme_metrics/publisher.py
+++ b/packages/python/readme_metrics/publisher.py
@@ -1,9 +1,8 @@
 import os
 import importlib
 import json
-import math
-from queue import Empty, Queue
-import time
+
+from queue import Empty
 from urllib.parse import urljoin
 
 import requests

--- a/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
+++ b/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
@@ -1,12 +1,11 @@
-import pytest  # pylint: disable=import-error
-import requests
 import json
 
-from .fixtures import Environ
+import requests
+import pytest
 
 from readme_metrics import MetricsApiConfig
 from readme_metrics import MetricsMiddleware
-from readme_metrics.Metrics import Metrics
+from .fixtures import Environ
 
 # for this, I'm not exactly sure how to test the __call__ function
 # possible options I considered was making a mock server inside this test case

--- a/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
+++ b/packages/python/readme_metrics/tests/MetricsMiddleware_test.py
@@ -1,42 +1,8 @@
-import json
-
-import requests
 import pytest
 
 from readme_metrics import MetricsApiConfig
 from readme_metrics import MetricsMiddleware
 from .fixtures import Environ
-
-# for this, I'm not exactly sure how to test the __call__ function
-# possible options I considered was making a mock server inside this test case
-# connected to the middleware somehow
-
-
-class MockServer:
-    def __init__(self):
-        # Not working when I tried the first time, but might as well write it
-        # self.app = Flask(__name__)
-        # self.app.wsgi_app = MetricsMiddleware(#config details)
-        pass
-
-    # I think requests package shouldn't be used cos we cant get the request body so
-    # I'm using it as placeholder
-    def doGET(self, url, params):
-        return requests.get(url, params)
-
-    def doPOST(self, url, data):
-        return requests.post(url, data=json.dumps(dict(data)))
-
-    def doPUT(self, url, data):
-        return requests.put(url, data=json.dumps(dict(data)))
-
-    def mockWSGI(self):
-        # create a moch wsgi that can call metrics middleware
-        pass
-
-    def sendRequestsAtOnce(self, requestQueue):
-        # accumulate the requests and send at once to the mockWSGI
-        return requestQueue
 
 
 # Mock middleware config
@@ -57,13 +23,13 @@ class MetricsCoreMock:
 
 # Mock application
 class MockApplication:
-    def __init__(self, responseObjectString):
-        self.responseObjectString = responseObjectString
+    def __init__(self, res):
+        self.res = res
 
     def __call__(self, environ, start_response):
         self.environ = environ
         self.start_response = start_response
-        return [self.responseObjectString.encode("utf-8")]
+        return [self.res.encode("utf-8")]
 
     def mockStartResponse(self, status, headers):
         self.status = status
@@ -71,54 +37,56 @@ class MockApplication:
 
 
 class TestMetricsMiddleware:
-    def setUp(self):
-        self.mockserver = MockServer()
+    def test_get_request(self):
+        req = b""
+        res = "{ responseObject: 'value' }"
+        environ = Environ.MockEnviron().getEnvironForRequest(req, "GET")
+        app = MockApplication(res)
 
-    # @pytest.mark.skip(reason="@todo")
-    def testNoRequest(self):
-        pass
-
-    def testGetRequest(self):
-        emptyByteString = b""
-        responseObjectString = "{ responseObject: 'value' }"
-        environ = Environ.MockEnviron().getEnvironForRequest(emptyByteString, "GET")
-        app = MockApplication(responseObjectString)
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, mockMiddlewareConfig())
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
-        assert metrics.req.data == emptyByteString
+
+        assert metrics.req.data == req
         assert metrics.req.method == "GET"
-        assert metrics.res.body == responseObjectString
+        assert metrics.res.body == res
 
-    def testEmptyPostRequest(self):
-        jsonString = b""
-        responseObjectString = "{ responseObject: 'value' }"
-        environ = Environ.MockEnviron().getEnvironForRequest(jsonString, "POST")
-        app = MockApplication(responseObjectString)
+    def test_empty_post_request(self):
+        req = b""
+        res = "{ responseObject: 'value' }"
+        environ = Environ.MockEnviron().getEnvironForRequest(req, "POST")
+        app = MockApplication(res)
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, mockMiddlewareConfig())
         middleware.metrics_core = metrics
-        next(middleware(environ, app.mockStartResponse))
-        assert metrics.req.data == jsonString
-        assert metrics.req.method == "POST"
-        assert metrics.res.body == responseObjectString
 
-    def testNonEmptyPostRequest(self):
-        jsonString = b"{abc: 123}"
-        responseObjectString = "{ responseObject: 'value' }"
-        environ = Environ.MockEnviron().getEnvironForRequest(jsonString, "POST")
-        app = MockApplication(responseObjectString)
+        next(middleware(environ, app.mockStartResponse))
+
+        assert metrics.req.data == req
+        assert metrics.req.method == "POST"
+        assert metrics.res.body == res
+
+    def test_non_empty_post_request(self):
+        req = b"{abc: 123}"
+        res = "{ responseObject: 'value' }"
+        environ = Environ.MockEnviron().getEnvironForRequest(req, "POST")
+        app = MockApplication(res)
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, mockMiddlewareConfig())
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
-        assert metrics.req.data == jsonString
+
+        assert metrics.req.data == req
         assert metrics.req.method == "POST"
-        assert metrics.res.body == responseObjectString
+        assert metrics.res.body == res
 
     @pytest.mark.skip(reason="@todo")
-    def testMultipleRequests(self):
+    def test_multiple_requests(self):
         # Test if multiple requests got through and processed
         # check by using the length of the request queue and loop by calling the
         # middleware for that length
@@ -126,18 +94,18 @@ class TestMetricsMiddleware:
         pass
 
     @pytest.mark.skip(reason="@todo")
-    def testClosed(self):
+    def test_closed(self):
         # Test if iterable got closed properly
         pass
 
     # Other tests that I think can be tested, but unsure if this should be tested in
     # this section
     @pytest.mark.skip(reason="@todo")
-    def testHeaders(self):
+    def test_headers(self):
         # Test to verify if the response header is passed correctly
         pass
 
     @pytest.mark.skip(reason="@todo")
-    def testStatus(self):
+    def test_status(self):
         # Test to verify if the response status is passed correctly
         pass

--- a/packages/python/readme_metrics/tests/PayloadBuilder_test.py
+++ b/packages/python/readme_metrics/tests/PayloadBuilder_test.py
@@ -1,13 +1,13 @@
-import pytest  # pylint: disable=import-error
-import requests
 import json
 import uuid
 
-from .fixtures import Environ
+import requests
+import pytest
 
 from readme_metrics import MetricsApiConfig
 from readme_metrics import MetricsMiddleware
 from readme_metrics.PayloadBuilder import PayloadBuilder
+from .fixtures import Environ
 
 
 # fetch json requests
@@ -75,7 +75,7 @@ class TestPayloadBuilder:
         res = None
         return res
 
-    def compareRequests(self, fromReq, fromPayload):
+    def compareRequests(self):
         # Compare the two contents and check if they are similar(?)
         return True
 
@@ -307,12 +307,12 @@ class TestPayloadBuilder:
     def testProduction(self):
         config = self.mockMiddlewareConfig(development_mode=False)
         payload = self.createPayload(config)
-        assert payload.development_mode == False
+        assert payload.development_mode is False
 
     def testDevelopment(self):
         config = self.mockMiddlewareConfig(development_mode=True)
         payload = self.createPayload(config)
-        assert payload.development_mode == True
+        assert payload.development_mode is True
 
     def testUuid(self):
         config = self.mockMiddlewareConfig(development_mode=True)

--- a/packages/python/readme_metrics/tests/PayloadBuilder_test.py
+++ b/packages/python/readme_metrics/tests/PayloadBuilder_test.py
@@ -1,28 +1,10 @@
 import json
 import uuid
 
-import requests
-import pytest
-
 from readme_metrics import MetricsApiConfig
 from readme_metrics import MetricsMiddleware
 from readme_metrics.PayloadBuilder import PayloadBuilder
 from .fixtures import Environ
-
-
-# fetch json requests
-class DataFetcher:
-    def getJSON(self, url):
-        res = requests.get(url)
-        return res.json()
-
-    def postJSON(self, url, param):
-        res = requests.post(url, data=json.dumps(dict(param)))
-        return res.json()
-
-    def putJSON(self, url, param):
-        res = requests.put(url, data=json.dumps(dict(param)))
-        return res.json()
 
 
 class MetricsCoreMock:
@@ -32,13 +14,13 @@ class MetricsCoreMock:
 
 
 class MockApplication:
-    def __init__(self, responseObjectString):
-        self.responseObjectString = responseObjectString
+    def __init__(self, res):
+        self.res = res
 
     def __call__(self, environ, start_response):
         self.environ = environ
         self.start_response = start_response
-        return [self.responseObjectString.encode("utf-8")]
+        return [self.res.encode("utf-8")]
 
     def mockStartResponse(self, status, headers):
         self.status = status
@@ -55,9 +37,6 @@ class TestPayloadBuilder:
 
     Basic pattern is create payload, get data, compare, then assert.
     """
-
-    def setUp(self):
-        self.data_fetcher = DataFetcher()
 
     def createPayload(self, config):
         # use this to test different blacklist/whitelist/devmode/groupfunc
@@ -98,63 +77,57 @@ class TestPayloadBuilder:
             whitelist=kwargs.get("whitelist", []),
         )
 
-    def testDenylist(self):
-
-        # Tests when the website is blacklisted
+    def test_denylist(self):
         config = self.mockMiddlewareConfig(denylist=["password"])
 
-        jsonString = json.dumps({"ok": 123, "password": 456}).encode()
-        responseObjectString = "{ 'responseObject': 'value' }"
-        environ = Environ.MockEnviron().getEnvironForRequest(jsonString, "POST")
-        app = MockApplication(responseObjectString)
+        req = json.dumps({"ok": 123, "password": 456}).encode()
+        environ = Environ.MockEnviron().getEnvironForRequest(req, "POST")
+        app = MockApplication("{ 'responseObject': 'value' }")
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
         text = data["request"]["log"]["entries"][0]["request"]["text"]
 
-        assert "ok" in text
-        assert "123" in text
-        assert "password" in text
-        assert "456" not in text
-        assert "[REDACTED]" in text
+        assert text == '{"ok": 123, "password": "[REDACTED]"}'
 
-    def testAllowlist(self):
+    def test_allowlist(self):
         config = self.mockMiddlewareConfig(allowlist=["ok"])
 
-        jsonString = json.dumps({"ok": 123, "password": 456}).encode()
-        responseObjectString = "{ 'responseObject': 'value' }"
-        environ = Environ.MockEnviron().getEnvironForRequest(jsonString, "POST")
-        app = MockApplication(responseObjectString)
+        req = json.dumps({"ok": 123, "password": 456}).encode()
+        environ = Environ.MockEnviron().getEnvironForRequest(req, "POST")
+        app = MockApplication("{ 'responseObject': 'value' }")
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
         text = data["request"]["log"]["entries"][0]["request"]["text"]
 
-        assert "ok" in text
-        assert "123" in text
-        assert "password" in text
-        assert "456" not in text
-        assert "[REDACTED]" in text
+        assert text == '{"ok": 123, "password": "[REDACTED]"}'
 
-    def testDeprecatedBlackListed(self):
-
-        # Tests when the website is blacklisted
+    def test_deprecated_blacklist(self):
         config = self.mockMiddlewareConfig(blacklist=["password"])
 
-        jsonString = json.dumps({"ok": 123, "password": 456}).encode()
-        responseObjectString = "{ 'responseObject': 'value' }"
-        environ = Environ.MockEnviron().getEnvironForRequest(jsonString, "POST")
-        app = MockApplication(responseObjectString)
+        req = json.dumps({"ok": 123, "password": 456}).encode()
+        environ = Environ.MockEnviron().getEnvironForRequest(req, "POST")
+        app = MockApplication("{ 'responseObject': 'value' }")
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
         text = data["request"]["log"]["entries"][0]["request"]["text"]
@@ -165,17 +138,19 @@ class TestPayloadBuilder:
         assert "456" not in text
         assert "[REDACTED]" in text
 
-    def testDeprecatedWhiteListed(self):
+    def test_deprecated_whitelist(self):
         config = self.mockMiddlewareConfig(whitelist=["ok"])
 
-        jsonString = json.dumps({"ok": 123, "password": 456}).encode()
-        responseObjectString = "{ 'responseObject': 'value' }"
-        environ = Environ.MockEnviron().getEnvironForRequest(jsonString, "POST")
-        app = MockApplication(responseObjectString)
+        req = json.dumps({"ok": 123, "password": 456}).encode()
+        environ = Environ.MockEnviron().getEnvironForRequest(req, "POST")
+        app = MockApplication("{ 'responseObject': 'value' }")
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
         text = data["request"]["log"]["entries"][0]["request"]["text"]
@@ -186,7 +161,7 @@ class TestPayloadBuilder:
         assert "456" not in text
         assert "[REDACTED]" in text
 
-    def testGroupingFunction(self):
+    def test_grouping_function(self):
         config = self.mockMiddlewareConfig(
             grouping_function=lambda req: {
                 "api_key": "spam",
@@ -195,13 +170,15 @@ class TestPayloadBuilder:
             }
         )
 
-        responseObjectString = "{ 'responseObject': 'value' }"
         environ = Environ.MockEnviron().getEnvironForRequest(b"", "POST")
-        app = MockApplication(responseObjectString)
+        app = MockApplication("{ 'responseObject': 'value' }")
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
         group = data["group"]
@@ -210,23 +187,26 @@ class TestPayloadBuilder:
         assert group["email"] == "flavor@spam.musubi"
         assert group["label"] == "Spam Musubi"
 
-    def testGroupingFunctionNone(self):
-        # PayloadBuilder should return None if the grouping_function returns
-        # None (which means not to log the request).
+    # `PayloadBuilder`` should return None if the `grouping_function`` returns
+    # `None` (which means not to log the request).
+    def test_grouping_function_that_returns_none(self):
         config = self.mockMiddlewareConfig(grouping_function=lambda req: None)
 
-        responseObjectString = "{ 'responseObject': 'value' }"
         environ = Environ.MockEnviron().getEnvironForRequest(b"", "POST")
-        app = MockApplication(responseObjectString)
+        app = MockApplication("{ 'responseObject': 'value' }")
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload_builder = self.createPayload(config)
         payload = payload_builder(metrics.req, metrics.res)
+
         assert payload is None
 
-    def testDeprecatedIDField(self):
+    def test_deprecated_id_grouping(self):
         config = self.mockMiddlewareConfig(
             grouping_function=lambda req: {
                 "id": "spam",
@@ -235,13 +215,15 @@ class TestPayloadBuilder:
             }
         )
 
-        responseObjectString = "{ 'responseObject': 'value' }"
         environ = Environ.MockEnviron().getEnvironForRequest(b"", "POST")
-        app = MockApplication(responseObjectString)
+        app = MockApplication("{ 'responseObject': 'value' }")
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
         group = data["group"]
@@ -250,7 +232,7 @@ class TestPayloadBuilder:
         assert group["email"] == "flavor@spam.musubi"
         assert group["label"] == "Spam Musubi"
 
-    def testGroupingFunctionValidationWhenMissingId(self):
+    def test_grouping_function_validation_when_missing_id(self):
         config = self.mockMiddlewareConfig(
             grouping_function=lambda req: {
                 "email": "flavor@spam.musubi",
@@ -258,23 +240,23 @@ class TestPayloadBuilder:
             }
         )
 
-        responseObjectString = "{ 'responseObject': 'value' }"
         environ = Environ.MockEnviron().getEnvironForRequest(b"", "POST")
-        app = MockApplication(responseObjectString)
+        app = MockApplication("{ 'responseObject': 'value' }")
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
 
-        # When the "id" and "api_key" fields are both missing,
-        # the payload should be None
+        # When the `id` and `api_key` fields are both missing, the payload should be `None`
         assert data is None
 
-    def testGroupingFunctionValidationWhenExtraFields(self):
-        # Extra fields included in the grouping function response
-        # should be stripped from the payload
+    # Extra fields included in the grouping function response should be stripped from the payload.
+    def test_grouping_function_validation_when_extra_fields_present(self):
         config = self.mockMiddlewareConfig(
             grouping_function=lambda req: {
                 "id": "spam",
@@ -284,99 +266,49 @@ class TestPayloadBuilder:
             }
         )
 
-        responseObjectString = "{ 'responseObject': 'value' }"
+        response = "{ 'responseObject': 'value' }"
         environ = Environ.MockEnviron().getEnvironForRequest(b"", "POST")
-        app = MockApplication(responseObjectString)
+        app = MockApplication(response)
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
+
         assert isinstance(data, dict)
         assert "group" in data
-        group = data["group"]
-
-        expected_group = {
+        assert data["group"] == {
             "id": "spam",
             "email": "flavor@spam.musubi",
             "label": "Spam Musubi",
         }
-        assert group == expected_group
 
-    def testProduction(self):
+    def test_production_mode(self):
         config = self.mockMiddlewareConfig(development_mode=False)
         payload = self.createPayload(config)
         assert payload.development_mode is False
 
-    def testDevelopment(self):
+    def test_development_mode(self):
         config = self.mockMiddlewareConfig(development_mode=True)
         payload = self.createPayload(config)
         assert payload.development_mode is True
 
-    def testUuid(self):
+    def test_uuid_generation(self):
         config = self.mockMiddlewareConfig(development_mode=True)
-        responseObjectString = "{ 'responseObject': 'value' }"
         environ = Environ.MockEnviron().getEnvironForRequest(b"", "POST")
-        app = MockApplication(responseObjectString)
+        app = MockApplication("{ 'responseObject': 'value' }")
+
         metrics = MetricsCoreMock()
         middleware = MetricsMiddleware(app, config)
         middleware.metrics_core = metrics
+
         next(middleware(environ, app.mockStartResponse))
+
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
+
         assert data["_id"] == str(uuid.UUID(data["_id"], version=4))
-
-    # for test GET/POST/PUT I'm putting the status code tests for now since we cant
-    # verify the body yet for status 401 and 403, they can also be moved to
-    # blacklisted(?)
-    @pytest.mark.skip(reason="@todo")
-    def testGET(self):
-        # payload = createPayload(MetricsApiConfig(#params here))
-
-        # Test GET with 200
-        # jsonRes = self.data_fetcher.getJSON(url)
-        # readMeRes = self.getMetricData()
-        # similar = compareRequests(jsonRes, readMeRes)
-        # self.assertTrue(similar)
-
-        # same pattern with these:
-        # Test GET with 400 (Bad Request)
-        # Test GET with 401 (Unauthorized)
-        # Test GET with 403 (Forbidden)
-        # Test GET with 404 (Not Found)
-        pass
-
-    @pytest.mark.skip(reason="@todo")
-    def testPOST(self):
-        # payload = createPayload(MetricsApiConfig(#params here))
-
-        # Test POST with 200
-        # jsonRes = self.data_fetcher.postJSON(url, param)
-        # readMeRes = self.getMetricData()
-        # similar = compareRequests(jsonRes, readMeRes)
-        # self.assertTrue(similar)
-
-        # same pattern with these:
-        # Test POST with 400 (Bad Request)
-        # Test POST with 401 (Unauthorized)
-        # Test POST with 403 (Forbidden)
-        # Test POST with 404 (Not Found)
-        pass
-
-    @pytest.mark.skip(reason="@todo")
-    def testPUT(self):
-        # payload = createPayload(MetricsApiConfig(#params here))
-
-        # Test PUT with 200
-        # jsonRes = self.data_fetcher.putJSON(url, param)
-        # readMeRes = self.getMetricData()
-        # similar = compareRequests(jsonRes, readMeRes)
-        # self.assertTrue(similar)
-
-        # same pattern with these:
-        # Test PUT with 400 (Bad Request)
-        # Test PUT with 401 (Unauthorized)
-        # Test PUT with 403 (Forbidden)
-        # Test PUT with 404 (Not Found)
-        pass

--- a/packages/python/readme_metrics/tests/PayloadBuilder_test.py
+++ b/packages/python/readme_metrics/tests/PayloadBuilder_test.py
@@ -312,3 +312,22 @@ class TestPayloadBuilder:
         data = payload(metrics.req, metrics.res)
 
         assert data["_id"] == str(uuid.UUID(data["_id"], version=4))
+
+    def test_har_creator(self):
+        config = self.mockMiddlewareConfig(development_mode=True)
+        environ = Environ.MockEnviron().getEnvironForRequest(b"", "POST")
+        app = MockApplication("{ 'responseObject': 'value' }")
+
+        metrics = MetricsCoreMock()
+        middleware = MetricsMiddleware(app, config)
+        middleware.metrics_core = metrics
+
+        next(middleware(environ, app.mockStartResponse))
+
+        payload = self.createPayload(config)
+        data = payload(metrics.req, metrics.res)
+        creator = data["request"]["log"]["creator"]
+
+        assert creator["name"] == "readme-metrics (python)"
+        assert isinstance(creator["version"], str)
+        assert isinstance(creator["comment"], str)

--- a/packages/python/readme_metrics/tests/django_test.py
+++ b/packages/python/readme_metrics/tests/django_test.py
@@ -1,9 +1,6 @@
 from datetime import datetime, timedelta
-import os
 import time
-from unittest.mock import Mock, MagicMock, patch
-
-import pytest
+from unittest.mock import Mock
 
 from readme_metrics import MetricsApiConfig
 from readme_metrics.django import MetricsMiddleware

--- a/packages/python/readme_metrics/tests/fixtures/Environ.py
+++ b/packages/python/readme_metrics/tests/fixtures/Environ.py
@@ -1,16 +1,19 @@
-import json
 import io
-import os
+import json
 
 from werkzeug import wsgi
 
 
 class MockEnviron:
     def __init__(self):
-        with open("./readme_metrics/tests/fixtures/environ_get.json") as json_file:
+        with open(
+            "./readme_metrics/tests/fixtures/environ_get.json", encoding="utf-8"
+        ) as json_file:
             self.environGetData = json.load(json_file)
 
-        with open("./readme_metrics/tests/fixtures/environ_post.json") as json_file:
+        with open(
+            "./readme_metrics/tests/fixtures/environ_post.json", encoding="utf-8"
+        ) as json_file:
             self.environPostData = json.load(json_file)
 
     def getEnvironForRequest(self, jsonByteString, httpRequestMethod):

--- a/packages/python/readme_metrics/tests/flask_test.py
+++ b/packages/python/readme_metrics/tests/flask_test.py
@@ -19,7 +19,7 @@ class TestFlaskExtension:
     def setUp(self):
         pass
 
-    def testInit(self):
+    def test_init(self):
         # the extension should register itself with the Flask application
         # provided to the constructor
         app = Mock()
@@ -27,7 +27,7 @@ class TestFlaskExtension:
         app.before_request.assert_called_with(extension.before_request)
         app.after_request.assert_called_with(extension.after_request)
 
-    def testBeforeRequest(self):
+    def test_before_request(self):
         app = Flask(__name__)
         extension = ReadMeMetrics(config=mock_config, app=app)
         with app.test_request_context("/"):
@@ -47,7 +47,7 @@ class TestFlaskExtension:
             current_millis = time.time() * 1000.0
             assert abs(current_millis - req_start_millis) < 1000.00
 
-    def testAfterRequest(self):
+    def test_after_request(self):
         app = Flask(__name__)
         print("hello")
         extension = ReadMeMetrics(config=mock_config, app=app)

--- a/packages/python/readme_metrics/tests/flask_test.py
+++ b/packages/python/readme_metrics/tests/flask_test.py
@@ -1,10 +1,8 @@
 from datetime import datetime, timedelta
 import time
-from unittest.mock import Mock, MagicMock
-from werkzeug.datastructures import EnvironHeaders
+from unittest.mock import Mock
 
 from flask import Flask, request
-import pytest
 from readme_metrics import MetricsApiConfig
 from readme_metrics.flask_readme import ReadMeMetrics
 from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper

--- a/packages/python/readme_metrics/tests/redaction_test.py
+++ b/packages/python/readme_metrics/tests/redaction_test.py
@@ -1,6 +1,5 @@
 import logging
 
-import pytest  # pylint: disable=import-error
 from readme_metrics.PayloadBuilder import PayloadBuilder
 
 
@@ -78,7 +77,7 @@ def test_redaction_with_allowlist():
         development_mode=True,
         grouping_function=None,
         logger=logger,
-    )._redact_dict(mapping)
+    ).redact_dict(mapping)
     assert allowlist_result == expected_allowlist_result
 
 
@@ -89,7 +88,7 @@ def test_redaction_with_denylist():
         development_mode=True,
         grouping_function=None,
         logger=logger,
-    )._redact_dict(mapping)
+    ).redact_dict(mapping)
     assert denylist_result == expected_denylist_result
 
 
@@ -101,5 +100,5 @@ def test_redaction_with_both():
         development_mode=True,
         grouping_function=None,
         logger=logger,
-    )._redact_dict(mapping)
+    ).redact_dict(mapping)
     assert denylist_result == expected_denylist_result

--- a/packages/python/requirements.txt
+++ b/packages/python/requirements.txt
@@ -1,6 +1,7 @@
 black==22.3.0
 Django==3.2.14
 Flask==2.0.1
+pylint==2.14.5
 pytest-mock==3.6.1
 pytest==7.1.2
 requests==2.25.1


### PR DESCRIPTION
| 🚥 Fix RM-5025, #415, #416 |
| :-- |

## 🧰 Changes

* [x] Overhauling our HAR `creator` field that we're setting so it's more consistent with the other SDKs.
* [x] Incorporating [Pylint](https://pylint.pycqa.org/en/latest/) into our linting flow and resolving some issues it uncovered.
* [x] Setting up CI to run tests against all currently supported versions of Python.
* [x] Setting up a `Makefile` in the run dependency installation, linting, and test commands.

### HAR changes

| | Before | After |
| :--- | :--- | :--- |
| `creator.name` | readme_metrics.PayloadBuilder | readme/metrics (python) |
| `creator.version` | 2.0.1 | 2.0.1 |
| `creator.comment` | 3.8.9 (default, Apr 13 2022, 08:48:06) <br />[Clang 13.1.6 (clang-1316.0.21.2.5)] | arm64-darwin21.3.0/3.8.9 |

## 🧬 QA & Testing

All existing tests are/should be still passing.