### PR TITLE
feat: splitting out the python dev deps into a separate requirements file

### DIFF
--- a/.alexignore
+++ b/.alexignore
@@ -1,3 +1,4 @@
 CHANGELOG.md
 packages/php/vendor/
 packages/python/requirements.txt
+packages/python/requirements.dev.txt

--- a/packages/python/Makefile
+++ b/packages/python/Makefile
@@ -1,5 +1,6 @@
 install: # Install all dependencies
 	pip3 install -r requirements.txt
+	pip3 install -r requirements.dev.txt
 
 lint: ## Run code standard checks
 	pylint --output-format=colorized examples/ readme_metrics/

--- a/packages/python/requirements.dev.txt
+++ b/packages/python/requirements.dev.txt
@@ -1,0 +1,4 @@
+black==22.3.0
+pylint==2.14.5
+pytest-mock==3.6.1
+pytest==7.1.2

--- a/packages/python/requirements.txt
+++ b/packages/python/requirements.txt
@@ -1,8 +1,4 @@
-black==22.3.0
 Django==3.2.15
 Flask==2.0.1
-pylint==2.14.5
-pytest-mock==3.6.1
-pytest==7.1.2
 requests==2.25.1
 Werkzeug==2.0.1

--- a/packages/python/setup.py
+++ b/packages/python/setup.py
@@ -11,11 +11,11 @@ setup(
     version=version,
     author="ReadMe",
     author_email="support@readme.io",
-    description="ReadMe API Metrics WSGI SDK",
+    description="ReadMe API Metrics SDK",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/readmeio/metrics-sdks/tree/main/packages/python",
     packages=["readme_metrics"],
-    install_requires=["requests"],
+    install_requires=["requests", "Werkzeug"],
     extras_require={"Flask": ["Flask"], "Django": ["Django"]},
 )


### PR DESCRIPTION
## 🧰 Changes

* [x] Splitting out dev-only dependencies in the Python SDK into a separate `requirements.dev.txt` file.
* [x] Adding `Werkzeug` as a required dependency in the package setup config as it's, well, required.
* [x] Removing mention of WSGI from the package description as it handles more than just WSGI frameworks.