### PR TITLE
feat(node): HAR consistency

### DIFF
--- a/packages/node/Makefile
+++ b/packages/node/Makefile
@@ -1,0 +1,14 @@
+install: # Install all dependencies
+	npm ci
+
+lint: ## Run code standard checks
+	npx eslint .
+
+lint-fix: ## Attempt to automatically fix any code standard violations
+	npx eslint --fix .
+
+test: ## Run unit tests
+	npx jest --coverage
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/packages/node/__tests__/lib/construct-payload.test.ts
+++ b/packages/node/__tests__/lib/construct-payload.test.ts
@@ -1,26 +1,14 @@
 import type { LogOptions, PayloadData } from '../../src/lib/construct-payload';
 
 import * as http from 'http';
+import os from 'os';
 import * as qs from 'querystring';
 
 import { isValidUUIDV4 } from 'is-valid-uuid-v4';
 import request from 'supertest';
 
-import packageJson from '../../package.json';
+import pkg from '../../package.json';
 import { constructPayload } from '../../src/lib/construct-payload';
-
-function fixPlatform(platform: string): 'mac' | 'windows' | 'linux' | 'unknown' {
-  switch (platform) {
-    case 'darwin':
-      return 'mac';
-    case 'win32':
-      return 'windows';
-    case 'linux':
-      return 'linux';
-    default:
-      return 'unknown';
-  }
-}
 
 function createApp(options?: LogOptions, payloadData?: PayloadData) {
   const requestListener = function (req: http.IncomingMessage, res: http.ServerResponse) {
@@ -105,9 +93,9 @@ describe('constructPayload()', () => {
       .post('/')
       .expect(({ body }) => {
         expect(body.request.log.creator).toStrictEqual({
-          name: packageJson.name,
-          version: packageJson.version,
-          comment: `${fixPlatform(process.platform)}/${process.version}`,
+          name: 'readme-metrics (node)',
+          version: pkg.version,
+          comment: `${os.arch()}-${os.platform()}${os.release()}/${process.versions.node}`,
         });
       }));
 

--- a/packages/node/src/lib/construct-payload.ts
+++ b/packages/node/src/lib/construct-payload.ts
@@ -2,11 +2,12 @@ import type { OutgoingLogBody } from './metrics-log';
 import type { ServerResponse, IncomingMessage } from 'http';
 import type { TLSSocket } from 'tls';
 
+import os from 'os';
 import { URL } from 'url';
 
 import { v4 as uuidv4 } from 'uuid';
 
-import { name, version } from '../../package.json';
+import { version } from '../../package.json';
 
 import processRequest from './process-request';
 import processResponse from './process-response';
@@ -95,25 +96,6 @@ export interface PayloadData {
   responseBody?: string;
 }
 
-/**
- * Translates Nodes platform strings into the allowed metrics platform strings
- *
- * @param platform
- * @returns
- */
-function fixPlatform(platform: string): 'mac' | 'windows' | 'linux' | 'unknown' {
-  switch (platform) {
-    case 'darwin':
-      return 'mac';
-    case 'win32':
-      return 'windows';
-    case 'linux':
-      return 'linux';
-    default:
-      return 'unknown';
-  }
-}
-
 export function constructPayload(
   req: IncomingMessage,
   res: ServerResponse,
@@ -133,7 +115,13 @@ export function constructPayload(
     development: !!logOptions?.development,
     request: {
       log: {
-        creator: { name, version, comment: `${fixPlatform(process.platform)}/${process.version}` },
+        version: '1.2',
+        creator: {
+          name: 'readme-metrics (node)',
+          version,
+          // x64-darwin21.3.0/14.19.3
+          comment: `${os.arch()}-${os.platform()}${os.release()}/${process.versions.node}`,
+        },
         entries: [
           {
             pageref: payloadData.routePath
@@ -151,7 +139,6 @@ export function constructPayload(
             },
           },
         ],
-        version: '', // what har version are we using? does it matter?
       },
     },
   };


### PR DESCRIPTION
| 🚥 Fix RM-5025, #415, #416 |
| :-- |

## 🧰 Changes

* [x] Overhauling our HAR `creator` field that we're setting so it's more consistent with the other SDKs.

### HAR changes

| | Before | After |
| :--- | :--- | :--- |
| `creator.name` | readmeio | readme-metrics (node) |
| `creator.version` | 5.2.1 | 5.2.1 |
| `creator.comment` | mac/v14.19.3 | x64-darwin21.3.0/14.19.3 |

## 🧬 QA & Testing

All existing tests are/should be still passing.
