### PR TITLE
feat(dotnet): HAR consistency

### DIFF
--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
@@ -112,7 +112,7 @@ namespace ReadMe.HarJsonTranslationLogics
      */
     private string GetCreatorVersion()
     {
-      return RuntimeInformation.OSArchitecture + "/" + Environment.OSVersion.Platform + "/" Environment.OSVersion.Version;
+      return RuntimeInformation.OSArchitecture + "/" + Environment.OSVersion.Platform + "/" + Environment.OSVersion.Version;
     }
 
     private async Task<string> ProcessResponseBody(HttpContext context)

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
@@ -101,34 +101,19 @@ namespace ReadMe.HarJsonTranslationLogics
     private Creator BuildCreator()
     {
       Creator creator = new Creator();
-      creator.name = ConstValues.name;
+      creator.name = "readme-metrics (dotnet)";
       creator.version = ConstValues.version;
-      creator.comment = GetOS();
+      creator.comment = GetCreatorVersion();
       return creator;
     }
-    private string GetOS()
-    {
-      string os = null;
-      if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-      {
-        os = "windows";
-      }
-      else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-      {
-        os = "mac";
-      }
-      else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-      {
-        os = "linux";
-      }
-      else
-      {
-        os = "unknown";
-      }
-      os = os + "/" + Environment.OSVersion.Version;
-      return os;
-    }
 
+    /**
+     * @example x86-win32nt/6.2.9200.0
+     */
+    private string GetCreatorVersion()
+    {
+      return RuntimeInformation.OSArchitecture + "/" + Environment.OSVersion.Platform + "/" Environment.OSVersion.Version;
+    }
 
     private async Task<string> ProcessResponseBody(HttpContext context)
     {
@@ -145,9 +130,5 @@ namespace ReadMe.HarJsonTranslationLogics
         return null;
       }
     }
-
-
   }
-
-
 }

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
@@ -112,7 +112,7 @@ namespace ReadMe.HarJsonTranslationLogics
      */
     private string GetCreatorVersion()
     {
-      return RuntimeInformation.OSArchitecture + "/" + Environment.OSVersion.Platform + "/" + Environment.OSVersion.Version;
+      return RuntimeInformation.OSArchitecture + "-" + Environment.OSVersion.Platform + "/" + Environment.OSVersion.Version;
     }
 
     private async Task<string> ProcessResponseBody(HttpContext context)

--- a/packages/dotnet/ReadMe/ReadMe.csproj
+++ b/packages/dotnet/ReadMe/ReadMe.csproj
@@ -17,7 +17,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.13.0" />
-	<FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
| 🚥 Fix RM-5025, #415, #416 |
| :-- |

## 🧰 Changes

* [x] Overhauling our HAR `creator` field that we're setting so it's more consistent with the other SDKs.

### HAR changes

| | Before | After |
| :--- | :--- | :--- |
| `creator.name` | 	readmeio.net | readme-metrics (dotnet) |
| `creator.version` | 2.0.0 | 2.0.0 |
| `creator.comment` | mac/6.2.9200.0 | x86-win32nt/6.2.9200.0 |

## 🧬 QA & Testing

All existing tests are/should be still passing.