### PR TITLE
feat(dotnet): overall cleanup

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,14 +3,27 @@ name: dotnet
 on: [push]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/dotnet
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v2
+        # with:
+        #   dotnet-version: '3.1.x' # SDK Version to use; x will use the latest version of the 3.1 channel
+      - run: make build
+
   integration:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - run: docker-compose run integration_metrics_dotnet_v6.0
+      - run: docker-compose run integration_metrics_dotnet_v6.0
 
-    - name: Cleanup
-      if: always()
-      run: docker-compose down
+      - name: Cleanup
+        if: always()
+        run: docker-compose down

--- a/packages/dotnet/Makefile
+++ b/packages/dotnet/Makefile
@@ -1,0 +1,11 @@
+build: clean ## Build the library (and run code standard checks)
+	dotnet build ReadMe/
+
+clean: ## Clean out the currently built library
+	rm -rf ReadMe/bin/ ReadMe/obj
+
+package: clean ## Build the library for publishing
+	dotnet pack ReadMe/
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/packages/dotnet/ReadMe.ruleset
+++ b/packages/dotnet/ReadMe.ruleset
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for the ReadMe .NET SDK" ToolsVersion="10.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!--
+      SA0001XmlCommentAnalysisDisabled
+      https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+    -->
+    <Rule Id="SA0001" Action="None" />
+
+    <!--
+      SA1200UsingDirectivesMustBePlacedCorrectly
+      https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+    -->
+    <Rule Id="SA1200" Action="None" />
+
+    <!--
+      SA1300ElementMustBeginWithUpperCaseLetter
+      https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+    -->
+    <Rule Id="SA1300" Action="None" />
+
+    <!--
+      SA1400AccessModifierMustBeDeclared
+      https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+    -->
+    <Rule Id="SA1400" Action="None" />
+
+    <!--
+      SA1402FileMayOnlyContainASingleType
+      https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+    -->
+    <Rule Id="SA1402" Action="None" />
+
+    <!--
+      SA1633FileMustHaveHeader
+      https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+    -->
+    <Rule Id="SA1633" Action="None" />
+  </Rules>
+</RuleSet>

--- a/packages/dotnet/ReadMe/ConfigValues.cs
+++ b/packages/dotnet/ReadMe/ConfigValues.cs
@@ -1,23 +1,31 @@
-﻿using ReadMe.HarJsonObjectModels;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using ReadMe.HarJsonObjectModels;
 
 namespace ReadMe
 {
   public class ConfigValues
   {
     public string apiKey { get; set; }
+
     public Group group { get; set; }
+
     public Options options { get; set; }
   }
 
   public class Options
   {
     public List<string> allowList { get; set; }
+
     public bool isAllowListEmpty { get; set; }
+
     public List<string> denyList { get; set; }
+
     public bool isDenyListEmpty { get; set; }
+
     public bool development { get; set; } = false;
+
     public int bufferLength { get; set; } = 1;
+
     public string baseLogUrl { get; set; } = "https://example.readme.com";
   }
 }

--- a/packages/dotnet/ReadMe/ConstValues.cs
+++ b/packages/dotnet/ReadMe/ConstValues.cs
@@ -4,16 +4,23 @@ namespace ReadMe
 {
   public static class ConstValues
   {
-    public static readonly string name = "readmeio.net";
-    public static readonly string version = "2.0.0";
-    public static readonly int wait = 0;
-    public static readonly string receive = null;
-    public static string readmeApiEndpoints
+    public static readonly string Name = "readmeio.net";
+
+    public static readonly string Version = "2.0.0";
+
+    public static readonly int Wait = 0;
+
+    public static readonly string Receive = null;
+
+    public static string ReadmeAPIEndpoints
     {
       get
       {
         var metricsHost = System.Environment.GetEnvironmentVariable("METRICS_SERVER");
-        if (metricsHost == null) metricsHost = "https://metrics.readme.io/";
+        if (metricsHost == null)
+        {
+          metricsHost = "https://metrics.readme.io/";
+        }
 
         UriBuilder uri = new UriBuilder(metricsHost);
         uri.Path = "/v1/request";

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Content.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Content.cs
@@ -6,7 +6,9 @@ namespace ReadMe.HarJsonObjectModels
   class Content
   {
     public string text { get; set; }
+
     public long size { get; set; }
+
     public string mimeType { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Cookies.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Cookies.cs
@@ -6,6 +6,7 @@ namespace ReadMe.HarJsonObjectModels
   class Cookies
   {
     public string name { get; set; }
+
     public string value { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Creator.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Creator.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace ReadMe.HarJsonObjectModels
 {
@@ -7,9 +7,9 @@ namespace ReadMe.HarJsonObjectModels
   class Creator
   {
     public string name { get; set; }
-    public string version { get; set; }
-    //comment is OS and its version
-    public string comment { get; set; }
 
+    public string version { get; set; }
+
+    public string comment { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Entries.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Entries.cs
@@ -6,12 +6,17 @@ namespace ReadMe.HarJsonObjectModels
   class Entries
   {
     public string pageref { get; set; }
-    public string startedDateTime { get; set; }
-    public int time { get; set; }
-    public string cache { get; set; }
-    public Timing timing { get; set; }
-    public Request request { get; set; }
-    public Response response { get; set; }
 
+    public string startedDateTime { get; set; }
+
+    public int time { get; set; }
+
+    public string cache { get; set; }
+
+    public Timing timing { get; set; }
+
+    public Request request { get; set; }
+
+    public Response response { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Group.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Group.cs
@@ -3,8 +3,9 @@
   public class Group
   {
     public string email { get; set; }
-    public string label { get; set; }
-    public string id { get; set; }
 
+    public string label { get; set; }
+
+    public string id { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Headers.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Headers.cs
@@ -3,6 +3,7 @@
   class Headers
   {
     public string name { get; set; }
+
     public string value { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Log.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Log.cs
@@ -5,7 +5,7 @@ namespace ReadMe.HarJsonObjectModels
   class Log
   {
     public Creator creator { get; set; }
-    public List<Entries> entries { get; set; }
 
+    public List<Entries> entries { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Params.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Params.cs
@@ -6,9 +6,13 @@ namespace ReadMe.HarJsonObjectModels
   class Params
   {
     public string name { get; set; }
+
     public string value { get; set; }
+
     public string fileName { get; set; }
+
     public string contentType { get; set; }
+
     public string comment { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/PostData.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/PostData.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace ReadMe.HarJsonObjectModels
 {
@@ -7,10 +7,11 @@ namespace ReadMe.HarJsonObjectModels
   class PostData
   {
     public string mimeType { get; set; }
+
     public string text { get; set; }
+
     public string comment { get; set; }
 
     public List<Params> @params { get; set; }
-
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/QueryStrings.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/QueryStrings.cs
@@ -6,6 +6,7 @@ namespace ReadMe.HarJsonObjectModels
   class QueryStrings
   {
     public string name { get; set; }
+
     public string value { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Request.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Request.cs
@@ -5,13 +5,19 @@ namespace ReadMe.HarJsonObjectModels
   class Request
   {
     public List<Headers> headers { get; set; }
+
     public long headersSize { get; set; }
+
     public List<QueryStrings> queryString { get; set; }
 
     public PostData postData { get; set; }
+
     public List<Cookies> cookies { get; set; }
+
     public string method { get; set; }
+
     public string url { get; set; }
+
     public string httpVersion { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/RequestMain.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/RequestMain.cs
@@ -2,11 +2,11 @@
 {
   class RequestMain
   {
-    public Log log { get; set; }
-
     public RequestMain(Log log)
     {
       this.log = log;
     }
+
+    public Log log { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Response.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Response.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace ReadMe.HarJsonObjectModels
 {
@@ -7,13 +7,21 @@ namespace ReadMe.HarJsonObjectModels
   class Response
   {
     public List<Headers> headers { get; set; }
+
     public Content content { get; set; }
+
     public int status { get; set; }
+
     public string statusText { get; set; }
+
     public string httpVersion { get; set; }
+
     public List<Cookies> cookies { get; set; }
+
     public string redirectURL { get; set; }
+
     public long headersSize { get; set; }
+
     public long bodySize { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Root.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Root.cs
@@ -3,10 +3,13 @@
   class Root
   {
     public string _id { get; set; }
-    public bool development { get; set; }
-    public string clientIPAddress { get; set; }
-    public Group group { get; set; }
-    public RequestMain request { get; set; }
 
+    public bool development { get; set; }
+
+    public string clientIPAddress { get; set; }
+
+    public Group group { get; set; }
+
+    public RequestMain request { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Timing.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Timing.cs
@@ -3,6 +3,7 @@
   class Timing
   {
     public int wait { get; set; }
+
     public string receive { get; set; }
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
@@ -112,7 +112,7 @@ namespace ReadMe.HarJsonTranslationLogics
      */
     private string GetCreatorVersion()
     {
-      return RuntimeInformation.OSArchitecture + "/" + Environment.OSVersion.Platform + "/" Environment.OSVersion.Version;
+      return RuntimeInformation.OSArchitecture + "/" + Environment.OSVersion.Platform + "/" + Environment.OSVersion.Version;
     }
 
     private async Task<string> ProcessResponseBody(HttpContext context)

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
@@ -101,34 +101,19 @@ namespace ReadMe.HarJsonTranslationLogics
     private Creator BuildCreator()
     {
       Creator creator = new Creator();
-      creator.name = ConstValues.name;
+      creator.name = "readme-metrics (dotnet)";
       creator.version = ConstValues.version;
-      creator.comment = GetOS();
+      creator.comment = GetCreatorVersion();
       return creator;
     }
-    private string GetOS()
-    {
-      string os = null;
-      if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-      {
-        os = "windows";
-      }
-      else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-      {
-        os = "mac";
-      }
-      else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-      {
-        os = "linux";
-      }
-      else
-      {
-        os = "unknown";
-      }
-      os = os + "/" + Environment.OSVersion.Version;
-      return os;
-    }
 
+    /**
+     * @example x86-win32nt/6.2.9200.0
+     */
+    private string GetCreatorVersion()
+    {
+      return RuntimeInformation.OSArchitecture + "/" + Environment.OSVersion.Platform + "/" Environment.OSVersion.Version;
+    }
 
     private async Task<string> ProcessResponseBody(HttpContext context)
     {
@@ -145,9 +130,5 @@ namespace ReadMe.HarJsonTranslationLogics
         return null;
       }
     }
-
-
   }
-
-
 }

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
@@ -113,7 +113,7 @@ namespace ReadMe.HarJsonTranslationLogics
      */
     private string GetCreatorVersion()
     {
-      return RuntimeInformation.OSArchitecture + "/" + Environment.OSVersion.Platform + "/" + Environment.OSVersion.Version;
+      return RuntimeInformation.OSArchitecture + "-" + Environment.OSVersion.Platform + "/" + Environment.OSVersion.Version;
     }
 
     private async Task<string> ProcessResponseBody(HttpContext context)

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/HarJsonBuilder.cs
@@ -1,42 +1,42 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
-using ReadMe.HarJsonObjectModels;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using ReadMe.HarJsonObjectModels;
 
 namespace ReadMe.HarJsonTranslationLogics
 {
   public class HarJsonBuilder
   {
-    private readonly RequestDelegate _next;
-    private readonly HttpContext _context;
-    private readonly DateTime _startDateTime;
-    private readonly IConfiguration _configuration;
-    ConfigValues _configValues;
+    private readonly RequestDelegate next;
+    private readonly HttpContext context;
+    private readonly DateTime startDateTime;
+    private readonly IConfiguration configuration;
+    ConfigValues configValues;
     string guid = null;
 
     public HarJsonBuilder(RequestDelegate next, HttpContext context, IConfiguration configuration, ConfigValues configValues)
     {
-      _next = next;
-      _context = context;
-      _startDateTime = DateTime.UtcNow;
-      _configuration = configuration;
-      _configValues = configValues;
+      this.next = next;
+      this.context = context;
+      this.startDateTime = DateTime.UtcNow;
+      this.configuration = configuration;
+      this.configValues = configValues;
     }
 
     public async Task<string> BuildHar()
     {
       Root harObj = new Root();
       harObj._id = Guid.NewGuid().ToString();
-      guid = harObj._id;
-      harObj.development = _configValues.options.development;
-      harObj.clientIPAddress = _context.Connection.RemoteIpAddress.ToString();
-      harObj.group = BuildGroup();
-      harObj.request = new RequestMain(await BuildLog());
+      this.guid = harObj._id;
+      harObj.development = this.configValues.options.development;
+      harObj.clientIPAddress = this.context.Connection.RemoteIpAddress.ToString();
+      harObj.group = this.BuildGroup();
+      harObj.request = new RequestMain(await this.BuildLog());
       string harJsonObj = JsonConvert.SerializeObject(new List<Root>() { harObj });
       return harJsonObj;
     }
@@ -44,17 +44,17 @@ namespace ReadMe.HarJsonTranslationLogics
     private Group BuildGroup()
     {
       Group group = new Group();
-      group.id = _configValues.group.id;
-      group.label = _configValues.group.label;
-      group.email = _configValues.group.email;
+      group.id = this.configValues.group.id;
+      group.label = this.configValues.group.label;
+      group.email = this.configValues.group.email;
       return group;
     }
 
     private async Task<Log> BuildLog()
     {
       Log log = new Log();
-      log.creator = BuildCreator();
-      log.entries = await BuildEntries();
+      log.creator = this.BuildCreator();
+      log.entries = await this.BuildEntries();
       return log;
     }
 
@@ -63,15 +63,15 @@ namespace ReadMe.HarJsonTranslationLogics
       List<Entries> entries = new List<Entries>();
 
       Entries entry = new Entries();
-      //entry.pageref = _configValues.options.baseLogUrl + "/users/" + guid;
-      entry.pageref = _context.Request.Scheme + "://" + _context.Request.Host.Host + ":" + _context.Request.Host.Port + "" + _context.Request.Path;
-      entry.startedDateTime = _startDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+      entry.pageref = this.context.Request.Scheme + "://" + this.context.Request.Host.Host + ":" + this.context.Request.Host.Port + this.context.Request.Path;
+      entry.startedDateTime = this.startDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
       entry.cache = null;
-      entry.timing = new Timing { wait = ConstValues.wait, receive = ConstValues.receive };
-      RequestProcessor requestProcessor = new RequestProcessor(_context.Request, _configValues);
+      entry.timing = new Timing { wait = ConstValues.Wait, receive = ConstValues.Receive };
+
+      RequestProcessor requestProcessor = new RequestProcessor(this.context.Request, this.configValues);
       entry.request = await requestProcessor.ProcessRequest();
-      entry.response = await BuildResponse();
-      entry.time = (int)DateTime.UtcNow.Subtract(_startDateTime).TotalMilliseconds;
+      entry.response = await this.BuildResponse();
+      entry.time = (int)DateTime.UtcNow.Subtract(this.startDateTime).TotalMilliseconds;
 
       entries.Add(entry);
       return entries;
@@ -81,20 +81,21 @@ namespace ReadMe.HarJsonTranslationLogics
     {
       Response response = null;
 
-      var originalBodyStream = _context.Response.Body;
+      var originalBodyStream = this.context.Response.Body;
       using (var responseBody = new MemoryStream())
       {
-        _context.Response.Body = responseBody;
+        this.context.Response.Body = responseBody;
 
-        await _next.Invoke(_context);
+        await this.next.Invoke(this.context);
 
-        string responseBodyData = await ProcessResponseBody(_context);
-        _context.Response.Headers.Add("x-documentation-url", _configValues.options.baseLogUrl + "/logs/" + guid);
-        ResponseProcessor responseProcessor = new ResponseProcessor(_context.Response, responseBodyData, _configValues);
+        string responseBodyData = await this.ProcessResponseBody(this.context);
+        this.context.Response.Headers.Add("x-documentation-url", this.configValues.options.baseLogUrl + "/logs/" + this.guid);
+        ResponseProcessor responseProcessor = new ResponseProcessor(this.context.Response, responseBodyData, this.configValues);
         response = responseProcessor.ProcessResponse();
 
         await responseBody.CopyToAsync(originalBodyStream);
       }
+
       return response;
     }
 
@@ -102,8 +103,8 @@ namespace ReadMe.HarJsonTranslationLogics
     {
       Creator creator = new Creator();
       creator.name = "readme-metrics (dotnet)";
-      creator.version = ConstValues.version;
-      creator.comment = GetCreatorVersion();
+      creator.version = ConstValues.Version;
+      creator.comment = this.GetCreatorVersion();
       return creator;
     }
 

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/ReadmeApiCaller.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/ReadmeApiCaller.cs
@@ -1,32 +1,31 @@
-﻿
-using RestSharp;
-using System;
+﻿using System;
 using System.Text;
 using System.Threading.Tasks;
+using RestSharp;
 
 namespace ReadMe.HarJsonTranslationLogics
 {
   class ReadMeApiCaller
   {
-    private readonly string _harJsonObject;
-    private readonly string _apiKey;
+    private readonly string harJsonObject;
+    private readonly string apiKey;
 
     public ReadMeApiCaller(string harJsonObject, string apiKey)
     {
-      _harJsonObject = harJsonObject;
-      _apiKey = apiKey;
+      this.harJsonObject = harJsonObject;
+      this.apiKey = apiKey;
     }
 
     public void SendHarObjToReadMeApi()
     {
       try
       {
-        var client = new RestClient(ConstValues.readmeApiEndpoints);
+        var client = new RestClient(ConstValues.ReadmeAPIEndpoints);
         var request = new RestRequest(Method.POST);
         request.AddHeader("Content-Type", "application/json");
-        string apiKey = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(_apiKey + ":"));
+        string apiKey = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(this.apiKey + ":"));
         request.AddHeader("Authorization", apiKey);
-        request.AddParameter("application/json", _harJsonObject, ParameterType.RequestBody);
+        request.AddParameter("application/json", this.harJsonObject, ParameterType.RequestBody);
         client.ExecuteAsync(request);
       }
       catch (Exception)

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/RequestProcessor.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/RequestProcessor.cs
@@ -1,33 +1,33 @@
-﻿using Microsoft.AspNetCore.Http;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 namespace ReadMe.HarJsonObjectModels
 {
   class RequestProcessor
   {
-    private readonly HttpRequest _request;
-    private readonly ConfigValues _configValues;
+    private readonly HttpRequest request;
+    private readonly ConfigValues configValues;
 
     public RequestProcessor(HttpRequest request, ConfigValues configValues)
     {
-      _request = request;
-      _configValues = configValues;
+      this.request = request;
+      this.configValues = configValues;
     }
 
     public async Task<Request> ProcessRequest()
     {
       Request requestObj = new Request();
-      requestObj.headers = GetHeaders();
-      requestObj.headersSize = GetHeadersSize();
-      requestObj.queryString = GetQueryStrings();
-      requestObj.cookies = GetCookies();
-      requestObj.method = _request.Method;
-      requestObj.url = _request.Scheme + "://" + _request.Host.Host + ":" + _request.Host.Port + "" + _request.Path;
-      requestObj.httpVersion = _request.Protocol;
-      requestObj.postData = await GetPostData();
+      requestObj.headers = this.GetHeaders();
+      requestObj.headersSize = this.GetHeadersSize();
+      requestObj.queryString = this.GetQueryStrings();
+      requestObj.cookies = this.GetCookies();
+      requestObj.method = this.request.Method;
+      requestObj.url = this.request.Scheme + "://" + this.request.Host.Host + ":" + this.request.Host.Port + this.request.Path;
+      requestObj.httpVersion = this.request.Protocol;
+      requestObj.postData = await this.GetPostData();
 
       return requestObj;
     }
@@ -35,83 +35,92 @@ namespace ReadMe.HarJsonObjectModels
     private async Task<PostData> GetPostData()
     {
       PostData postData = new PostData();
-      postData.mimeType = _request.ContentType;
-      if (_request.ContentType == "application/x-www-form-urlencoded")
+      postData.mimeType = this.request.ContentType;
+      if (this.request.ContentType == "application/x-www-form-urlencoded")
       {
         List<Params> @params = new List<Params>();
-        if (_request.Form.Keys.Count > 0)
+        if (this.request.Form.Keys.Count > 0)
         {
-          foreach (string key in _request.Form.Keys)
+          foreach (string key in this.request.Form.Keys)
           {
-            if (!_configValues.options.isAllowListEmpty)
+            if (!this.configValues.options.isAllowListEmpty)
             {
-              if (CheckAllowList(key))
+              if (this.CheckAllowList(key))
               {
-                @params.Add(new Params { name = key, value = _request.Form[key] });
+                @params.Add(new Params { name = key, value = this.request.Form[key] });
               }
             }
-            else if (!_configValues.options.isDenyListEmpty)
+            else if (!this.configValues.options.isDenyListEmpty)
             {
-              if (!CheckDenyList(key))
+              if (!this.CheckDenyList(key))
               {
-                @params.Add(new Params { name = key, value = _request.Form[key] });
+                @params.Add(new Params { name = key, value = this.request.Form[key] });
               }
             }
             else
             {
-              @params.Add(new Params { name = key, value = _request.Form[key] });
+              @params.Add(new Params { name = key, value = this.request.Form[key] });
             }
           }
         }
+
         postData.@params = @params;
       }
-      else if (_request.HasFormContentType)
+      else if (this.request.HasFormContentType)
       {
         List<Params> @params = new List<Params>();
-        if (_request.Form.Keys.Count > 0)
+        if (this.request.Form.Keys.Count > 0)
         {
-          foreach (string key in _request.Form.Keys)
+          foreach (string key in this.request.Form.Keys)
           {
-            if (!_configValues.options.isAllowListEmpty)
+            if (!this.configValues.options.isAllowListEmpty)
             {
-              if (CheckAllowList(key))
+              if (this.CheckAllowList(key))
               {
-                @params.Add(new Params { name = key, value = _request.Form[key] });
+                @params.Add(new Params { name = key, value = this.request.Form[key] });
               }
             }
-            else if (!_configValues.options.isDenyListEmpty)
+            else if (!this.configValues.options.isDenyListEmpty)
             {
-              if (!CheckDenyList(key))
+              if (!this.CheckDenyList(key))
               {
-                @params.Add(new Params { name = key, value = _request.Form[key] });
+                @params.Add(new Params { name = key, value = this.request.Form[key] });
               }
             }
             else
             {
-              @params.Add(new Params { name = key, value = _request.Form[key] });
+              @params.Add(new Params { name = key, value = this.request.Form[key] });
             }
           }
         }
+
         postData.@params = @params;
       }
-      else if (_request.ContentType != null)
+      else if (this.request.ContentType != null)
       {
-        postData.text = await GetRequestBodyData();
+        postData.text = await this.GetRequestBodyData();
       }
+
       return postData;
     }
 
-    private bool CheckAllowList(string key) => (_configValues.options.allowList.Any(v => v.Trim().ToLower() == key.Trim().ToLower())) ? true : false;
-    private bool CheckDenyList(string key) => (_configValues.options.denyList.Any(v => v.Trim().ToLower() == key.Trim().ToLower())) ? true : false;
+    private bool CheckAllowList(string key)
+    {
+      return this.configValues.options.allowList.Any(v => v.Trim().ToLower() == key.Trim().ToLower()) ? true : false;
+    }
 
+    private bool CheckDenyList(string key)
+    {
+      return this.configValues.options.denyList.Any(v => v.Trim().ToLower() == key.Trim().ToLower()) ? true : false;
+    }
 
     private async Task<string> GetRequestBodyData()
     {
       try
       {
-        StreamReader requestBodyReader = new StreamReader(_request.Body);
+        StreamReader requestBodyReader = new StreamReader(this.request.Body);
         string requestBodyData = await requestBodyReader.ReadToEndAsync();
-        _request.Body.Position = 0;
+        this.request.Body.Position = 0;
         return requestBodyData;
       }
       catch (System.Exception)
@@ -119,17 +128,17 @@ namespace ReadMe.HarJsonObjectModels
         return null;
       }
     }
+
     private List<Headers> GetHeaders()
     {
       List<Headers> headers = new List<Headers>();
-      if (_request.Headers.Count > 0)
+      if (this.request.Headers.Count > 0)
       {
-        foreach (var reqHeader in _request.Headers)
+        foreach (var reqHeader in this.request.Headers)
         {
-
-          if (!_configValues.options.isAllowListEmpty)
+          if (!this.configValues.options.isAllowListEmpty)
           {
-            if (CheckAllowList(reqHeader.Key))
+            if (this.CheckAllowList(reqHeader.Key))
             {
               Headers header = new Headers();
               header.name = reqHeader.Key;
@@ -137,9 +146,9 @@ namespace ReadMe.HarJsonObjectModels
               headers.Add(header);
             }
           }
-          else if (!_configValues.options.isDenyListEmpty)
+          else if (!this.configValues.options.isDenyListEmpty)
           {
-            if (!CheckDenyList(reqHeader.Key))
+            if (!this.CheckDenyList(reqHeader.Key))
             {
               Headers header = new Headers();
               header.name = reqHeader.Key;
@@ -156,31 +165,35 @@ namespace ReadMe.HarJsonObjectModels
           }
         }
       }
+
       return headers;
     }
+
     private long GetHeadersSize()
     {
       long headersSize = 0;
-      if (_request.Headers.Count > 0)
+      if (this.request.Headers.Count > 0)
       {
-        foreach (var reqHeader in _request.Headers)
+        foreach (var reqHeader in this.request.Headers)
         {
           headersSize += reqHeader.Value.ToString().Length;
         }
       }
+
       return headersSize;
     }
+
     private List<QueryStrings> GetQueryStrings()
     {
       List<QueryStrings> queryStrings = new List<QueryStrings>();
-      if (_request.Query.Count > 0)
+      if (this.request.Query.Count > 0)
       {
-        var queryStings = _request.Query;
+        var queryStings = this.request.Query;
         foreach (var qs in queryStings)
         {
-          if (!_configValues.options.isAllowListEmpty)
+          if (!this.configValues.options.isAllowListEmpty)
           {
-            if (CheckAllowList(qs.Key))
+            if (this.CheckAllowList(qs.Key))
             {
               QueryStrings qString = new QueryStrings();
               qString.name = qs.Key;
@@ -188,9 +201,9 @@ namespace ReadMe.HarJsonObjectModels
               queryStrings.Add(qString);
             }
           }
-          else if (!_configValues.options.isDenyListEmpty)
+          else if (!this.configValues.options.isDenyListEmpty)
           {
-            if (!CheckDenyList(qs.Key))
+            if (!this.CheckDenyList(qs.Key))
             {
               QueryStrings qString = new QueryStrings();
               qString.name = qs.Key;
@@ -207,14 +220,16 @@ namespace ReadMe.HarJsonObjectModels
           }
         }
       }
+
       return queryStrings;
     }
+
     private List<Cookies> GetCookies()
     {
       List<Cookies> cookies = new List<Cookies>();
-      if (_request.Cookies.Count > 0)
+      if (this.request.Cookies.Count > 0)
       {
-        foreach (var reqCookie in _request.Cookies)
+        foreach (var reqCookie in this.request.Cookies)
         {
           Cookies cookie = new Cookies();
           cookie.name = reqCookie.Key;
@@ -222,8 +237,8 @@ namespace ReadMe.HarJsonObjectModels
           cookies.Add(cookie);
         }
       }
+
       return cookies;
     }
-
   }
 }

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/ResponseProcessor.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/ResponseProcessor.cs
@@ -1,44 +1,44 @@
-﻿using Microsoft.AspNetCore.Http;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 
 namespace ReadMe.HarJsonObjectModels
 {
   class ResponseProcessor
   {
-    private readonly HttpResponse _response;
-    private readonly string _responseBodyData;
-    private readonly ConfigValues _configValues;
+    private readonly HttpResponse response;
+    private readonly string responseBodyData;
+    private readonly ConfigValues configValues;
 
     public ResponseProcessor(HttpResponse response, string responseBodyData, ConfigValues configValues)
     {
-      _response = response;
-      _responseBodyData = responseBodyData;
-      _configValues = configValues;
+      this.response = response;
+      this.responseBodyData = responseBodyData;
+      this.configValues = configValues;
     }
 
     public Response ProcessResponse()
     {
       Response responseObj = new Response();
-      responseObj.headers = GetHeaders();
-      responseObj.headersSize = GetHeadersSize();
-      responseObj.status = _response.StatusCode;
-      responseObj.statusText = GetStatusTextByStatusCode(_response.StatusCode);
-      responseObj.content = GetContent();
-      responseObj.bodySize = _responseBodyData.Length;
+      responseObj.headers = this.GetHeaders();
+      responseObj.headersSize = this.GetHeadersSize();
+      responseObj.status = this.response.StatusCode;
+      responseObj.statusText = this.GetStatusTextByStatusCode(this.response.StatusCode);
+      responseObj.content = this.GetContent();
+      responseObj.bodySize = this.responseBodyData.Length;
       return responseObj;
     }
 
     private List<Headers> GetHeaders()
     {
       List<Headers> headers = new List<Headers>();
-      if (_response.Headers.Count > 0)
+      if (this.response.Headers.Count > 0)
       {
-        foreach (var resHeader in _response.Headers)
+        foreach (var resHeader in this.response.Headers)
         {
-          if (!_configValues.options.isAllowListEmpty)
+          if (!this.configValues.options.isAllowListEmpty)
           {
-            if (CheckAllowList(resHeader.Key))
+            if (this.CheckAllowList(resHeader.Key))
             {
               Headers header = new Headers();
               header.name = resHeader.Key;
@@ -46,9 +46,9 @@ namespace ReadMe.HarJsonObjectModels
               headers.Add(header);
             }
           }
-          else if (!_configValues.options.isDenyListEmpty)
+          else if (!this.configValues.options.isDenyListEmpty)
           {
-            if (!CheckDenyList(resHeader.Key))
+            if (!this.CheckDenyList(resHeader.Key))
             {
               Headers header = new Headers();
               header.name = resHeader.Key;
@@ -65,31 +65,38 @@ namespace ReadMe.HarJsonObjectModels
           }
         }
       }
+
       return headers;
     }
+
     private long GetHeadersSize()
     {
       long headersSize = 0;
-      if (_response.Headers.Count > 0)
+      if (this.response.Headers.Count > 0)
       {
-        foreach (var reqHeader in _response.Headers)
+        foreach (var reqHeader in this.response.Headers)
         {
           headersSize += reqHeader.Value.ToString().Length;
         }
       }
+
       return headersSize;
     }
 
     private Content GetContent()
     {
       Content content = new Content();
-      content.text = _responseBodyData;
-      content.size = _responseBodyData.Length;
-      content.mimeType = _response.ContentType;
+      content.text = this.responseBodyData;
+      content.size = this.responseBodyData.Length;
+      content.mimeType = this.response.ContentType;
       return content;
     }
 
-
+    /**
+     * This list has been pulled from our `@readme/http-status-codes` NPM package.
+     *
+     * @see {@link https://github.com/readmeio/http-status-codes}
+     */
     private string GetStatusTextByStatusCode(int statusCode)
     {
       switch (statusCode)
@@ -97,6 +104,8 @@ namespace ReadMe.HarJsonObjectModels
         case 100: return "Continue";
         case 101: return "Switching Protocols";
         case 102: return "Processing";
+        case 103: return "Early Hints"; // Also informally used as "Checkpoint".
+
         case 200: return "OK";
         case 201: return "Created";
         case 202: return "Accepted";
@@ -105,13 +114,20 @@ namespace ReadMe.HarJsonObjectModels
         case 205: return "Reset Content";
         case 206: return "Partial Content";
         case 207: return "Multi-Status";
+        case 208: return "Already Reported";
+        case 218: return "This is fine"; // Unofficial
+        case 226: return "IM Used";
+
         case 300: return "Multiple Choices";
         case 301: return "Moved Permanently";
         case 302: return "Found";
         case 303: return "See Other";
         case 304: return "Not Modified";
         case 305: return "Use Proxy";
+        case 306: return "Switch Proxy";
         case 307: return "Temporary Redirect";
+        case 308: return "Permanent Redirect";
+
         case 400: return "Bad Request";
         case 401: return "Unauthorized";
         case 402: return "Payment Required";
@@ -125,29 +141,72 @@ namespace ReadMe.HarJsonObjectModels
         case 410: return "Gone";
         case 411: return "Length Required";
         case 412: return "Precondition Failed";
-        case 413: return "Request Entity Too Large";
-        case 414: return "Request-Uri Too Long";
+        case 413: return "Payload Too Large";
+        case 414: return "URI Too Long";
         case 415: return "Unsupported Media Type";
-        case 416: return "Requested Range Not Satisfiable";
+        case 416: return "Range Not Satisfiable";
         case 417: return "Expectation Failed";
+        case 418: return "I'm a teapot";
+        case 419: return "Page Expired"; // Unofficial
+        case 420: return "Enhance Your Calm"; // Unofficial
+        case 421: return "Misdirected Request";
         case 422: return "Unprocessable Entity";
         case 423: return "Locked";
         case 424: return "Failed Dependency";
+        case 425: return "Too Early";
+        case 426: return "Upgrade Required";
+        case 428: return "Precondition Required";
+        case 429: return "Too Many Requests";
+        case 430: return "Request Header Fields Too Large"; // Unofficial
+        case 431: return "Request Header Fields Too Large";
+        case 440: return "Login Time-out"; // Unofficial
+        case 444: return "No Response"; // Unofficial
+        case 449: return "Retry With"; // Unofficial
+        case 450: return "Blocked by Windows Parental Controls"; // Unofficial
+        case 451: return "Unavailable For Legal Reasons";
+        case 494: return "Request Header Too Large"; // Unofficial
+        case 495: return "SSL Certificate Error"; // Unofficial
+        case 496: return "SSL Certificate Required"; // Unofficial
+        case 497: return "HTTP Request Sent to HTTPS Port"; // Unofficial
+        case 498: return "Invalid Token"; // Unofficial
+        case 499: return "Client Error"; // "Token Request" on ArcGIS, "Client Closed Request" on nginx
+
         case 500: return "Internal Server Error";
         case 501: return "Not Implemented";
         case 502: return "Bad Gateway";
         case 503: return "Service Unavailable";
         case 504: return "Gateway Timeout";
-        case 505: return "Http Version Not Supported";
+        case 505: return "HTTP Version Not Supported";
+        case 506: return "Variant Also Negotiates";
         case 507: return "Insufficient Storage";
+        case 508: return "Loop Detected";
+        case 509: return "Bandwidth Limit Exceeded";
+        case 510: return "Not Extended";
+        case 511: return "Network Authentication Required";
+        case 520: return "Web Server Returned an Unknown Error"; // Unofficial
+        case 521: return "Web Server Is Down"; // Unofficial
+        case 522: return "Connection Timed Out"; // Unofficial
+        case 523: return "Origin Is Unreachable"; // Unofficial
+        case 524: return "A Timeout Occurred"; // Unofficial
+        case 525: return "SSL Handshake Failed"; // Unofficial
+        case 526: return "Invalid SSL Certificate"; // Unofficial
+        case 527: return "Railgun Error"; // Unofficial
+        case 529: return "Site is Overloaded"; // Unofficial
+        case 530: return "Site is Frozen"; // Unofficial
+        case 598: return "Network Read Timeout Error"; // Unofficial
       }
-      return "";
+
+      return string.Empty;
     }
 
+    private bool CheckAllowList(string key)
+    {
+      return this.configValues.options.allowList.Any(v => v.Trim().ToLower() == key.Trim().ToLower()) ? true : false;
+    }
 
-
-    private bool CheckAllowList(string key) => (_configValues.options.allowList.Any(v => v.Trim().ToLower() == key.Trim().ToLower())) ? true : false;
-    private bool CheckDenyList(string key) => (_configValues.options.denyList.Any(v => v.Trim().ToLower() == key.Trim().ToLower())) ? true : false;
-
+    private bool CheckDenyList(string key)
+    {
+      return this.configValues.options.denyList.Any(v => v.Trim().ToLower() == key.Trim().ToLower()) ? true : false;
+    }
   }
 }

--- a/packages/dotnet/ReadMe/ReadMe.csproj
+++ b/packages/dotnet/ReadMe/ReadMe.csproj
@@ -9,7 +9,11 @@
     <Product>ReadMe.Metrics DotnetCore</Product>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>readme2.png</PackageIcon>
-    <Description>The Metrics API gives you access to usage data for your API and hub, so you can make more data-driven decisions around your platform and API roadmap. Many of the metrics that you can get using this API are also available as visualizations directly in ReadMe in our Metrics charts.</Description>
+    <Description>Track usage of your API and troubleshoot issues faster.</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\ReadMe.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +23,11 @@
     <PackageReference Include="RestSharp" Version="106.13.0" />
 
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -31,5 +40,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
 </Project>

--- a/packages/dotnet/ReadMe/ReadMe.csproj
+++ b/packages/dotnet/ReadMe/ReadMe.csproj
@@ -17,7 +17,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.13.0" />
-	<FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/dotnet/ReadMe/Webhook.cs
+++ b/packages/dotnet/ReadMe/Webhook.cs
@@ -1,9 +1,9 @@
-using Microsoft.Extensions.Primitives;
 using System;
 using System.Linq;
 using System.Security.Cryptography;
-using static System.Text.Encoding;
 using System.Text;
+using Microsoft.Extensions.Primitives;
+using static System.Text.Encoding;
 
 namespace ReadMe
 {


### PR DESCRIPTION
| 🚥 Fix #415, #453 |
| :-- |

## 🧰 Changes

> ⚠️ There's a fair bit of yakshaving going on here so it'd probably be best to view the diff with whitespace disabled.

* [x] Implementing and conforming to code standards from [StyleCop](https://github.com/DotNetAnalyzers/StyleCopAnalyzers).
* [x] Bulking up the `GetStatusTextByStatusCode` method with the HTTP status codes I've compiled in our [@readme/http-status-codes](https://npm.im/@readme/http-status-codes) package.
* [x] Setting up a `Makefile` for running build and publish commands.
* [x] Setting up a GitHub action for running `dotnet build` to make sure that not only does the library build (outside of the build that happens in the integration job), but that there aren't any code standard violations being introduced.

## 🧬 QA & Testing

All existing tests are/should be still passing.