### PR TITLE
feat(snippets): allowing webhook secrets to be injected into snippets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-test-metrics-php-laravel:
-	EXAMPLE_SERVER="php packages/php/examples/laravel/artisan serve" npm run test:integration-metrics
-
-test-webhooks-php-laravel:
-	EXAMPLE_SERVER="php packages/php/examples/laravel/artisan serve" npm run test:integration-webhooks

--- a/packages/dotnet/examples/net6.0-webhook/Program.cs
+++ b/packages/dotnet/examples/net6.0-webhook/Program.cs
@@ -2,8 +2,9 @@ var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
 var port = Environment.GetEnvironmentVariable("PORT") ?? "4000";
-var secret = Environment.GetEnvironmentVariable("README_API_KEY");
 
+// Your ReadMe secret
+var secret = Environment.GetEnvironmentVariable("README_API_KEY");
 if (secret == null)
 {
   Console.Error.WriteLine("Missing `README_API_KEY` environment variable");
@@ -12,6 +13,7 @@ if (secret == null)
 
 app.MapPost("/webhook", async context =>
 {
+  // Verify the request is legitimate and came from ReadMe.
   var signature = context.Request.Headers["readme-signature"];
   var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
 
@@ -28,6 +30,9 @@ app.MapPost("/webhook", async context =>
     });
     return;
   }
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // @todo Write your own query logic to fetch a user by `body["email"]`.
 
   await context.Response.WriteAsJsonAsync(new
   {

--- a/packages/node/examples/express/webhook.js
+++ b/packages/node/examples/express/webhook.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 import express from 'express';
 import readme from 'readmeio';
 
@@ -12,25 +11,26 @@ if (!process.env.README_API_KEY) {
 const app = express();
 const port = process.env.PORT || 4000;
 
-app.post('/webhook', express.json({ type: 'application/json' }), (req, res) => {
+// Your ReadMe secret
+const secret = process.env.README_API_KEY;
+
+app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
   // Verify the request is legitimate and came from ReadMe
   const signature = req.headers['readme-signature'];
-  // Your ReadMe secret
-  const secret = process.env.README_API_KEY;
+
   try {
     readme.verifyWebhook(req.body, signature, secret);
   } catch (e) {
     // Handle invalid requests
     return res.status(401).json({ error: e.message });
   }
-  // Fetch the user from the db
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define, @typescript-eslint/no-unused-vars
-  return db.find({ email: req.body.email }).then(user => {
-    return res.json({
-      // OAS Security variables
-      petstore_auth: 'default-key',
-      basic_auth: { user: 'user', pass: 'pass' },
-    });
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // const user = await db.find({ email: req.body.email })
+  return res.json({
+    // OAS Security variables
+    petstore_auth: 'default-key',
+    basic_auth: { user: 'user', pass: 'pass' },
   });
 });
 
@@ -38,9 +38,3 @@ const server = app.listen(port, 'localhost', function () {
   // eslint-disable-next-line no-console
   console.log('Example app listening at http://%s:%s', server.address().address, port);
 });
-
-class db {
-  static find() {
-    return Promise.resolve({});
-  }
-}

--- a/packages/php/examples/laravel/routes/web.php
+++ b/packages/php/examples/laravel/routes/web.php
@@ -13,18 +13,18 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+// Your ReadMe secret
+$secret = env('README_API_KEY');
+
 Route::get('/', function () {
     return response()->json([
         'message' => 'hello world'
     ]);
 });
 
-Route::post('/webhook', function (\Illuminate\Http\Request $request) {
+Route::post('/webhook', function (\Illuminate\Http\Request $request) use ($secret) {
     // Verify the request is legitimate and came from ReadMe.
     $signature = $request->headers->get('readme-signature', '');
-
-    // Your ReadMe secret
-    $secret = env('README_API_KEY', config('readme.api_key'));
 
     try {
         \ReadMe\Webhooks::verify($request->input(), $signature, $secret);

--- a/packages/python/examples/flask/webhook.py
+++ b/packages/python/examples/flask/webhook.py
@@ -16,7 +16,7 @@ secret = os.getenv("README_API_KEY").encode("utf8")
 
 @app.post("/webhook")
 def webhook():
-    # Verify the request is legitimate and came from ReadMe
+    # Verify the request is legitimate and came from ReadMe.
     signature = request.headers.get("readme-signature", None)
 
     try:

--- a/packages/python/examples/flask/webhook.py
+++ b/packages/python/examples/flask/webhook.py
@@ -10,14 +10,14 @@ if os.getenv("README_API_KEY") is None:
 
 app = Flask(__name__)
 
+# Your ReadMe secret
+secret = os.getenv("README_API_KEY").encode("utf8")
+
 
 @app.post("/webhook")
 def webhook():
     # Verify the request is legitimate and came from ReadMe
     signature = request.headers.get("readme-signature", None)
-
-    # Your ReadMe secret
-    secret = os.getenv("README_API_KEY").encode("utf8")
 
     try:
         VerifyWebhook(request.get_json(), signature, secret)
@@ -28,6 +28,8 @@ def webhook():
             {"Content-Type": "application/json; charset=utf-8"},
         )
 
+    # Fetch the user from the database and return their data for use with OpenAPI variables.
+    # user = User.objects.get(email__exact=request.values.get("email"))
     return (
         {
             "petstore_auth": "default-key",

--- a/packages/sdk-snippets/README.md
+++ b/packages/sdk-snippets/README.md
@@ -19,20 +19,23 @@ npm install --save @readme/metrics-sdk-snippets
 ```js
 import { MetricsSDKSnippet } from '@readme/metrics-sdk-snippets';
 
-const { convert } = new MetricsSDKSnippet([
-  {
-    name: 'petstore_auth',
-    default: 'default-key',
-    source: 'security',
-    type: 'oauth2',
-  },
-  {
-    name: 'basic_auth',
-    default: 'default',
-    source: 'security',
-    type: 'http',
-  },
-], { secret: 'my-readme-secret' });
+const { convert } = new MetricsSDKSnippet(
+  [
+    {
+      name: 'petstore_auth',
+      default: 'default-key',
+      source: 'security',
+      type: 'oauth2',
+    },
+    {
+      name: 'basic_auth',
+      default: 'default',
+      source: 'security',
+      type: 'http',
+    },
+  ],
+  { secret: 'my-readme-secret' }
+);
 
 console.log(convert('webhooks', 'node', 'express'));
 ```

--- a/packages/sdk-snippets/README.md
+++ b/packages/sdk-snippets/README.md
@@ -32,7 +32,7 @@ const { convert } = new MetricsSDKSnippet([
     source: 'security',
     type: 'http',
   },
-]);
+], { secret: 'my-readme-secret' });
 
 console.log(convert('webhooks', 'node', 'express'));
 ```
@@ -54,34 +54,33 @@ This generates the following object:
 The generated snippet for this results in a [ReadMe Node Metrics SDK](https://npm.im/readmeio) webhooks example:
 
 ```js
-// Save this code as `server.js`
-// Run the server with `node server.js`
-const readme = require('readmeio');
-const express = require('express');
+import express from 'express';
+import readme from 'readmeio';
 
 const app = express();
 
-app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
+// Your ReadMe secret
+const secret = 'my-readme-secret';
+
+app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
   // Verify the request is legitimate and came from ReadMe
   const signature = req.headers['readme-signature'];
 
-  // Your ReadMe secret
-  const secret = 'rdme_xxxx';
-
   try {
-    readme.verify(req.body, signature, secret);
+    readme.verifyWebhook(req.body, signature, secret);
   } catch (e) {
     // Handle invalid requests
-    return res.sendStatus(401);
+    return res.status(401).json({ error: e.message });
   }
 
-  // Fetch the user from the db
-  db.find({ email: req.body.email }).then(user => {
-    return res.json({
-      // OAS Security variables
-      petstore_auth: 'default-key',
-      basic_auth: { user: 'user', pass: 'pass' },
-    });
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // const user = await db.find({ email: req.body.email })
+  return res.json({
+    // OAS Security variables
+    petstore_auth: 'default-key',
+    basic_auth: { user: 'user', pass: 'pass' },
   });
 });
+
+app.listen(4000);
 ```

--- a/packages/sdk-snippets/src/index.ts
+++ b/packages/sdk-snippets/src/index.ts
@@ -21,10 +21,18 @@ export interface SecurityVariable {
 export type Variables = (ServerVariable | SecurityVariable)[];
 
 export class MetricsSDKSnippet {
+  secret: string;
+
   variables: Variables = [];
 
-  constructor(input: Variables) {
+  constructor(
+    input: Variables,
+    data: {
+      secret?: string;
+    } = {}
+  ) {
     this.variables = input;
+    this.secret = data.secret ?? 'my-readme-secret';
   }
 
   convert = (snippetType: SnippetType, targetId: TargetId, clientId?: ClientId, options?: any) => {
@@ -49,6 +57,6 @@ export class MetricsSDKSnippet {
       { server: [], security: [] }
     );
 
-    return convert({ server, security }, options);
+    return convert({ secret: this.secret, server, security }, options);
   };
 }

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -248,3 +248,86 @@ Object {
   },
 }
 `;
+
+exports[`webhooks Python snippet generation flask request should match fixture for "empty" 1`] = `Object {}`;
+
+exports[`webhooks Python snippet generation flask request should match fixture for "empty-default" 1`] = `
+Object {
+  "security": Object {
+    "petstore_auth": Object {
+      "line": 37,
+    },
+  },
+  "server": Object {
+    "name": Object {
+      "line": 34,
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation flask request should match fixture for "security-and-server-variables" 1`] = `
+Object {
+  "security": Object {
+    "basic_auth": Object {
+      "line": 39,
+    },
+    "petstore_auth": Object {
+      "line": 38,
+    },
+  },
+  "server": Object {
+    "name": Object {
+      "line": 34,
+    },
+    "port": Object {
+      "line": 35,
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation flask request should match fixture for "security-types" 1`] = `
+Object {
+  "security": Object {
+    "api_key": Object {
+      "line": 34,
+    },
+    "http_basic": Object {
+      "line": 35,
+    },
+    "http_bearer": Object {
+      "line": 36,
+    },
+    "oauth2": Object {
+      "line": 37,
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation flask request should match fixture for "security-variables" 1`] = `
+Object {
+  "security": Object {
+    "basic_auth": Object {
+      "line": 35,
+    },
+    "petstore_auth": Object {
+      "line": 34,
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation flask request should match fixture for "server-variables" 1`] = `
+Object {
+  "server": Object {
+    "name": Object {
+      "line": 34,
+    },
+    "port": Object {
+      "line": 35,
+    },
+  },
+}
+`;

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -89,12 +89,12 @@ exports[`webhooks Node.js snippet generation express request should match fixtur
 Object {
   "security": Object {
     "petstore_auth": Object {
-      "line": 24,
+      "line": 27,
     },
   },
   "server": Object {
     "name": Object {
-      "line": 21,
+      "line": 24,
     },
   },
 }
@@ -104,18 +104,18 @@ exports[`webhooks Node.js snippet generation express request should match fixtur
 Object {
   "security": Object {
     "basic_auth": Object {
-      "line": 26,
+      "line": 29,
     },
     "petstore_auth": Object {
-      "line": 25,
+      "line": 28,
     },
   },
   "server": Object {
     "name": Object {
-      "line": 21,
+      "line": 24,
     },
     "port": Object {
-      "line": 22,
+      "line": 25,
     },
   },
 }
@@ -125,16 +125,16 @@ exports[`webhooks Node.js snippet generation express request should match fixtur
 Object {
   "security": Object {
     "api_key": Object {
-      "line": 21,
+      "line": 24,
     },
     "http_basic": Object {
-      "line": 22,
+      "line": 25,
     },
     "http_bearer": Object {
-      "line": 23,
+      "line": 26,
     },
     "oauth2": Object {
-      "line": 24,
+      "line": 27,
     },
   },
 }
@@ -144,10 +144,10 @@ exports[`webhooks Node.js snippet generation express request should match fixtur
 Object {
   "security": Object {
     "basic_auth": Object {
-      "line": 22,
+      "line": 25,
     },
     "petstore_auth": Object {
-      "line": 21,
+      "line": 24,
     },
   },
 }
@@ -157,10 +157,10 @@ exports[`webhooks Node.js snippet generation express request should match fixtur
 Object {
   "server": Object {
     "name": Object {
-      "line": 21,
+      "line": 24,
     },
     "port": Object {
-      "line": 22,
+      "line": 25,
     },
   },
 }

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -6,12 +6,12 @@ exports[`webhooks .NET snippet generation net6 request should match fixture for 
 Object {
   "security": Object {
     "petstore_auth": Object {
-      "line": 31,
+      "line": 36,
     },
   },
   "server": Object {
     "name": Object {
-      "line": 28,
+      "line": 33,
     },
   },
 }
@@ -21,18 +21,18 @@ exports[`webhooks .NET snippet generation net6 request should match fixture for 
 Object {
   "security": Object {
     "basic_auth": Object {
-      "line": 33,
+      "line": 38,
     },
     "petstore_auth": Object {
-      "line": 32,
+      "line": 37,
     },
   },
   "server": Object {
     "name": Object {
-      "line": 28,
+      "line": 33,
     },
     "port": Object {
-      "line": 29,
+      "line": 34,
     },
   },
 }
@@ -42,16 +42,16 @@ exports[`webhooks .NET snippet generation net6 request should match fixture for 
 Object {
   "security": Object {
     "api_key": Object {
-      "line": 28,
+      "line": 33,
     },
     "http_basic": Object {
-      "line": 29,
+      "line": 34,
     },
     "http_bearer": Object {
-      "line": 30,
+      "line": 35,
     },
     "oauth2": Object {
-      "line": 31,
+      "line": 36,
     },
   },
 }
@@ -61,10 +61,10 @@ exports[`webhooks .NET snippet generation net6 request should match fixture for 
 Object {
   "security": Object {
     "basic_auth": Object {
-      "line": 29,
+      "line": 34,
     },
     "petstore_auth": Object {
-      "line": 28,
+      "line": 33,
     },
   },
 }
@@ -74,10 +74,10 @@ exports[`webhooks .NET snippet generation net6 request should match fixture for 
 Object {
   "server": Object {
     "name": Object {
-      "line": 28,
+      "line": 33,
     },
     "port": Object {
-      "line": 29,
+      "line": 34,
     },
   },
 }

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -255,12 +255,12 @@ exports[`webhooks Python snippet generation flask request should match fixture f
 Object {
   "security": Object {
     "petstore_auth": Object {
-      "line": 37,
+      "line": 39,
     },
   },
   "server": Object {
     "name": Object {
-      "line": 34,
+      "line": 36,
     },
   },
 }
@@ -270,18 +270,18 @@ exports[`webhooks Python snippet generation flask request should match fixture f
 Object {
   "security": Object {
     "basic_auth": Object {
-      "line": 39,
+      "line": 41,
     },
     "petstore_auth": Object {
-      "line": 38,
+      "line": 40,
     },
   },
   "server": Object {
     "name": Object {
-      "line": 34,
+      "line": 36,
     },
     "port": Object {
-      "line": 35,
+      "line": 37,
     },
   },
 }
@@ -291,16 +291,16 @@ exports[`webhooks Python snippet generation flask request should match fixture f
 Object {
   "security": Object {
     "api_key": Object {
-      "line": 34,
-    },
-    "http_basic": Object {
-      "line": 35,
-    },
-    "http_bearer": Object {
       "line": 36,
     },
-    "oauth2": Object {
+    "http_basic": Object {
       "line": 37,
+    },
+    "http_bearer": Object {
+      "line": 38,
+    },
+    "oauth2": Object {
+      "line": 39,
     },
   },
 }
@@ -310,10 +310,10 @@ exports[`webhooks Python snippet generation flask request should match fixture f
 Object {
   "security": Object {
     "basic_auth": Object {
-      "line": 35,
+      "line": 37,
     },
     "petstore_auth": Object {
-      "line": 34,
+      "line": 36,
     },
   },
 }
@@ -323,10 +323,10 @@ exports[`webhooks Python snippet generation flask request should match fixture f
 Object {
   "server": Object {
     "name": Object {
-      "line": 34,
+      "line": 36,
     },
     "port": Object {
-      "line": 35,
+      "line": 37,
     },
   },
 }

--- a/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/client.ts
@@ -9,7 +9,7 @@ export const net6: Client = {
     link: 'https://docs.microsoft.com/en-us/dotnet/core/introduction',
     description: 'ReadMe Metrics Webhooks SDK usage on .NET 6.0',
   },
-  convert: ({ security, server }, options) => {
+  convert: ({ secret, security, server }, options) => {
     const opts = {
       indent: '  ',
       ...options,
@@ -22,12 +22,14 @@ export const net6: Client = {
 
     blank();
 
-    push('var secret = Environment.GetEnvironmentVariable("README_API_KEY");');
+    push('// Your ReadMe secret');
+    push(`var secret = "${secret}";`);
 
     blank();
 
     push('app.MapPost("/webhook", async context =>');
     push('{');
+    push('// Verify the request is legitimate and came from ReadMe.', 1);
     push('var signature = context.Request.Headers["readme-signature"];', 1);
     push('var body = await new StreamReader(context.Request.Body).ReadToEndAsync();', 1);
 
@@ -46,7 +48,10 @@ export const net6: Client = {
     push('});', 2);
     push('return;', 2);
     push('}', 1);
+    blank();
 
+    push('// Fetch the user from the database and return their data for use with OpenAPI variables.', 1);
+    push('// @todo Write your own query logic to fetch a user by `body["email"]`.', 1);
     blank();
 
     push('await context.Response.WriteAsJsonAsync(new', 1);
@@ -86,8 +91,6 @@ export const net6: Client = {
     blank();
 
     push('app.Run($"http://localhost:4000");');
-
-    blank();
 
     return {
       ranges: ranges(),

--- a/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/empty-default.cs
+++ b/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/empty-default.cs
@@ -1,10 +1,12 @@
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-var secret = Environment.GetEnvironmentVariable("README_API_KEY");
+// Your ReadMe secret
+var secret = "my-readme-secret";
 
 app.MapPost("/webhook", async context =>
 {
+  // Verify the request is legitimate and came from ReadMe.
   var signature = context.Request.Headers["readme-signature"];
   var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
 
@@ -21,6 +23,9 @@ app.MapPost("/webhook", async context =>
     });
     return;
   }
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // @todo Write your own query logic to fetch a user by `body["email"]`.
 
   await context.Response.WriteAsJsonAsync(new
   {

--- a/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/empty.cs
+++ b/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/empty.cs
@@ -1,10 +1,12 @@
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-var secret = Environment.GetEnvironmentVariable("README_API_KEY");
+// Your ReadMe secret
+var secret = "my-readme-secret";
 
 app.MapPost("/webhook", async context =>
 {
+  // Verify the request is legitimate and came from ReadMe.
   var signature = context.Request.Headers["readme-signature"];
   var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
 
@@ -21,6 +23,9 @@ app.MapPost("/webhook", async context =>
     });
     return;
   }
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // @todo Write your own query logic to fetch a user by `body["email"]`.
 
   await context.Response.WriteAsJsonAsync(new
   {

--- a/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/security-and-server-variables.cs
+++ b/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/security-and-server-variables.cs
@@ -1,10 +1,12 @@
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-var secret = Environment.GetEnvironmentVariable("README_API_KEY");
+// Your ReadMe secret
+var secret = "my-readme-secret";
 
 app.MapPost("/webhook", async context =>
 {
+  // Verify the request is legitimate and came from ReadMe.
   var signature = context.Request.Headers["readme-signature"];
   var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
 
@@ -21,6 +23,9 @@ app.MapPost("/webhook", async context =>
     });
     return;
   }
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // @todo Write your own query logic to fetch a user by `body["email"]`.
 
   await context.Response.WriteAsJsonAsync(new
   {

--- a/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/security-types.cs
+++ b/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/security-types.cs
@@ -1,10 +1,12 @@
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-var secret = Environment.GetEnvironmentVariable("README_API_KEY");
+// Your ReadMe secret
+var secret = "my-readme-secret";
 
 app.MapPost("/webhook", async context =>
 {
+  // Verify the request is legitimate and came from ReadMe.
   var signature = context.Request.Headers["readme-signature"];
   var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
 
@@ -21,6 +23,9 @@ app.MapPost("/webhook", async context =>
     });
     return;
   }
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // @todo Write your own query logic to fetch a user by `body["email"]`.
 
   await context.Response.WriteAsJsonAsync(new
   {

--- a/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/security-variables.cs
+++ b/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/security-variables.cs
@@ -1,10 +1,12 @@
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-var secret = Environment.GetEnvironmentVariable("README_API_KEY");
+// Your ReadMe secret
+var secret = "my-readme-secret";
 
 app.MapPost("/webhook", async context =>
 {
+  // Verify the request is legitimate and came from ReadMe.
   var signature = context.Request.Headers["readme-signature"];
   var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
 
@@ -21,6 +23,9 @@ app.MapPost("/webhook", async context =>
     });
     return;
   }
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // @todo Write your own query logic to fetch a user by `body["email"]`.
 
   await context.Response.WriteAsJsonAsync(new
   {

--- a/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/server-variables.cs
+++ b/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/server-variables.cs
@@ -1,10 +1,12 @@
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-var secret = Environment.GetEnvironmentVariable("README_API_KEY");
+// Your ReadMe secret
+var secret = "my-readme-secret";
 
 app.MapPost("/webhook", async context =>
 {
+  // Verify the request is legitimate and came from ReadMe.
   var signature = context.Request.Headers["readme-signature"];
   var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
 
@@ -21,6 +23,9 @@ app.MapPost("/webhook", async context =>
     });
     return;
   }
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // @todo Write your own query logic to fetch a user by `body["email"]`.
 
   await context.Response.WriteAsJsonAsync(new
   {

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
@@ -9,7 +9,7 @@ export const express: Client = {
     link: 'https://expressjs.com/',
     description: 'ReadMe Metrics Webhooks SDK usage on Express',
   },
-  convert: ({ security, server }, options) => {
+  convert: ({ secret, security, server }, options) => {
     const opts = {
       indent: '  ',
       ...options,
@@ -23,28 +23,33 @@ export const express: Client = {
     blank();
 
     push('const app = express();');
-
     blank();
 
-    push("app.post('/webhook', express.json({ type: 'application/json' }), (req, res) => {");
+    push('// Your ReadMe secret');
+    push(`const secret = '${secret}';`);
+    blank();
+
+    push("app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {");
     push('// Verify the request is legitimate and came from ReadMe', 1);
     push("const signature = req.headers['readme-signature'];", 1);
-    push('// Your ReadMe secret', 1);
-    push('const secret = process.env.README_API_KEY;', 1);
+    blank();
+
     push('try {', 1);
     push('readme.verifyWebhook(req.body, signature, secret);', 2);
     push('} catch (e) {', 1);
     push('// Handle invalid requests', 2);
     push('return res.status(401).json({ error: e.message });', 2);
     push('}', 1);
-    push('// Fetch the user from the db', 1);
-    push('return db.find({ email: req.body.email }).then(user => {', 1);
-    push('return res.json({', 2);
+    blank();
+
+    push('// Fetch the user from the database and return their data for use with OpenAPI variables.', 1);
+    push('// const user = await db.find({ email: req.body.email })', 1);
+    push('return res.json({', 1);
 
     if (server.length) {
-      push('// OAS Server variables', 3);
+      push('// OAS Server variables', 2);
       server.forEach(data => {
-        push(`${data.name}: '${data.default || data.default === '' ? data.default : data.name}',`, 3);
+        push(`${data.name}: '${data.default || data.default === '' ? data.default : data.name}',`, 2);
         variable('server', data.name);
       });
     }
@@ -54,31 +59,28 @@ export const express: Client = {
     }
 
     if (security.length) {
-      push('// OAS Security variables', 3);
+      push('// OAS Security variables', 2);
       security.forEach(data => {
         if (data.type === 'http') {
           // Only HTTP Basic auth has any special handling for supplying auth.
           if (data.scheme === 'basic') {
-            push(`${data.name}: { user: 'user', pass: 'pass' },`, 3);
+            push(`${data.name}: { user: 'user', pass: 'pass' },`, 2);
             variable('security', data.name);
             return;
           }
         }
 
-        push(`${data.name}: '${data.default || data.default === '' ? data.default : data.name}',`, 3);
+        push(`${data.name}: '${data.default || data.default === '' ? data.default : data.name}',`, 2);
         variable('security', data.name);
       });
     }
 
-    push('});', 2);
     push('});', 1);
     push('});');
 
     blank();
 
     push('app.listen(4000);');
-
-    blank();
 
     return {
       ranges: ranges(),

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
@@ -30,7 +30,7 @@ export const express: Client = {
     blank();
 
     push("app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {");
-    push('// Verify the request is legitimate and came from ReadMe', 1);
+    push('// Verify the request is legitimate and came from ReadMe.', 1);
     push("const signature = req.headers['readme-signature'];", 1);
     blank();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
@@ -7,7 +7,7 @@ const app = express();
 const secret = 'my-readme-secret';
 
 app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
-  // Verify the request is legitimate and came from ReadMe
+  // Verify the request is legitimate and came from ReadMe.
   const signature = req.headers['readme-signature'];
 
   try {

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
@@ -3,26 +3,28 @@ import readme from 'readmeio';
 
 const app = express();
 
-app.post('/webhook', express.json({ type: 'application/json' }), (req, res) => {
+// Your ReadMe secret
+const secret = 'my-readme-secret';
+
+app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
   // Verify the request is legitimate and came from ReadMe
   const signature = req.headers['readme-signature'];
-  // Your ReadMe secret
-  const secret = process.env.README_API_KEY;
+
   try {
     readme.verifyWebhook(req.body, signature, secret);
   } catch (e) {
     // Handle invalid requests
     return res.status(401).json({ error: e.message });
   }
-  // Fetch the user from the db
-  return db.find({ email: req.body.email }).then(user => {
-    return res.json({
-      // OAS Server variables
-      name: '',
 
-      // OAS Security variables
-      petstore_auth: '',
-    });
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // const user = await db.find({ email: req.body.email })
+  return res.json({
+    // OAS Server variables
+    name: '',
+
+    // OAS Security variables
+    petstore_auth: '',
   });
 });
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
@@ -7,7 +7,7 @@ const app = express();
 const secret = 'my-readme-secret';
 
 app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
-  // Verify the request is legitimate and came from ReadMe
+  // Verify the request is legitimate and came from ReadMe.
   const signature = req.headers['readme-signature'];
 
   try {

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
@@ -3,21 +3,23 @@ import readme from 'readmeio';
 
 const app = express();
 
-app.post('/webhook', express.json({ type: 'application/json' }), (req, res) => {
+// Your ReadMe secret
+const secret = 'my-readme-secret';
+
+app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
   // Verify the request is legitimate and came from ReadMe
   const signature = req.headers['readme-signature'];
-  // Your ReadMe secret
-  const secret = process.env.README_API_KEY;
+
   try {
     readme.verifyWebhook(req.body, signature, secret);
   } catch (e) {
     // Handle invalid requests
     return res.status(401).json({ error: e.message });
   }
-  // Fetch the user from the db
-  return db.find({ email: req.body.email }).then(user => {
-    return res.json({
-    });
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // const user = await db.find({ email: req.body.email })
+  return res.json({
   });
 });
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
@@ -7,7 +7,7 @@ const app = express();
 const secret = 'my-readme-secret';
 
 app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
-  // Verify the request is legitimate and came from ReadMe
+  // Verify the request is legitimate and came from ReadMe.
   const signature = req.headers['readme-signature'];
 
   try {

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
@@ -3,28 +3,30 @@ import readme from 'readmeio';
 
 const app = express();
 
-app.post('/webhook', express.json({ type: 'application/json' }), (req, res) => {
+// Your ReadMe secret
+const secret = 'my-readme-secret';
+
+app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
   // Verify the request is legitimate and came from ReadMe
   const signature = req.headers['readme-signature'];
-  // Your ReadMe secret
-  const secret = process.env.README_API_KEY;
+
   try {
     readme.verifyWebhook(req.body, signature, secret);
   } catch (e) {
     // Handle invalid requests
     return res.status(401).json({ error: e.message });
   }
-  // Fetch the user from the db
-  return db.find({ email: req.body.email }).then(user => {
-    return res.json({
-      // OAS Server variables
-      name: 'default-name',
-      port: '',
 
-      // OAS Security variables
-      petstore_auth: 'default-key',
-      basic_auth: { user: 'user', pass: 'pass' },
-    });
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // const user = await db.find({ email: req.body.email })
+  return res.json({
+    // OAS Server variables
+    name: 'default-name',
+    port: '',
+
+    // OAS Security variables
+    petstore_auth: 'default-key',
+    basic_auth: { user: 'user', pass: 'pass' },
   });
 });
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
@@ -7,7 +7,7 @@ const app = express();
 const secret = 'my-readme-secret';
 
 app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
-  // Verify the request is legitimate and came from ReadMe
+  // Verify the request is legitimate and came from ReadMe.
   const signature = req.headers['readme-signature'];
 
   try {

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
@@ -3,26 +3,28 @@ import readme from 'readmeio';
 
 const app = express();
 
-app.post('/webhook', express.json({ type: 'application/json' }), (req, res) => {
+// Your ReadMe secret
+const secret = 'my-readme-secret';
+
+app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
   // Verify the request is legitimate and came from ReadMe
   const signature = req.headers['readme-signature'];
-  // Your ReadMe secret
-  const secret = process.env.README_API_KEY;
+
   try {
     readme.verifyWebhook(req.body, signature, secret);
   } catch (e) {
     // Handle invalid requests
     return res.status(401).json({ error: e.message });
   }
-  // Fetch the user from the db
-  return db.find({ email: req.body.email }).then(user => {
-    return res.json({
-      // OAS Security variables
-      api_key: 'default-api_key-key',
-      http_basic: { user: 'user', pass: 'pass' },
-      http_bearer: 'default-http_bearer-key',
-      oauth2: 'default-oauth2-key',
-    });
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // const user = await db.find({ email: req.body.email })
+  return res.json({
+    // OAS Security variables
+    api_key: 'default-api_key-key',
+    http_basic: { user: 'user', pass: 'pass' },
+    http_bearer: 'default-http_bearer-key',
+    oauth2: 'default-oauth2-key',
   });
 });
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
@@ -7,7 +7,7 @@ const app = express();
 const secret = 'my-readme-secret';
 
 app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
-  // Verify the request is legitimate and came from ReadMe
+  // Verify the request is legitimate and came from ReadMe.
   const signature = req.headers['readme-signature'];
 
   try {

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
@@ -3,24 +3,26 @@ import readme from 'readmeio';
 
 const app = express();
 
-app.post('/webhook', express.json({ type: 'application/json' }), (req, res) => {
+// Your ReadMe secret
+const secret = 'my-readme-secret';
+
+app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
   // Verify the request is legitimate and came from ReadMe
   const signature = req.headers['readme-signature'];
-  // Your ReadMe secret
-  const secret = process.env.README_API_KEY;
+
   try {
     readme.verifyWebhook(req.body, signature, secret);
   } catch (e) {
     // Handle invalid requests
     return res.status(401).json({ error: e.message });
   }
-  // Fetch the user from the db
-  return db.find({ email: req.body.email }).then(user => {
-    return res.json({
-      // OAS Security variables
-      petstore_auth: 'default-key',
-      basic_auth: { user: 'user', pass: 'pass' },
-    });
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // const user = await db.find({ email: req.body.email })
+  return res.json({
+    // OAS Security variables
+    petstore_auth: 'default-key',
+    basic_auth: { user: 'user', pass: 'pass' },
   });
 });
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
@@ -7,7 +7,7 @@ const app = express();
 const secret = 'my-readme-secret';
 
 app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
-  // Verify the request is legitimate and came from ReadMe
+  // Verify the request is legitimate and came from ReadMe.
   const signature = req.headers['readme-signature'];
 
   try {

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
@@ -3,24 +3,26 @@ import readme from 'readmeio';
 
 const app = express();
 
-app.post('/webhook', express.json({ type: 'application/json' }), (req, res) => {
+// Your ReadMe secret
+const secret = 'my-readme-secret';
+
+app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
   // Verify the request is legitimate and came from ReadMe
   const signature = req.headers['readme-signature'];
-  // Your ReadMe secret
-  const secret = process.env.README_API_KEY;
+
   try {
     readme.verifyWebhook(req.body, signature, secret);
   } catch (e) {
     // Handle invalid requests
     return res.status(401).json({ error: e.message });
   }
-  // Fetch the user from the db
-  return db.find({ email: req.body.email }).then(user => {
-    return res.json({
-      // OAS Server variables
-      name: 'default-name',
-      port: '',
-    });
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // const user = await db.find({ email: req.body.email })
+  return res.json({
+    // OAS Server variables
+    name: 'default-name',
+    port: '',
   });
 });
 

--- a/packages/sdk-snippets/src/targets/php/laravel/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/php/laravel/webhooks/client.ts
@@ -9,7 +9,7 @@ export const laravel: Client = {
     link: 'https://laravel.com/',
     description: 'ReadMe Metrics Webhooks SDK usage on Laravel',
   },
-  convert: ({ security, server }, options) => {
+  convert: ({ secret, security, server }, options) => {
     const opts = {
       indent: '    ',
       ...options,
@@ -20,14 +20,14 @@ export const laravel: Client = {
     push('<?php');
     blank();
 
-    push('// Add this code into your `routes/web.php` file.');
-    push("Route::post('/webhook', function (\\Illuminate\\Http\\Request $request) {");
-    push('// Verify the request is legitimate and came from ReadMe.', 1);
-    push("$signature = $request->headers->get('readme-signature', '');", 1);
+    push('// Your ReadMe secret');
+    push(`$secret = '${secret}';`);
     blank();
 
-    push('// Your ReadMe secret', 1);
-    push("$secret = env('README_API_KEY', config('readme.api_key'));", 1);
+    push('// Add this code into your `routes/web.php` file.');
+    push("Route::post('/webhook', function (\\Illuminate\\Http\\Request $request) use ($secret) {");
+    push('// Verify the request is legitimate and came from ReadMe.', 1);
+    push("$signature = $request->headers->get('readme-signature', '');", 1);
     blank();
 
     push('try {', 1);

--- a/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/empty-default.php
+++ b/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/empty-default.php
@@ -1,12 +1,12 @@
 <?php
 
+// Your ReadMe secret
+$secret = 'my-readme-secret';
+
 // Add this code into your `routes/web.php` file.
-Route::post('/webhook', function (\Illuminate\Http\Request $request) {
+Route::post('/webhook', function (\Illuminate\Http\Request $request) use ($secret) {
     // Verify the request is legitimate and came from ReadMe.
     $signature = $request->headers->get('readme-signature', '');
-
-    // Your ReadMe secret
-    $secret = env('README_API_KEY', config('readme.api_key'));
 
     try {
         \ReadMe\Webhooks::verify($request->input(), $signature, $secret);

--- a/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/empty.php
+++ b/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/empty.php
@@ -1,12 +1,12 @@
 <?php
 
+// Your ReadMe secret
+$secret = 'my-readme-secret';
+
 // Add this code into your `routes/web.php` file.
-Route::post('/webhook', function (\Illuminate\Http\Request $request) {
+Route::post('/webhook', function (\Illuminate\Http\Request $request) use ($secret) {
     // Verify the request is legitimate and came from ReadMe.
     $signature = $request->headers->get('readme-signature', '');
-
-    // Your ReadMe secret
-    $secret = env('README_API_KEY', config('readme.api_key'));
 
     try {
         \ReadMe\Webhooks::verify($request->input(), $signature, $secret);

--- a/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/security-and-server-variables.php
+++ b/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/security-and-server-variables.php
@@ -1,12 +1,12 @@
 <?php
 
+// Your ReadMe secret
+$secret = 'my-readme-secret';
+
 // Add this code into your `routes/web.php` file.
-Route::post('/webhook', function (\Illuminate\Http\Request $request) {
+Route::post('/webhook', function (\Illuminate\Http\Request $request) use ($secret) {
     // Verify the request is legitimate and came from ReadMe.
     $signature = $request->headers->get('readme-signature', '');
-
-    // Your ReadMe secret
-    $secret = env('README_API_KEY', config('readme.api_key'));
 
     try {
         \ReadMe\Webhooks::verify($request->input(), $signature, $secret);

--- a/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/security-types.php
+++ b/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/security-types.php
@@ -1,12 +1,12 @@
 <?php
 
+// Your ReadMe secret
+$secret = 'my-readme-secret';
+
 // Add this code into your `routes/web.php` file.
-Route::post('/webhook', function (\Illuminate\Http\Request $request) {
+Route::post('/webhook', function (\Illuminate\Http\Request $request) use ($secret) {
     // Verify the request is legitimate and came from ReadMe.
     $signature = $request->headers->get('readme-signature', '');
-
-    // Your ReadMe secret
-    $secret = env('README_API_KEY', config('readme.api_key'));
 
     try {
         \ReadMe\Webhooks::verify($request->input(), $signature, $secret);

--- a/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/security-variables.php
+++ b/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/security-variables.php
@@ -1,12 +1,12 @@
 <?php
 
+// Your ReadMe secret
+$secret = 'my-readme-secret';
+
 // Add this code into your `routes/web.php` file.
-Route::post('/webhook', function (\Illuminate\Http\Request $request) {
+Route::post('/webhook', function (\Illuminate\Http\Request $request) use ($secret) {
     // Verify the request is legitimate and came from ReadMe.
     $signature = $request->headers->get('readme-signature', '');
-
-    // Your ReadMe secret
-    $secret = env('README_API_KEY', config('readme.api_key'));
 
     try {
         \ReadMe\Webhooks::verify($request->input(), $signature, $secret);

--- a/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/server-variables.php
+++ b/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/server-variables.php
@@ -1,12 +1,12 @@
 <?php
 
+// Your ReadMe secret
+$secret = 'my-readme-secret';
+
 // Add this code into your `routes/web.php` file.
-Route::post('/webhook', function (\Illuminate\Http\Request $request) {
+Route::post('/webhook', function (\Illuminate\Http\Request $request) use ($secret) {
     // Verify the request is legitimate and came from ReadMe.
     $signature = $request->headers->get('readme-signature', '');
-
-    // Your ReadMe secret
-    $secret = env('README_API_KEY', config('readme.api_key'));
 
     try {
         \ReadMe\Webhooks::verify($request->input(), $signature, $secret);

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/client.ts
@@ -39,7 +39,7 @@ export const flask: Client = {
 
     push('@app.post("/webhook")');
     push('def webhook():');
-    push('# Verify the request is legitimate and came from ReadMe', 1);
+    push('# Verify the request is legitimate and came from ReadMe.', 1);
     push('signature = request.headers.get("readme-signature", None)', 1);
     blank();
 
@@ -96,65 +96,6 @@ export const flask: Client = {
 
     push('if __name__ == "__main__":');
     push('app.run(debug=False, host="127.0.0.1", port=os.getenv("PORT", "4000"))', 1);
-
-    // push('<?php');
-    // blank();
-
-    // push('// Add this code into your `routes/web.php` file.');
-    // push("Route::post('/webhook', function (\\Illuminate\\Http\\Request $request) {");
-    // push('// Verify the request is legitimate and came from ReadMe.', 1);
-    // push("$signature = $request->headers->get('readme-signature', '');", 1);
-    // blank();
-
-    // push('// Your ReadMe secret', 1);
-    // push("$secret = env('README_API_KEY', config('readme.api_key'));", 1);
-    // blank();
-
-    // push('try {', 1);
-    // push('\\ReadMe\\Webhooks::verify($request->input(), $signature, $secret);', 2);
-    // push('} catch (\\Exception $e) {', 1);
-    // push('// Handle invalid requests', 2);
-    // push('return response()->json([', 2);
-    // push("'error' => $e->getMessage()", 3);
-    // push('], 401);', 2);
-    // push('}', 1);
-    // blank();
-
-    // push('// Fetch the user from the database and return their data for use with OpenAPI variables.', 1);
-    // push("// $user = DB::table('users')->where('email', $request->input('email'))->limit(1)->get();", 1);
-    // push('return response()->json([', 1);
-
-    // if (server.length) {
-    //   push('// OAS Server variables', 2);
-    //   server.forEach(data => {
-    //     push(`'${data.name}' => '${data.default || data.default === '' ? data.default : data.name}',`, 2);
-    //     variable('server', data.name);
-    //   });
-    // }
-
-    // if (server.length && security.length) {
-    //   blank();
-    // }
-
-    // if (security.length) {
-    //   push('// OAS Security variables', 2);
-    //   security.forEach(data => {
-    //     if (data.type === 'http') {
-    //       // Only HTTP Basic auth has any special handling for supplying auth.
-    //       if (data.scheme === 'basic') {
-    //         push(`'${data.name}' => ['user' => 'user', 'pass' => 'pass'],`, 2);
-    //         variable('security', data.name);
-    //         return;
-    //       }
-    //     }
-
-    //     push(`'${data.name}' => '${data.default || data.default === '' ? data.default : data.name}',`, 2);
-    //     variable('security', data.name);
-    //   });
-    // }
-
-    // push(']);', 1);
-    // push('});');
 
     return {
       ranges: ranges(),

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/client.ts
@@ -1,0 +1,162 @@
+import type { Client } from '../../../targets';
+
+import { CodeBuilder } from '../../../../helpers/code-builder';
+
+export const flask: Client = {
+  info: {
+    key: 'flask',
+    title: 'Flask',
+    link: 'https://flask.palletsprojects.com',
+    description: 'ReadMe Metrics Webhooks SDK usage on Flask',
+  },
+  convert: ({ security, server }, options) => {
+    const opts = {
+      indent: '    ',
+      ...options,
+    };
+
+    const { blank, join, push, ranges, variable } = new CodeBuilder({ indent: opts.indent });
+
+    push('import os');
+    push('import sys');
+    push('from flask import Flask, request');
+    push('from readme_metrics.VerifyWebhook import VerifyWebhook');
+    blank();
+
+    push('if os.getenv("README_API_KEY") is None:');
+    push('sys.stderr.write("Missing `README_API_KEY` environment variable")', 1);
+    push('sys.stderr.flush()', 1);
+    push('sys.exit(1)', 1);
+    blank();
+
+    push('app = Flask(__name__)');
+    blank();
+    blank();
+
+    push('@app.post("/webhook")');
+    push('def webhook():');
+    push('# Verify the request is legitimate and came from ReadMe', 1);
+    push('signature = request.headers.get("readme-signature", None)', 1);
+    blank();
+
+    push('# Your ReadMe secret', 1);
+    push('secret = os.getenv("README_API_KEY").encode("utf8")', 1);
+    blank();
+
+    push('try:', 1);
+    push('VerifyWebhook(request.get_json(), signature, secret)', 2);
+    push('except Exception as error:', 1);
+    push('return (', 2);
+    push('{"error": str(error)},', 3);
+    push('401,', 3);
+    push('{"Content-Type": "application/json; charset=utf-8"},', 3);
+    push(')', 2);
+    blank();
+
+    push('return (', 1);
+    push('{', 2);
+
+    if (server.length) {
+      push('# OAS Server variables', 3);
+      server.forEach(data => {
+        push(`"${data.name}": "${data.default || data.default === '' ? data.default : data.name}",`, 3);
+        variable('server', data.name);
+      });
+    }
+
+    if (server.length && security.length) {
+      blank();
+    }
+
+    if (security.length) {
+      push('# OAS Security variables', 3);
+      security.forEach(data => {
+        if (data.type === 'http') {
+          // Only HTTP Basic auth has any special handling for supplying auth.
+          if (data.scheme === 'basic') {
+            push(`"${data.name}": {"user": "user", "pass": "pass"},`, 3);
+            variable('security', data.name);
+            return;
+          }
+        }
+
+        push(`"${data.name}": "${data.default || data.default === '' ? data.default : data.name}",`, 3);
+        variable('security', data.name);
+      });
+    }
+
+    push('},', 2);
+    push('200,', 2);
+    push('{"Content-Type": "application/json; charset=utf-8"},', 2);
+    push(')', 1);
+    blank();
+    blank();
+
+    push('if __name__ == "__main__":');
+    push('app.run(debug=False, host="127.0.0.1", port=os.getenv("PORT", "4000"))', 1);
+
+    // push('<?php');
+    // blank();
+
+    // push('// Add this code into your `routes/web.php` file.');
+    // push("Route::post('/webhook', function (\\Illuminate\\Http\\Request $request) {");
+    // push('// Verify the request is legitimate and came from ReadMe.', 1);
+    // push("$signature = $request->headers->get('readme-signature', '');", 1);
+    // blank();
+
+    // push('// Your ReadMe secret', 1);
+    // push("$secret = env('README_API_KEY', config('readme.api_key'));", 1);
+    // blank();
+
+    // push('try {', 1);
+    // push('\\ReadMe\\Webhooks::verify($request->input(), $signature, $secret);', 2);
+    // push('} catch (\\Exception $e) {', 1);
+    // push('// Handle invalid requests', 2);
+    // push('return response()->json([', 2);
+    // push("'error' => $e->getMessage()", 3);
+    // push('], 401);', 2);
+    // push('}', 1);
+    // blank();
+
+    // push('// Fetch the user from the database and return their data for use with OpenAPI variables.', 1);
+    // push("// $user = DB::table('users')->where('email', $request->input('email'))->limit(1)->get();", 1);
+    // push('return response()->json([', 1);
+
+    // if (server.length) {
+    //   push('// OAS Server variables', 2);
+    //   server.forEach(data => {
+    //     push(`'${data.name}' => '${data.default || data.default === '' ? data.default : data.name}',`, 2);
+    //     variable('server', data.name);
+    //   });
+    // }
+
+    // if (server.length && security.length) {
+    //   blank();
+    // }
+
+    // if (security.length) {
+    //   push('// OAS Security variables', 2);
+    //   security.forEach(data => {
+    //     if (data.type === 'http') {
+    //       // Only HTTP Basic auth has any special handling for supplying auth.
+    //       if (data.scheme === 'basic') {
+    //         push(`'${data.name}' => ['user' => 'user', 'pass' => 'pass'],`, 2);
+    //         variable('security', data.name);
+    //         return;
+    //       }
+    //     }
+
+    //     push(`'${data.name}' => '${data.default || data.default === '' ? data.default : data.name}',`, 2);
+    //     variable('security', data.name);
+    //   });
+    // }
+
+    // push(']);', 1);
+    // push('});');
+
+    return {
+      ranges: ranges(),
+      snippet: join(),
+    };
+  },
+};

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/client.ts
@@ -9,7 +9,7 @@ export const flask: Client = {
     link: 'https://flask.palletsprojects.com',
     description: 'ReadMe Metrics Webhooks SDK usage on Flask',
   },
-  convert: ({ security, server }, options) => {
+  convert: ({ secret, security, server }, options) => {
     const opts = {
       indent: '    ',
       ...options,
@@ -31,16 +31,16 @@ export const flask: Client = {
 
     push('app = Flask(__name__)');
     blank();
+
+    push('# Your ReadMe secret');
+    push(`secret = "${secret}"`);
+    blank();
     blank();
 
     push('@app.post("/webhook")');
     push('def webhook():');
     push('# Verify the request is legitimate and came from ReadMe', 1);
     push('signature = request.headers.get("readme-signature", None)', 1);
-    blank();
-
-    push('# Your ReadMe secret', 1);
-    push('secret = os.getenv("README_API_KEY").encode("utf8")', 1);
     blank();
 
     push('try:', 1);
@@ -53,6 +53,8 @@ export const flask: Client = {
     push(')', 2);
     blank();
 
+    push('# Fetch the user from the database and return their data for use with OpenAPI variables.', 1);
+    push('# user = User.objects.get(email__exact=request.values.get("email"))', 1);
     push('return (', 1);
     push('{', 2);
 

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty-default.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty-default.py
@@ -30,8 +30,11 @@ def webhook():
 
     return (
         {
-            "petstore_auth": "default-key",
-            "basic_auth": {"user": "user", "pass": "pass"},
+            # OAS Server variables
+            "name": "",
+
+            # OAS Security variables
+            "petstore_auth": "",
         },
         200,
         {"Content-Type": "application/json; charset=utf-8"},

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty-default.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty-default.py
@@ -16,7 +16,7 @@ secret = "my-readme-secret"
 
 @app.post("/webhook")
 def webhook():
-    # Verify the request is legitimate and came from ReadMe
+    # Verify the request is legitimate and came from ReadMe.
     signature = request.headers.get("readme-signature", None)
 
     try:

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty-default.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty-default.py
@@ -10,14 +10,14 @@ if os.getenv("README_API_KEY") is None:
 
 app = Flask(__name__)
 
+# Your ReadMe secret
+secret = "my-readme-secret"
+
 
 @app.post("/webhook")
 def webhook():
     # Verify the request is legitimate and came from ReadMe
     signature = request.headers.get("readme-signature", None)
-
-    # Your ReadMe secret
-    secret = os.getenv("README_API_KEY").encode("utf8")
 
     try:
         VerifyWebhook(request.get_json(), signature, secret)
@@ -28,6 +28,8 @@ def webhook():
             {"Content-Type": "application/json; charset=utf-8"},
         )
 
+    # Fetch the user from the database and return their data for use with OpenAPI variables.
+    # user = User.objects.get(email__exact=request.values.get("email"))
     return (
         {
             # OAS Server variables

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty.py
@@ -30,8 +30,6 @@ def webhook():
 
     return (
         {
-            "petstore_auth": "default-key",
-            "basic_auth": {"user": "user", "pass": "pass"},
         },
         200,
         {"Content-Type": "application/json; charset=utf-8"},

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty.py
@@ -10,14 +10,14 @@ if os.getenv("README_API_KEY") is None:
 
 app = Flask(__name__)
 
+# Your ReadMe secret
+secret = "my-readme-secret"
+
 
 @app.post("/webhook")
 def webhook():
     # Verify the request is legitimate and came from ReadMe
     signature = request.headers.get("readme-signature", None)
-
-    # Your ReadMe secret
-    secret = os.getenv("README_API_KEY").encode("utf8")
 
     try:
         VerifyWebhook(request.get_json(), signature, secret)
@@ -28,6 +28,8 @@ def webhook():
             {"Content-Type": "application/json; charset=utf-8"},
         )
 
+    # Fetch the user from the database and return their data for use with OpenAPI variables.
+    # user = User.objects.get(email__exact=request.values.get("email"))
     return (
         {
         },

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/empty.py
@@ -16,7 +16,7 @@ secret = "my-readme-secret"
 
 @app.post("/webhook")
 def webhook():
-    # Verify the request is legitimate and came from ReadMe
+    # Verify the request is legitimate and came from ReadMe.
     signature = request.headers.get("readme-signature", None)
 
     try:

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-and-server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-and-server-variables.py
@@ -16,7 +16,7 @@ secret = "my-readme-secret"
 
 @app.post("/webhook")
 def webhook():
-    # Verify the request is legitimate and came from ReadMe
+    # Verify the request is legitimate and came from ReadMe.
     signature = request.headers.get("readme-signature", None)
 
     try:

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-and-server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-and-server-variables.py
@@ -10,14 +10,14 @@ if os.getenv("README_API_KEY") is None:
 
 app = Flask(__name__)
 
+# Your ReadMe secret
+secret = "my-readme-secret"
+
 
 @app.post("/webhook")
 def webhook():
     # Verify the request is legitimate and came from ReadMe
     signature = request.headers.get("readme-signature", None)
-
-    # Your ReadMe secret
-    secret = os.getenv("README_API_KEY").encode("utf8")
 
     try:
         VerifyWebhook(request.get_json(), signature, secret)
@@ -28,6 +28,8 @@ def webhook():
             {"Content-Type": "application/json; charset=utf-8"},
         )
 
+    # Fetch the user from the database and return their data for use with OpenAPI variables.
+    # user = User.objects.get(email__exact=request.values.get("email"))
     return (
         {
             # OAS Server variables

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-and-server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-and-server-variables.py
@@ -30,6 +30,11 @@ def webhook():
 
     return (
         {
+            # OAS Server variables
+            "name": "default-name",
+            "port": "",
+
+            # OAS Security variables
             "petstore_auth": "default-key",
             "basic_auth": {"user": "user", "pass": "pass"},
         },

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-types.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-types.py
@@ -16,7 +16,7 @@ secret = "my-readme-secret"
 
 @app.post("/webhook")
 def webhook():
-    # Verify the request is legitimate and came from ReadMe
+    # Verify the request is legitimate and came from ReadMe.
     signature = request.headers.get("readme-signature", None)
 
     try:

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-types.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-types.py
@@ -10,14 +10,14 @@ if os.getenv("README_API_KEY") is None:
 
 app = Flask(__name__)
 
+# Your ReadMe secret
+secret = "my-readme-secret"
+
 
 @app.post("/webhook")
 def webhook():
     # Verify the request is legitimate and came from ReadMe
     signature = request.headers.get("readme-signature", None)
-
-    # Your ReadMe secret
-    secret = os.getenv("README_API_KEY").encode("utf8")
 
     try:
         VerifyWebhook(request.get_json(), signature, secret)
@@ -28,6 +28,8 @@ def webhook():
             {"Content-Type": "application/json; charset=utf-8"},
         )
 
+    # Fetch the user from the database and return their data for use with OpenAPI variables.
+    # user = User.objects.get(email__exact=request.values.get("email"))
     return (
         {
             # OAS Security variables

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-types.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-types.py
@@ -30,8 +30,11 @@ def webhook():
 
     return (
         {
-            "petstore_auth": "default-key",
-            "basic_auth": {"user": "user", "pass": "pass"},
+            # OAS Security variables
+            "api_key": "default-api_key-key",
+            "http_basic": {"user": "user", "pass": "pass"},
+            "http_bearer": "default-http_bearer-key",
+            "oauth2": "default-oauth2-key",
         },
         200,
         {"Content-Type": "application/json; charset=utf-8"},

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-variables.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-variables.py
@@ -30,6 +30,7 @@ def webhook():
 
     return (
         {
+            # OAS Security variables
             "petstore_auth": "default-key",
             "basic_auth": {"user": "user", "pass": "pass"},
         },

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-variables.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-variables.py
@@ -16,7 +16,7 @@ secret = "my-readme-secret"
 
 @app.post("/webhook")
 def webhook():
-    # Verify the request is legitimate and came from ReadMe
+    # Verify the request is legitimate and came from ReadMe.
     signature = request.headers.get("readme-signature", None)
 
     try:

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-variables.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/security-variables.py
@@ -10,14 +10,14 @@ if os.getenv("README_API_KEY") is None:
 
 app = Flask(__name__)
 
+# Your ReadMe secret
+secret = "my-readme-secret"
+
 
 @app.post("/webhook")
 def webhook():
     # Verify the request is legitimate and came from ReadMe
     signature = request.headers.get("readme-signature", None)
-
-    # Your ReadMe secret
-    secret = os.getenv("README_API_KEY").encode("utf8")
 
     try:
         VerifyWebhook(request.get_json(), signature, secret)
@@ -28,6 +28,8 @@ def webhook():
             {"Content-Type": "application/json; charset=utf-8"},
         )
 
+    # Fetch the user from the database and return their data for use with OpenAPI variables.
+    # user = User.objects.get(email__exact=request.values.get("email"))
     return (
         {
             # OAS Security variables

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/server-variables.py
@@ -16,7 +16,7 @@ secret = "my-readme-secret"
 
 @app.post("/webhook")
 def webhook():
-    # Verify the request is legitimate and came from ReadMe
+    # Verify the request is legitimate and came from ReadMe.
     signature = request.headers.get("readme-signature", None)
 
     try:

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/server-variables.py
@@ -10,14 +10,14 @@ if os.getenv("README_API_KEY") is None:
 
 app = Flask(__name__)
 
+# Your ReadMe secret
+secret = "my-readme-secret"
+
 
 @app.post("/webhook")
 def webhook():
     # Verify the request is legitimate and came from ReadMe
     signature = request.headers.get("readme-signature", None)
-
-    # Your ReadMe secret
-    secret = os.getenv("README_API_KEY").encode("utf8")
 
     try:
         VerifyWebhook(request.get_json(), signature, secret)
@@ -28,6 +28,8 @@ def webhook():
             {"Content-Type": "application/json; charset=utf-8"},
         )
 
+    # Fetch the user from the database and return their data for use with OpenAPI variables.
+    # user = User.objects.get(email__exact=request.values.get("email"))
     return (
         {
             # OAS Server variables

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/server-variables.py
@@ -30,8 +30,9 @@ def webhook():
 
     return (
         {
-            "petstore_auth": "default-key",
-            "basic_auth": {"user": "user", "pass": "pass"},
+            # OAS Server variables
+            "name": "default-name",
+            "port": "",
         },
         200,
         {"Content-Type": "application/json; charset=utf-8"},

--- a/packages/sdk-snippets/src/targets/python/target.ts
+++ b/packages/sdk-snippets/src/targets/python/target.ts
@@ -1,0 +1,19 @@
+import type { Target } from '../targets';
+
+import { flask } from './flask/webhooks/client';
+
+export const python: Target = {
+  info: {
+    key: 'python',
+    title: 'Python',
+    extname: '.py',
+    default: 'flask',
+    cli: 'python3 %s',
+  },
+  services: {
+    server: {},
+    webhooks: {
+      flask,
+    },
+  },
+};

--- a/packages/sdk-snippets/src/targets/targets.ts
+++ b/packages/sdk-snippets/src/targets/targets.ts
@@ -5,6 +5,7 @@ import type { Merge } from 'type-fest';
 import { dotnet } from './dotnet/target';
 import { node } from './node/target';
 import { php } from './php/target';
+import { python } from './python/target';
 
 export type TargetId = keyof typeof targets;
 export type SnippetType = 'webhooks' | 'server';
@@ -60,4 +61,5 @@ export const targets = {
   dotnet,
   node,
   php,
+  python,
 };

--- a/packages/sdk-snippets/src/targets/targets.ts
+++ b/packages/sdk-snippets/src/targets/targets.ts
@@ -25,6 +25,7 @@ export interface ClientRanges {
 
 export type Converter<T extends Record<string, any>> = (
   params: {
+    secret?: string;
     security: SecurityVariable[];
     server: ServerVariable[];
   },


### PR DESCRIPTION
## 🧰 Changes

* [x] Adding a new argument to the SDK snippet package constructor that allows us to pass in `{ secret: 'something' }` so we can inject real user webhook secrets into their own code snippets.
* [x] Cleaning up our webhook snippets a bit so they match the same general pattern.
