### PR TITLE
fix(snippets): sanitizing webhook variables before inserting them into code snippets

### DIFF
--- a/packages/sdk-snippets/src/fixtures/webhooks/quirky-escaping.js
+++ b/packages/sdk-snippets/src/fixtures/webhooks/quirky-escaping.js
@@ -1,0 +1,42 @@
+module.exports = [
+  {
+    name: '"petstore" auth',
+    default: 'default "key"\\',
+    source: 'security',
+    type: 'oauth2',
+  },
+  {
+    name: 'basic-auth',
+    default: 'default',
+    source: 'security',
+    type: 'http',
+    scheme: 'basic',
+  },
+  {
+    name: 'normal_security_var',
+    default: 'default',
+    source: 'security',
+    type: 'http',
+    scheme: 'basic',
+  },
+  {
+    name: '2name',
+    default: 'default-name',
+    source: 'server',
+  },
+  {
+    name: '*port',
+    default: '',
+    source: 'server',
+  },
+  {
+    name: 'p*o?r*t',
+    default: '',
+    source: 'server',
+  },
+  {
+    name: 'normal_server_var',
+    default: '',
+    source: 'server',
+  },
+];

--- a/packages/sdk-snippets/src/helpers/escape.ts
+++ b/packages/sdk-snippets/src/helpers/escape.ts
@@ -1,0 +1,123 @@
+export interface EscapeOptions {
+  /**
+   * The delimiter that will be used to wrap the string (and so must be escaped
+   * when used within the string).
+   * Defaults to "
+   */
+  delimiter?: string;
+
+  /**
+   * The char to use to escape the delimiter and other special characters.
+   * Defaults to \
+   */
+  escapeChar?: string;
+
+  /**
+   * Whether newlines (\n and \r) should be escaped within the string.
+   * Defaults to true.
+   */
+  escapeNewlines?: boolean;
+}
+
+/**
+ * Escape characters within a value to make it safe to insert directly into a
+ * snippet. Takes options which define the escape requirements.
+ *
+ * This is closely based on the JSON-stringify string serialization algorithm,
+ * but generalized for other string delimiters (e.g. " or ') and different escape
+ * characters (e.g. Powershell uses `)
+ *
+ * See https://tc39.es/ecma262/multipage/structured-data.html#sec-quotejsonstring
+ * for the complete original algorithm.
+ */
+export function escapeString(rawValue: any, options: EscapeOptions = {}) {
+  const { delimiter = '"', escapeChar = '\\', escapeNewlines = true } = options;
+
+  const stringValue = rawValue.toString();
+
+  return [...stringValue]
+    .map(c => {
+      if (c === '\b') {
+        return `${escapeChar}b`;
+      } else if (c === '\t') {
+        return `${escapeChar}t`;
+      } else if (c === '\n') {
+        if (escapeNewlines) {
+          return `${escapeChar}n`;
+        }
+        return c; // Don't just continue, or this is caught by < \u0020
+      } else if (c === '\f') {
+        return `${escapeChar}f`;
+      } else if (c === '\r') {
+        if (escapeNewlines) {
+          return `${escapeChar}r`;
+        }
+        return c; // Don't just continue, or this is caught by < \u0020
+      } else if (c === escapeChar) {
+        return escapeChar + escapeChar;
+      } else if (c === delimiter) {
+        return escapeChar + delimiter;
+      } else if (c < '\u0020' || c > '\u007E') {
+        // Delegate the trickier non-ASCII cases to the normal algorithm. Some of these
+        // are escaped as \uXXXX, whilst others are represented literally. Since we're
+        // using this primarily for header values that are generally (though not 100%
+        // strictly?) ASCII-only, this should almost never happen.
+        return JSON.stringify(c).slice(1, -1);
+      }
+      return c;
+    })
+    .join('');
+}
+
+/**
+ * Make a string value safe to insert literally into a snippet within single quotes,
+ * by escaping problematic characters, including single quotes inside the string,
+ * backslashes, newlines, and other special characters.
+ *
+ * If value is not a string, it will be stringified with .toString() first.
+ */
+export const escapeForSingleQuotes = (value: any) => escapeString(value, { delimiter: "'" });
+
+/**
+ * Make a string value safe to insert literally into a snippet within double quotes,
+ * by escaping problematic characters, including double quotes inside the string,
+ * backslashes, newlines, and other special characters.
+ *
+ * If value is not a string, it will be stringified with .toString() first.
+ */
+export const escapeForDoubleQuotes = (value: any) => escapeString(value, { delimiter: '"' });
+
+function quotedString(str: string, doubleQuotes: boolean) {
+  if (doubleQuotes) {
+    return `"${str}"`;
+  }
+
+  return `'${str}'`;
+}
+
+/**
+ * Safely escape and prepare a string to be used as an object key.
+ *
+ */
+export function escapeForObjectKey(str: string, doubleQuotes = false) {
+  const escaped = doubleQuotes ? escapeForDoubleQuotes(str) : escapeForSingleQuotes(str);
+
+  // If this key doesn't start with an alpha character then we should always wrap it in quotes and
+  // then run it through some escaping logic to make sure that it doesn't contain anything that
+  // might break out of the quotes.
+  if (!/^([A-Za-z]{1})/.test(str)) {
+    return quotedString(escaped, doubleQuotes);
+  } else if (escaped === str) {
+    // If our key doesn't have any characters that might break out of quotes and requring escaping
+    // but might have any non-alphanumeric characters in it that might not be able to be used as
+    // a JS property key then we should wrap the key in quotes.
+    if (/([^A-Za-z_0-9])/.test(str)) {
+      return quotedString(str, doubleQuotes);
+    }
+
+    // If our key doesn't need to be escaped then we don't need to wrap it in quotes.
+    return str;
+  }
+
+  return quotedString(str, doubleQuotes);
+}

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -17,6 +17,36 @@ Object {
 }
 `;
 
+exports[`webhooks .NET snippet generation net6 request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "security": Object {
+    "\\"petstore\\" auth": Object {
+      "line": 39,
+    },
+    "basic-auth": Object {
+      "line": 40,
+    },
+    "normal_security_var": Object {
+      "line": 41,
+    },
+  },
+  "server": Object {
+    "*port": Object {
+      "line": 34,
+    },
+    "2name": Object {
+      "line": 33,
+    },
+    "normal_server_var": Object {
+      "line": 36,
+    },
+    "p*o?r*t": Object {
+      "line": 35,
+    },
+  },
+}
+`;
+
 exports[`webhooks .NET snippet generation net6 request should match fixture for "security-and-server-variables" 1`] = `
 Object {
   "security": Object {
@@ -95,6 +125,36 @@ Object {
   "server": Object {
     "name": Object {
       "line": 24,
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js snippet generation express request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "security": Object {
+    "\\"petstore\\" auth": Object {
+      "line": 30,
+    },
+    "basic-auth": Object {
+      "line": 31,
+    },
+    "normal_security_var": Object {
+      "line": 32,
+    },
+  },
+  "server": Object {
+    "*port": Object {
+      "line": 25,
+    },
+    "2name": Object {
+      "line": 24,
+    },
+    "normal_server_var": Object {
+      "line": 27,
+    },
+    "p*o?r*t": Object {
+      "line": 26,
     },
   },
 }
@@ -183,6 +243,36 @@ Object {
 }
 `;
 
+exports[`webhooks PHP snippet generation laravel request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "security": Object {
+    "\\"petstore\\" auth": Object {
+      "line": 30,
+    },
+    "basic-auth": Object {
+      "line": 31,
+    },
+    "normal_security_var": Object {
+      "line": 32,
+    },
+  },
+  "server": Object {
+    "*port": Object {
+      "line": 25,
+    },
+    "2name": Object {
+      "line": 24,
+    },
+    "normal_server_var": Object {
+      "line": 27,
+    },
+    "p*o?r*t": Object {
+      "line": 26,
+    },
+  },
+}
+`;
+
 exports[`webhooks PHP snippet generation laravel request should match fixture for "security-and-server-variables" 1`] = `
 Object {
   "security": Object {
@@ -261,6 +351,36 @@ Object {
   "server": Object {
     "name": Object {
       "line": 36,
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation flask request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "security": Object {
+    "\\"petstore\\" auth": Object {
+      "line": 42,
+    },
+    "basic-auth": Object {
+      "line": 43,
+    },
+    "normal_security_var": Object {
+      "line": 44,
+    },
+  },
+  "server": Object {
+    "*port": Object {
+      "line": 37,
+    },
+    "2name": Object {
+      "line": 36,
+    },
+    "normal_server_var": Object {
+      "line": 39,
+    },
+    "p*o?r*t": Object {
+      "line": 38,
     },
   },
 }

--- a/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/client.ts
@@ -1,6 +1,7 @@
 import type { Client } from '../../../targets';
 
 import { CodeBuilder } from '../../../../helpers/code-builder';
+import { escapeForObjectKey, escapeForDoubleQuotes } from '../../../../helpers/escape';
 
 export const net6: Client = {
   info: {
@@ -59,7 +60,12 @@ export const net6: Client = {
     if (server.length) {
       push('// OAS Server variables', 2);
       server.forEach(data => {
-        push(`${data.name} = "${data.default || data.default === '' ? data.default : data.name}",`, 2);
+        push(
+          `${escapeForObjectKey(data.name, true)} = "${escapeForDoubleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}",`,
+          2
+        );
         variable('server', data.name);
       });
     }
@@ -74,13 +80,18 @@ export const net6: Client = {
         if (data.type === 'http') {
           // Only HTTP Basic auth has any special handling for supplying auth.
           if (data.scheme === 'basic') {
-            push(`${data.name} = new { user = "user", pass = "pass" },`, 2);
+            push(`${escapeForObjectKey(data.name, true)} = new { user = "user", pass = "pass" },`, 2);
             variable('security', data.name);
             return;
           }
         }
 
-        push(`${data.name} = "${data.default || data.default === '' ? data.default : data.name}",`, 2);
+        push(
+          `${escapeForObjectKey(data.name, true)} = "${escapeForDoubleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}",`,
+          2
+        );
         variable('security', data.name);
       });
     }

--- a/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/quirky-escaping.cs
+++ b/packages/sdk-snippets/src/targets/dotnet/net6/webhooks/fixtures/quirky-escaping.cs
@@ -1,0 +1,45 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+// Your ReadMe secret
+var secret = "my-readme-secret";
+
+app.MapPost("/webhook", async context =>
+{
+  // Verify the request is legitimate and came from ReadMe.
+  var signature = context.Request.Headers["readme-signature"];
+  var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
+
+  try
+  {
+    ReadMe.Webhook.Verify(body, signature, secret);
+  }
+  catch (Exception e)
+  {
+    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+    await context.Response.WriteAsJsonAsync(new
+    {
+      error = e.Message,
+    });
+    return;
+  }
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // @todo Write your own query logic to fetch a user by `body["email"]`.
+
+  await context.Response.WriteAsJsonAsync(new
+  {
+    // OAS Server variables
+    "2name" = "default-name",
+    "*port" = "",
+    "p*o?r*t" = "",
+    normal_server_var = "",
+
+    // OAS Security variables
+    "\"petstore\" auth" = "default \"key\"\\",
+    "basic-auth" = new { user = "user", pass = "pass" },
+    normal_security_var = new { user = "user", pass = "pass" },
+  });
+});
+
+app.Run($"http://localhost:4000");

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
@@ -1,6 +1,7 @@
 import type { Client } from '../../../targets';
 
 import { CodeBuilder } from '../../../../helpers/code-builder';
+import { escapeForObjectKey, escapeForSingleQuotes } from '../../../../helpers/escape';
 
 export const express: Client = {
   info: {
@@ -49,7 +50,12 @@ export const express: Client = {
     if (server.length) {
       push('// OAS Server variables', 2);
       server.forEach(data => {
-        push(`${data.name}: '${data.default || data.default === '' ? data.default : data.name}',`, 2);
+        push(
+          `${escapeForObjectKey(data.name)}: '${escapeForSingleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}',`,
+          2
+        );
         variable('server', data.name);
       });
     }
@@ -64,13 +70,18 @@ export const express: Client = {
         if (data.type === 'http') {
           // Only HTTP Basic auth has any special handling for supplying auth.
           if (data.scheme === 'basic') {
-            push(`${data.name}: { user: 'user', pass: 'pass' },`, 2);
+            push(`${escapeForObjectKey(data.name)}: { user: 'user', pass: 'pass' },`, 2);
             variable('security', data.name);
             return;
           }
         }
 
-        push(`${data.name}: '${data.default || data.default === '' ? data.default : data.name}',`, 2);
+        push(
+          `${escapeForObjectKey(data.name)}: '${escapeForSingleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}',`,
+          2
+        );
         variable('security', data.name);
       });
     }

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/quirky-escaping.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/quirky-escaping.js
@@ -1,0 +1,36 @@
+import express from 'express';
+import readme from 'readmeio';
+
+const app = express();
+
+// Your ReadMe secret
+const secret = 'my-readme-secret';
+
+app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {
+  // Verify the request is legitimate and came from ReadMe.
+  const signature = req.headers['readme-signature'];
+
+  try {
+    readme.verifyWebhook(req.body, signature, secret);
+  } catch (e) {
+    // Handle invalid requests
+    return res.status(401).json({ error: e.message });
+  }
+
+  // Fetch the user from the database and return their data for use with OpenAPI variables.
+  // const user = await db.find({ email: req.body.email })
+  return res.json({
+    // OAS Server variables
+    '2name': 'default-name',
+    '*port': '',
+    'p*o?r*t': '',
+    normal_server_var: '',
+
+    // OAS Security variables
+    '"petstore" auth': 'default "key"\\',
+    'basic-auth': { user: 'user', pass: 'pass' },
+    normal_security_var: { user: 'user', pass: 'pass' },
+  });
+});
+
+app.listen(4000);

--- a/packages/sdk-snippets/src/targets/php/laravel/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/php/laravel/webhooks/client.ts
@@ -1,6 +1,7 @@
 import type { Client } from '../../../targets';
 
 import { CodeBuilder } from '../../../../helpers/code-builder';
+import { escapeForSingleQuotes } from '../../../../helpers/escape';
 
 export const laravel: Client = {
   info: {
@@ -47,7 +48,12 @@ export const laravel: Client = {
     if (server.length) {
       push('// OAS Server variables', 2);
       server.forEach(data => {
-        push(`'${data.name}' => '${data.default || data.default === '' ? data.default : data.name}',`, 2);
+        push(
+          `'${escapeForSingleQuotes(data.name)}' => '${escapeForSingleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}',`,
+          2
+        );
         variable('server', data.name);
       });
     }
@@ -62,13 +68,18 @@ export const laravel: Client = {
         if (data.type === 'http') {
           // Only HTTP Basic auth has any special handling for supplying auth.
           if (data.scheme === 'basic') {
-            push(`'${data.name}' => ['user' => 'user', 'pass' => 'pass'],`, 2);
+            push(`'${escapeForSingleQuotes(data.name)}' => ['user' => 'user', 'pass' => 'pass'],`, 2);
             variable('security', data.name);
             return;
           }
         }
 
-        push(`'${data.name}' => '${data.default || data.default === '' ? data.default : data.name}',`, 2);
+        push(
+          `'${escapeForSingleQuotes(data.name)}' => '${escapeForSingleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}',`,
+          2
+        );
         variable('security', data.name);
       });
     }

--- a/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/quirky-escaping.php
+++ b/packages/sdk-snippets/src/targets/php/laravel/webhooks/fixtures/quirky-escaping.php
@@ -1,0 +1,34 @@
+<?php
+
+// Your ReadMe secret
+$secret = 'my-readme-secret';
+
+// Add this code into your `routes/web.php` file.
+Route::post('/webhook', function (\Illuminate\Http\Request $request) use ($secret) {
+    // Verify the request is legitimate and came from ReadMe.
+    $signature = $request->headers->get('readme-signature', '');
+
+    try {
+        \ReadMe\Webhooks::verify($request->input(), $signature, $secret);
+    } catch (\Exception $e) {
+        // Handle invalid requests
+        return response()->json([
+            'error' => $e->getMessage()
+        ], 401);
+    }
+
+    // Fetch the user from the database and return their data for use with OpenAPI variables.
+    // $user = DB::table('users')->where('email', $request->input('email'))->limit(1)->get();
+    return response()->json([
+        // OAS Server variables
+        '2name' => 'default-name',
+        '*port' => '',
+        'p*o?r*t' => '',
+        'normal_server_var' => '',
+
+        // OAS Security variables
+        '"petstore" auth' => 'default "key"\\',
+        'basic-auth' => ['user' => 'user', 'pass' => 'pass'],
+        'normal_security_var' => ['user' => 'user', 'pass' => 'pass'],
+    ]);
+});

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/client.ts
@@ -1,6 +1,7 @@
 import type { Client } from '../../../targets';
 
 import { CodeBuilder } from '../../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../../helpers/escape';
 
 export const flask: Client = {
   info: {
@@ -61,7 +62,12 @@ export const flask: Client = {
     if (server.length) {
       push('# OAS Server variables', 3);
       server.forEach(data => {
-        push(`"${data.name}": "${data.default || data.default === '' ? data.default : data.name}",`, 3);
+        push(
+          `"${escapeForDoubleQuotes(data.name)}": "${escapeForDoubleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}",`,
+          3
+        );
         variable('server', data.name);
       });
     }
@@ -76,13 +82,18 @@ export const flask: Client = {
         if (data.type === 'http') {
           // Only HTTP Basic auth has any special handling for supplying auth.
           if (data.scheme === 'basic') {
-            push(`"${data.name}": {"user": "user", "pass": "pass"},`, 3);
+            push(`"${escapeForDoubleQuotes(data.name)}": {"user": "user", "pass": "pass"},`, 3);
             variable('security', data.name);
             return;
           }
         }
 
-        push(`"${data.name}": "${data.default || data.default === '' ? data.default : data.name}",`, 3);
+        push(
+          `"${escapeForDoubleQuotes(data.name)}": "${escapeForDoubleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}",`,
+          3
+        );
         variable('security', data.name);
       });
     }

--- a/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/quirky-escaping.py
+++ b/packages/sdk-snippets/src/targets/python/flask/webhooks/fixtures/quirky-escaping.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from flask import Flask, request
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+if os.getenv("README_API_KEY") is None:
+    sys.stderr.write("Missing `README_API_KEY` environment variable")
+    sys.stderr.flush()
+    sys.exit(1)
+
+app = Flask(__name__)
+
+# Your ReadMe secret
+secret = "my-readme-secret"
+
+
+@app.post("/webhook")
+def webhook():
+    # Verify the request is legitimate and came from ReadMe.
+    signature = request.headers.get("readme-signature", None)
+
+    try:
+        VerifyWebhook(request.get_json(), signature, secret)
+    except Exception as error:
+        return (
+            {"error": str(error)},
+            401,
+            {"Content-Type": "application/json; charset=utf-8"},
+        )
+
+    # Fetch the user from the database and return their data for use with OpenAPI variables.
+    # user = User.objects.get(email__exact=request.values.get("email"))
+    return (
+        {
+            # OAS Server variables
+            "2name": "default-name",
+            "*port": "",
+            "p*o?r*t": "",
+            "normal_server_var": "",
+
+            # OAS Security variables
+            "\"petstore\" auth": "default \"key\"\\",
+            "basic-auth": {"user": "user", "pass": "pass"},
+            "normal_security_var": {"user": "user", "pass": "pass"},
+        },
+        200,
+        {"Content-Type": "application/json; charset=utf-8"},
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=False, host="127.0.0.1", port=os.getenv("PORT", "4000"))


### PR DESCRIPTION
## 🧰 Changes

This fixes a problem with all of our SDK snippet generators where if any webhook security or server variable had weird characters in either its name or value we might generate a code snippet that wouldn't be parseable by the language in question.

## 🧬 QA & Testing

All of these `quirky-escaping` fixtures have been verified to be valid by way of VSCode's intellisense feature. Look mah,  no squigglies.

#### .NET
![Screen Shot 2022-08-19 at 6 14 04 PM](https://user-images.githubusercontent.com/33762/185723706-860ddd98-4df8-42d7-a215-a82f0181504c.png)

#### PHP
![Screen Shot 2022-08-19 at 6 14 33 PM](https://user-images.githubusercontent.com/33762/185723716-4714a5f9-b6db-45ea-aa31-4ecb3f48c238.png)

#### Python
![Screen Shot 2022-08-19 at 6 14 41 PM](https://user-images.githubusercontent.com/33762/185723720-6228cc3e-08bc-48e3-b6ad-499ab0809dd0.png)

#### Node
![Screen Shot 2022-08-19 at 6 15 38 PM](https://user-images.githubusercontent.com/33762/185723733-41e2cd19-430b-4a07-a011-a146304d7397.png)