### PR TITLE
feat(integration): add POST method test

### DIFF
--- a/packages/node/examples/express/index.js
+++ b/packages/node/examples/express/index.js
@@ -28,6 +28,10 @@ app.get('/', (req, res) => {
   res.json({ message: 'hello world' });
 });
 
+app.post('/', express.json(), (req, res) => {
+  res.sendStatus(200);
+});
+
 const server = app.listen(port, 'localhost', function () {
   // eslint-disable-next-line no-console
   console.log('Example app listening at http://%s:%s', server.address().address, port);


### PR DESCRIPTION
Right now the hapi/fastify examples are not working properly for accepting
an incoming POST body. This adds a test to expose that flaw, but does not
yet fix it.

I think this refactor makes the most sense to finish once
https://github.com/readmeio/metrics-sdks/pull/459 is merged in.

| 🚥 Fix RM-XXX |
| :-- |

## 🧰 Changes

Describe in detail what this PR is for.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
