### PR TITLE
fix(python): postData wasn't being sent correctly

### DIFF
--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -170,7 +170,7 @@ class PayloadBuilder:
             "httpVersion": request.environ["SERVER_PROTOCOL"],
             "headers": [{"name": k, "value": v} for (k, v) in headers.items()],
             "queryString": [{"name": k, "value": v} for (k, v) in params],
-            **post_data,
+            "postData": post_data,
         }
 
     def _build_response_payload(self, response: ResponseInfoWrapper) -> dict:

--- a/packages/python/readme_metrics/tests/PayloadBuilder_test.py
+++ b/packages/python/readme_metrics/tests/PayloadBuilder_test.py
@@ -92,7 +92,7 @@ class TestPayloadBuilder:
 
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
-        text = data["request"]["log"]["entries"][0]["request"]["text"]
+        text = data["request"]["log"]["entries"][0]["request"]["postData"]["text"]
 
         assert text == '{"ok": 123, "password": "[REDACTED]"}'
 
@@ -111,7 +111,7 @@ class TestPayloadBuilder:
 
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
-        text = data["request"]["log"]["entries"][0]["request"]["text"]
+        text = data["request"]["log"]["entries"][0]["request"]["postData"]["text"]
 
         assert text == '{"ok": 123, "password": "[REDACTED]"}'
 
@@ -130,7 +130,7 @@ class TestPayloadBuilder:
 
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
-        text = data["request"]["log"]["entries"][0]["request"]["text"]
+        text = data["request"]["log"]["entries"][0]["request"]["postData"]["text"]
 
         assert "ok" in text
         assert "123" in text
@@ -153,7 +153,7 @@ class TestPayloadBuilder:
 
         payload = self.createPayload(config)
         data = payload(metrics.req, metrics.res)
-        text = data["request"]["log"]["entries"][0]["request"]["text"]
+        text = data["request"]["log"]["entries"][0]["request"]["postData"]["text"]
 
         assert "ok" in text
         assert "123" in text
@@ -315,7 +315,8 @@ class TestPayloadBuilder:
 
     def test_har_creator(self):
         config = self.mockMiddlewareConfig(development_mode=True)
-        environ = Environ.MockEnviron().getEnvironForRequest(b"", "POST")
+        req = json.dumps({"ok": 123, "password": 456}).encode()
+        environ = Environ.MockEnviron().getEnvironForRequest(req, "POST")
         app = MockApplication("{ 'responseObject': 'value' }")
 
         metrics = MetricsCoreMock()
@@ -331,3 +332,8 @@ class TestPayloadBuilder:
         assert creator["name"] == "readme-metrics (python)"
         assert isinstance(creator["version"], str)
         assert isinstance(creator["comment"], str)
+
+        post_data = data["request"]["log"]["entries"][0]["request"]["postData"]
+
+        assert post_data["text"] == json.dumps({"ok": 123, "password": 456})
+        assert post_data["mimeType"] == "application/json"


### PR DESCRIPTION
We were sending post data like this:

```js
{
  method: 'POST',
  url: 'http://localhost:51141/',
  httpVersion: 'HTTP/1.1',
  headers: [],
  queryString: [],
  text: '{"user":{"email":"dom@readme.io"}}',
  mimeType: 'application/json'
}
```

When it should be nested inside a `postData` key, like so:

```js
{
  method: 'POST',
  url: 'http://localhost:51141/',
  httpVersion: 'HTTP/1.1',
  headers: [],
  queryString: [],
  postData: {
    text: '{"user":{"email":"dom@readme.io"}}',
    mimeType: 'application/json'
  }
}
```

----

Tbh I didn't know what the ** python syntax did here, but I figured it out
by doing this in the repl:

```
>>> b = { "test": 1 }
>>> { "a": 123, **b }
{'a': 123, 'test': 1}
```

So it appears to be similar to the spread syntax in JS.