### PR TITLE
fix(python/django): move instantiation of grouping_function 

### DIFF
--- a/packages/python/examples/metrics_django/metrics/models.py
+++ b/packages/python/examples/metrics_django/metrics/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+
+class Person(models.Model):
+    first_name = models.CharField(max_length=30)

--- a/packages/python/examples/metrics_django/metrics/views.py
+++ b/packages/python/examples/metrics_django/metrics/views.py
@@ -1,5 +1,6 @@
 from django.http import JsonResponse, HttpResponse
 
+from .models import Person
 
 # pylint: disable=unused-argument
 def grouping_function(request):

--- a/packages/python/examples/metrics_django/metrics/views.py
+++ b/packages/python/examples/metrics_django/metrics/views.py
@@ -1,5 +1,6 @@
 from django.http import JsonResponse, HttpResponse
 
+# pylint: disable=unused-import
 from .models import Person
 
 # pylint: disable=unused-argument

--- a/packages/python/examples/metrics_django/metrics_django/settings.py
+++ b/packages/python/examples/metrics_django/metrics_django/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "metrics",
 ]
 
 MIDDLEWARE = [

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -3,6 +3,7 @@ import math
 import queue
 import threading
 import traceback
+import importlib
 
 from readme_metrics import MetricsApiConfig
 from readme_metrics.publisher import publish_batch
@@ -28,11 +29,19 @@ class Metrics:
         """
 
         self.config = config
+
+        if isinstance(self.config.GROUPING_FUNCTION, str):
+            module_name, function_name = self.config.GROUPING_FUNCTION.rsplit(".", 1)
+            module = importlib.import_module(module_name)
+            self.grouping_function = getattr(module, function_name)
+        else:
+            self.grouping_function = self.config.GROUPING_FUNCTION
+
         self.payload_builder = PayloadBuilder(
             config.DENYLIST,
             config.ALLOWLIST,
             config.IS_DEVELOPMENT_MODE,
-            config.GROUPING_FUNCTION,
+            self.grouping_function,
             config.LOGGER,
         )
         self.queue = queue.Queue()

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -1,5 +1,4 @@
 # pylint: disable=too-many-instance-attributes
-import importlib
 from typing import List, Any, Callable
 
 from readme_metrics.util import util_build_logger

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -112,12 +112,7 @@ class MetricsApiConfig:
                 Default 3 seconds.
         """
         self.README_API_KEY = api_key
-        if isinstance(grouping_function, str):
-            module_name, function_name = grouping_function.rsplit(".", 1)
-            module = importlib.import_module(module_name)
-            self.GROUPING_FUNCTION = getattr(module, function_name)
-        else:
-            self.GROUPING_FUNCTION = grouping_function
+        self.GROUPING_FUNCTION = grouping_function
         self.BUFFER_LENGTH = buffer_length
         self.IS_DEVELOPMENT_MODE = development_mode
         self.IS_BACKGROUND_MODE = background_worker_mode

--- a/packages/python/readme_metrics/tests/Metrics_test.py
+++ b/packages/python/readme_metrics/tests/Metrics_test.py
@@ -1,0 +1,12 @@
+import types
+
+from readme_metrics.Metrics import Metrics
+from readme_metrics import MetricsApiConfig
+
+
+class TestMetrics:
+    def test_grouping_function_import(self):
+        config = MetricsApiConfig(api_key=123456, grouping_function="json.loads")
+        assert isinstance(config.GROUPING_FUNCTION, str)
+        metrics = Metrics(config)
+        assert isinstance(metrics.grouping_function, types.FunctionType)


### PR DESCRIPTION
## 🧰 Changes

Previously we were trying to import the grouping function in MetricsApiConfig
which in Django's case gets called from settings.py (before the models have
been setup). So if your grouping function was located in a file that happened
to use a model (or was a function on a model) it would error with the following:

```
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```

This PR moves the loading of the grouping function (if it needs to be
imported) into Metrics instead of in the Config, this is late enough for
django to have started so you can use models.


## 🧬 QA & Testing

We're having some issues running the python integration tests on CI, so to test this locally you can run:

```sh
make test-python-metrics-django
```
