### PR TITLE
fix: node snippets not working out of the box on node w/o esm compat

### DIFF
--- a/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
@@ -20,8 +20,8 @@ export const express: Client = {
       indent: opts.indent,
     });
 
-    push("import express from 'express';");
-    push("import readme from 'readmeio';");
+    push("const express = require('express');");
+    push("const readme = require('readmeio');");
 
     blank();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
@@ -1,5 +1,5 @@
-import express from 'express';
-import readme from 'readmeio';
+const express = require('express');
+const readme = require('readmeio');
 
 const app = express();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
@@ -1,5 +1,5 @@
-import express from 'express';
-import readme from 'readmeio';
+const express = require('express');
+const readme = require('readmeio');
 
 const app = express();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/quirky-escaping.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/quirky-escaping.js
@@ -1,5 +1,5 @@
-import express from 'express';
-import readme from 'readmeio';
+const express = require('express');
+const readme = require('readmeio');
 
 const app = express();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
@@ -1,5 +1,5 @@
-import express from 'express';
-import readme from 'readmeio';
+const express = require('express');
+const readme = require('readmeio');
 
 const app = express();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
@@ -1,5 +1,5 @@
-import express from 'express';
-import readme from 'readmeio';
+const express = require('express');
+const readme = require('readmeio');
 
 const app = express();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
@@ -1,5 +1,5 @@
-import express from 'express';
-import readme from 'readmeio';
+const express = require('express');
+const readme = require('readmeio');
 
 const app = express();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
@@ -1,5 +1,5 @@
-import express from 'express';
-import readme from 'readmeio';
+const express = require('express');
+const readme = require('readmeio');
 
 const app = express();
 


### PR DESCRIPTION
## 🧰 Changes

Because our Node SDK snippets use `import` they don't work out of the box on Node without the `NODE_OPTIONS=--experimental-vm-modules` flag.