### PR TITLE
feat: adding HAR validation to our integration suite + fixing bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ cleanup-failure:
 ##
 test-metrics-dotnet: ## Run Metrics tests against the .NET SDK
 	docker-compose up --build --detach integration_dotnet_metrics_v6.0
+	sleep 5
 	npm run test:integration-metrics || make cleanup-failure
 	@make cleanup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint": "^8.21.0",
         "form-data-encoder": "^2.1.0",
         "formdata-node": "^5.0.0",
+        "har-validator": "^5.1.5",
         "husky": "^8.0.1",
         "isomorphic-fetch": "^3.0.0",
         "mocha": "^10.0.0",
@@ -6165,6 +6166,20 @@
       "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/hard-rejection": {
@@ -18511,6 +18526,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
     },
     "hard-rejection": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^8.21.0",
     "form-data-encoder": "^2.1.0",
     "formdata-node": "^5.0.0",
+    "har-validator": "^5.1.5",
     "husky": "^8.0.1",
     "isomorphic-fetch": "^3.0.0",
     "mocha": "^10.0.0",

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Content.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Content.cs
@@ -2,7 +2,6 @@
 
 namespace ReadMe.HarJsonObjectModels
 {
-  [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
   class Content
   {
     public string text { get; set; }

--- a/packages/dotnet/ReadMe/HarJsonObjectModels/Request.cs
+++ b/packages/dotnet/ReadMe/HarJsonObjectModels/Request.cs
@@ -13,6 +13,8 @@ namespace ReadMe.HarJsonObjectModels
 
     public long headersSize { get; set; }
 
+    public long bodySize { get; set; }
+
     public List<QueryStrings> queryString { get; set; }
 
     public PostData postData { get; set; }

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/RequestProcessor.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/RequestProcessor.cs
@@ -22,6 +22,7 @@ namespace ReadMe.HarJsonObjectModels
       Request requestObj = new Request();
       requestObj.headers = this.GetHeaders();
       requestObj.headersSize = this.GetHeadersSize();
+      requestObj.bodySize = -1;
       requestObj.queryString = this.GetQueryStrings();
       requestObj.cookies = this.GetCookies();
       requestObj.method = this.request.Method;

--- a/packages/dotnet/ReadMe/HarJsonTranslationLogics/ResponseProcessor.cs
+++ b/packages/dotnet/ReadMe/HarJsonTranslationLogics/ResponseProcessor.cs
@@ -88,7 +88,7 @@ namespace ReadMe.HarJsonObjectModels
       Content content = new Content();
       content.text = this.responseBodyData;
       content.size = this.responseBodyData.Length;
-      content.mimeType = this.response.ContentType;
+      content.mimeType = this.response.ContentType ??= "text/plain";
       return content;
     }
 

--- a/packages/node/src/lib/object-to-array.ts
+++ b/packages/node/src/lib/object-to-array.ts
@@ -2,15 +2,19 @@ import type { URLSearchParams } from 'url';
 
 export function objectToArray(
   object: Record<string, unknown>,
-  castToString?: boolean
+  opts: {
+    castToString: boolean;
+  } = {
+    castToString: false,
+  }
 ): { name: string; value: string }[] {
   return Object.entries(object).reduce((prev, [name, value]) => {
     if (Array.isArray(value)) {
       value.forEach(val => {
-        prev.push({ name, value: castToString ? String(val) : val });
+        prev.push({ name, value: opts.castToString ? String(val) : val });
       });
     } else {
-      prev.push({ name, value: castToString ? String(value) : value });
+      prev.push({ name, value: opts.castToString ? String(value) : value });
     }
 
     return prev;

--- a/packages/node/src/lib/object-to-array.ts
+++ b/packages/node/src/lib/object-to-array.ts
@@ -1,13 +1,16 @@
 import type { URLSearchParams } from 'url';
 
-export function objectToArray(object: Record<string, unknown>): { name: string; value: string }[] {
+export function objectToArray(
+  object: Record<string, unknown>,
+  castToString?: boolean
+): { name: string; value: string }[] {
   return Object.entries(object).reduce((prev, [name, value]) => {
     if (Array.isArray(value)) {
       value.forEach(val => {
-        prev.push({ name, value: val });
+        prev.push({ name, value: castToString ? String(val) : val });
       });
     } else {
-      prev.push({ name, value });
+      prev.push({ name, value: castToString ? String(value) : value });
     }
 
     return prev;

--- a/packages/node/src/lib/process-request.ts
+++ b/packages/node/src/lib/process-request.ts
@@ -203,8 +203,8 @@ export default function processRequest(
     postData,
     // TODO: When readme starts accepting these, send the correct values
     cookies: [],
-    headersSize: 0,
-    bodySize: 0,
+    headersSize: -1,
+    bodySize: -1,
   };
 
   if (requestData.postData === null) {

--- a/packages/node/src/lib/process-response.ts
+++ b/packages/node/src/lib/process-response.ts
@@ -63,7 +63,7 @@ export default function processResponse(
     // This is the same thing that Node.js does internally:
     // https://github.com/nodejs/node/blob/9b8ba2536044ae08a1cd747a3aa52df7d1815e7e/lib/_http_server.js#L318
     statusText: res.statusMessage || STATUS_CODES[res.statusCode],
-    headers: objectToArray(headers, true),
+    headers: objectToArray(headers, { castToString: true }),
     content: {
       text: JSON.stringify(body),
       size: Number(fixHeader(res.getHeader('content-length') || 0)),

--- a/packages/node/src/lib/process-response.ts
+++ b/packages/node/src/lib/process-response.ts
@@ -63,11 +63,11 @@ export default function processResponse(
     // This is the same thing that Node.js does internally:
     // https://github.com/nodejs/node/blob/9b8ba2536044ae08a1cd747a3aa52df7d1815e7e/lib/_http_server.js#L318
     statusText: res.statusMessage || STATUS_CODES[res.statusCode],
-    headers: objectToArray(headers),
+    headers: objectToArray(headers, true),
     content: {
       text: JSON.stringify(body),
       size: Number(fixHeader(res.getHeader('content-length') || 0)),
-      mimeType: fixHeader(res.getHeader('content-type')),
+      mimeType: fixHeader(res.getHeader('content-type')) || 'text/plain',
     },
     // TODO: Once readme starts accepting these, send the correct values
     httpVersion: '',

--- a/packages/php/src/HAR/Payload.php
+++ b/packages/php/src/HAR/Payload.php
@@ -137,7 +137,10 @@ class Payload
             'url' => $request->fullUrl(),
             'httpVersion' => $request->server('SERVER_PROTOCOL', 'HTTP/1.1'),
             'headers' => static::convertHeaderBagToArray($request->headers),
+            'headersSize' => -1,
             'queryString' => static::convertObjectToArray($request->query()),
+            'cookies' => static::convertObjectToArray($request->cookie()),
+            'bodySize' => -1,
         ];
 
         if ($post_data) {
@@ -184,6 +187,8 @@ class Payload
                 ? Response::$statusTexts[$status_code]
                 : 'Unknown status',
             'headers' => static::convertHeaderBagToArray($response->headers),
+            'headersSize' => -1,
+            'bodySize' => (int)$content_size,
             'content' => [
                 'text' => (is_scalar($body)) ? $body : json_encode($body),
                 'size' => (int)$content_size,

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -114,10 +114,13 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
                 ['name' => 'accept-charset', 'value' => 'ISO-8859-1,utf-8;q=0.7,*;q=0.7'],
                 ['name' => 'content-type', 'value' => 'application/json']
             ],
+            'headersSize' => -1,
             'queryString' => [
                 ['name' => 'arr', 'value' => json_encode([1 => '3'])],
                 ['name' => 'val', 'value' => '1'],
             ],
+            'cookies' => [],
+            'bodySize' => -1,
             'postData' => [
                 'mimeType' => 'application/json',
                 'text' => json_encode([

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -203,7 +203,10 @@ class PayloadBuilder:
             "url": self._build_base_url(request),
             "httpVersion": request.environ["SERVER_PROTOCOL"],
             "headers": [{"name": k, "value": v} for (k, v) in headers.items()],
+            "headersSize": -1,
             "queryString": [{"name": k, "value": v} for (k, v) in queryString],
+            "cookies": [],
+            "bodySize": -1,
         }
 
         if not post_data is False:
@@ -234,6 +237,8 @@ class PayloadBuilder:
             "status": status_code,
             "statusText": status_text or "",
             "headers": headers,
+            "headersSize": -1,
+            "bodySize": int(response.content_length),
             "content": {
                 "text": body,
                 "size": int(response.content_length),

--- a/packages/ruby/lib/readme/har/collection.rb
+++ b/packages/ruby/lib/readme/har/collection.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Readme
   module Har
     class Collection
@@ -11,7 +13,7 @@ module Readme
       end
 
       def to_a
-        filtered_hash.map { |name, value| { name: name, value: value } }
+        filtered_hash.map { |name, value| { name: name, value: value.is_a?(Hash) ? value.to_json : value } }
       end
 
       private


### PR DESCRIPTION
| 🚥 Fix RM-5036 |
| :-- |

## 🧰 Changes

This adds a couple new Chai assertions:

* [x] `.har`: Does very basic HAR checks to make sure that `log.entries[*]` is present .
* [x] `.har.request`: Asserts that a HAR `log.entries[*].request` object is valid to the spec.
* [x] `.har.response`: Asserts that a HAR `log.entries[*].response` object is valid to the spec.

Along with these new assertions I've also fixed some issues in our SDKs that cropped up from it:

* [x] Most all SDKs didn't have a `headersSize` or `bodySize` in `request` or `response`, or if they did it was set to 0. [Per the spec if we don't have the value it should be -1.](http://www.softwareishard.com/blog/har-12-spec/#request)

###  .NET
* [x] If `request.content.mimeType` or `response.content.mimeType` were `null` because there was no `Content-Type` header it'd get removed from the HAR and not sent to us. Not only do we not do null filtering in that class anymore but I'm also defaulting `mimeType` to `text/plain` if we don't have one.

### Node
* [x] When we composed the HAR `queryString` array we weren't casting values as strings. The spec requires that `queryString[*].value` be a string.
* [x] `response.content.mimeType` was being set to `undefined` if we didn't have a `Content-Type` header -- we now default to `text/plain`.

### PHP
* [x] Didn't set or support `request.cookies` at all. Node and Python set `cookies` to an empty array but Ruby and .NET supported it. PHP now supports sending us cookies if they're present.

### Ruby
* [x] When we were constructing `request.queryString` if the query string value were a non-scalar value we would dump it into the HAR as-is. We now check to see if it's scalar and if it is we JSON encode it.
  * ⚠️ Any HAR with a query string with a non-scalar value will almost certainly crash code snippet generation and Try It execution.