### PR TITLE
fix(node webhook snippet): add app server link

### DIFF
--- a/packages/sdk-snippets/README.md
+++ b/packages/sdk-snippets/README.md
@@ -54,7 +54,7 @@ This generates the following object:
 }
 ```
 
-The generated snippet for this results in a [ReadMe Node Metrics SDK](https://npm.im/readmeio) webhooks example:
+The generated snippet for this results in a [ReadMe Node Metrics SDK](https://npm.im/readmeio) Personalized Docs Webhook example:
 
 ```js
 import express from 'express';
@@ -85,5 +85,8 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
   });
 });
 
-app.listen(8000);
+const port = 8000;
+const server = app.listen(port, '0.0.0.0', function () {
+  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+});
 ```

--- a/packages/sdk-snippets/README.md
+++ b/packages/sdk-snippets/README.md
@@ -87,6 +87,6 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
 
 const port = 8000;
 const server = app.listen(port, '0.0.0.0', function () {
-  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+  console.log('Example app listening at http://%s:%s', server.address().address, port);
 });
 ```

--- a/packages/sdk-snippets/README.md
+++ b/packages/sdk-snippets/README.md
@@ -54,7 +54,9 @@ This generates the following object:
 }
 ```
 
-The generated snippet for this results in a [ReadMe Node Metrics SDK](https://npm.im/readmeio) Personalized Docs Webhook example:
+<!-- TODO: add a link to the ReadMe documentation for personalized docs once that's published -->
+
+The generated snippet for this results in a Personalized Docs Webhook example, which uses the [ReadMe Node Metrics SDK](https://npm.im/readmeio):
 
 ```js
 import express from 'express';

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
@@ -113,7 +113,7 @@ export const express: Client = {
     push('const port = 8000;');
     push("const server = app.listen(port, '0.0.0.0', function () {");
     push(
-      "console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);",
+      "console.log('Example app listening at http://%s:%s', server.address().address, port);",
       1
     );
     push('});');

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
@@ -112,10 +112,7 @@ export const express: Client = {
 
     push('const port = 8000;');
     push("const server = app.listen(port, '0.0.0.0', function () {");
-    push(
-      "console.log('Example app listening at http://%s:%s', server.address().address, port);",
-      1
-    );
+    push("console.log('Example app listening at http://%s:%s', server.address().address, port);", 1);
     push('});');
     blank();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
@@ -112,7 +112,10 @@ export const express: Client = {
 
     push('const port = 8000;');
     push("const server = app.listen(port, '0.0.0.0', function () {");
-    push("console.log('Webhooks example app listening at http://%s:%s', server.address().address, port);", 1);
+    push(
+      "console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);",
+      1
+    );
     push('});');
     blank();
 

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/client.ts
@@ -110,7 +110,10 @@ export const express: Client = {
 
     blank();
 
-    push('app.listen(8000);');
+    push('const port = 8000;');
+    push("const server = app.listen(port, '0.0.0.0', function () {");
+    push("console.log('Webhooks example app listening at http://%s:%s', server.address().address, port);", 1);
+    push('});');
     blank();
 
     return {

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
@@ -30,5 +30,5 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
 
 const port = 8000;
 const server = app.listen(port, '0.0.0.0', function () {
-  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+  console.log('Example app listening at http://%s:%s', server.address().address, port);
 });

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty-default.js
@@ -28,4 +28,7 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
   });
 });
 
-app.listen(8000);
+const port = 8000;
+const server = app.listen(port, '0.0.0.0', function () {
+  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+});

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
@@ -26,5 +26,5 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
 
 const port = 8000;
 const server = app.listen(port, '0.0.0.0', function () {
-  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+  console.log('Example app listening at http://%s:%s', server.address().address, port);
 });

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/empty.js
@@ -24,4 +24,7 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
   });
 });
 
-app.listen(8000);
+const port = 8000;
+const server = app.listen(port, '0.0.0.0', function () {
+  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+});

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/quirky-escaping.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/quirky-escaping.js
@@ -33,4 +33,7 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
   });
 });
 
-app.listen(8000);
+const port = 8000;
+const server = app.listen(port, '0.0.0.0', function () {
+  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+});

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/quirky-escaping.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/quirky-escaping.js
@@ -35,5 +35,5 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
 
 const port = 8000;
 const server = app.listen(port, '0.0.0.0', function () {
-  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+  console.log('Example app listening at http://%s:%s', server.address().address, port);
 });

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
@@ -30,4 +30,7 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
   });
 });
 
-app.listen(8000);
+const port = 8000;
+const server = app.listen(port, '0.0.0.0', function () {
+  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+});

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-and-server-variables.js
@@ -32,5 +32,5 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
 
 const port = 8000;
 const server = app.listen(port, '0.0.0.0', function () {
-  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+  console.log('Example app listening at http://%s:%s', server.address().address, port);
 });

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
@@ -30,5 +30,5 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
 
 const port = 8000;
 const server = app.listen(port, '0.0.0.0', function () {
-  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+  console.log('Example app listening at http://%s:%s', server.address().address, port);
 });

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-types.js
@@ -28,4 +28,7 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
   });
 });
 
-app.listen(8000);
+const port = 8000;
+const server = app.listen(port, '0.0.0.0', function () {
+  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+});

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
@@ -26,4 +26,7 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
   });
 });
 
-app.listen(8000);
+const port = 8000;
+const server = app.listen(port, '0.0.0.0', function () {
+  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+});

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/security-variables.js
@@ -28,5 +28,5 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
 
 const port = 8000;
 const server = app.listen(port, '0.0.0.0', function () {
-  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+  console.log('Example app listening at http://%s:%s', server.address().address, port);
 });

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
@@ -26,4 +26,7 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
   });
 });
 
-app.listen(8000);
+const port = 8000;
+const server = app.listen(port, '0.0.0.0', function () {
+  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+});

--- a/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/express/webhooks/fixtures/server-variables.js
@@ -28,5 +28,5 @@ app.post('/webhook', express.json({ type: 'application/json' }), async (req, res
 
 const port = 8000;
 const server = app.listen(port, '0.0.0.0', function () {
-  console.log('Personalized Docs Webhook example app listening at http://%s:%s', server.address().address, port);
+  console.log('Example app listening at http://%s:%s', server.address().address, port);
 });


### PR DESCRIPTION
| 🚥 Fix RM-5469 |
| :-- |

## 🧰 Changes

Per some internal discussion, this updates our Metrics SDK snippet for the Personalized Docs Webhook to print the example server URL to the console once the user starts the server.

In an effort to fast-track this for some launch-related materials, this PR only updates our Node/Express snippet and I've created a ticket for the other snippets in RM-5488.

## 🧬 QA & Testing

Does the new snippet look good? And do tests pass?
