### PR TITLE
fix: quirk where an allowlist would redact HAR URLs

### DIFF
--- a/packages/node/src/lib/process-request.ts
+++ b/packages/node/src/lib/process-request.ts
@@ -130,6 +130,9 @@ export default function processRequest(
   requestBody?: Record<string, unknown> | string,
   options?: LogOptions
 ): Entry['request'] {
+  const protocol = fixHeader(req.headers['x-forwarded-proto'])?.toLowerCase() || getProto(req);
+  const host = fixHeader(req.headers['x-forwarded-host']) || req.headers.host;
+
   const denylist = options?.denylist || options?.blacklist;
   const allowlist = options?.allowlist || options?.whitelist;
 
@@ -178,8 +181,6 @@ export default function processRequest(
     };
   }
 
-  const protocol = fixHeader(req.headers['x-forwarded-proto'])?.toLowerCase() || getProto(req);
-  const host = fixHeader(req.headers['x-forwarded-host']) || req.headers.host;
   // We use a fake host here because we rely on the host header which could be redacted.
   // We only ever use this reqUrl with the fake hostname for the pathname and querystring.
   // req.originalUrl is express specific, req.url is node.js

--- a/packages/node/test/helpers/chai-plugins.ts
+++ b/packages/node/test/helpers/chai-plugins.ts
@@ -15,7 +15,12 @@ declare global {
       /**
        * Assert that a given HAR `headers` array has a given header matching a specific value.
        */
-      header: (header: string, expected: string) => void;
+      header: (header: string, expected: string | RegExp) => void;
+
+      /**
+       * Assert that a given URL is a valid URL.
+       */
+      url: void;
     }
   }
 }
@@ -87,6 +92,23 @@ export default function chaiPlugins(_chai, utils) {
       new chai.Assertion(headers.get(header)).to.oneOf(expected.map(e => e.toString()));
     } else {
       new chai.Assertion(headers.get(header)).to.equal(expected.toString());
+    }
+  });
+
+  /**
+   * Assert that a given URL is a valid URL.
+   *
+   * @example
+   * expect(body.url).to.be.a.url;
+   */
+  utils.addProperty(chai.Assertion.prototype, 'url', function () {
+    const url = utils.flag(this, 'object');
+
+    try {
+      // eslint-disable-next-line no-new
+      new URL(url);
+    } catch (err) {
+      new chai.Assertion(err.code).not.to.equal('ERR_INVALID_URL', `${url} is not a valid url`);
     }
   });
 }

--- a/packages/node/test/lib/process-request.test.ts
+++ b/packages/node/test/lib/process-request.test.ts
@@ -157,6 +157,7 @@ describe('process-request', function () {
           .post('/')
           .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .expect(({ body }) => {
+            expect(body.url).to.be.a.url;
             expect(body.postData.text).to.equal(
               '{"password":"[REDACTED 6]","apiKey":"[REDACTED 3]","another":"Hello world"}'
             );
@@ -171,6 +172,7 @@ describe('process-request', function () {
           .send('password=123456&apiKey=abc&another=Hello world')
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .expect(({ body }) => {
+            expect(body.url).to.be.a.url;
             expect(body.postData.text).to.be.undefined;
             expect(body.postData.params).to.deep.equal([
               {
@@ -196,6 +198,7 @@ describe('process-request', function () {
           .post('/')
           .send({ a: { b: { c: {} } } })
           .expect(({ body }) => {
+            expect(body.url).to.be.a.url;
             expect(body.postData.text).to.equal('{"a":{"b":{"c":"[REDACTED]"}}}');
           });
       });
@@ -207,6 +210,7 @@ describe('process-request', function () {
           .post('/')
           .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .expect(({ body }) => {
+            expect(body.url).to.be.a.url;
             expect(body.postData.text).to.equal('{"password":"123456","apiKey":"abc","another":"[REDACTED 11]"}');
           });
       });
@@ -218,6 +222,7 @@ describe('process-request', function () {
           .post('/')
           .send('password=123456&apiKey=abc&another=Hello world')
           .expect(({ body }) => {
+            expect(body.url).to.be.a.url;
             expect(body.postData.text).to.be.undefined;
             expect(body.postData.params).to.deep.equal([
               {
@@ -243,6 +248,7 @@ describe('process-request', function () {
           .post('/')
           .send({ a: { b: { c: 1 } }, d: 2 })
           .expect(({ body }) => {
+            expect(body.url).to.be.a.url;
             expect(body.postData.text).to.equal('{"a":{"b":{"c":1}},"d":"[REDACTED]"}');
           });
       });
@@ -254,6 +260,7 @@ describe('process-request', function () {
           .post('/')
           .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
           .expect(({ body }) => {
+            expect(body.url).to.be.a.url;
             expect(body.postData.text).to.equal(
               '{"password":"[REDACTED 6]","apiKey":"[REDACTED 3]","another":"Hello world"}'
             );
@@ -265,26 +272,28 @@ describe('process-request', function () {
 
         return request(app)
           .post('/')
-          .set('a', '1')
+          .set('x-ratelimit-limit', '10')
           .expect(({ body }) => {
+            expect(body.url).to.be.a.url;
             expect(body.headers).to.have.header('host', '[REDACTED 15]');
             expect(body.headers).to.have.header('accept-encoding', '[REDACTED 13]');
-            expect(body.headers).to.have.header('a', '1');
+            expect(body.headers).to.have.header('x-ratelimit-limit', '10');
             expect(body.headers).to.have.header('connection', '[REDACTED 5]');
             expect(body.headers).to.have.header('content-length', '0');
           });
       });
 
       it('should only send allowlisted headers', function () {
-        const app = createApp({ allowlist: ['a'] });
+        const app = createApp({ allowlist: ['x-ratelimit-limit'] });
 
         return request(app)
           .post('/')
-          .set('a', '1')
+          .set('x-ratelimit-limit', '10')
           .expect(({ body }) => {
+            expect(body.url).to.be.a.url;
             expect(body.headers).to.have.header('host', '[REDACTED 15]');
             expect(body.headers).to.have.header('accept-encoding', '[REDACTED 13]');
-            expect(body.headers).to.have.header('a', '1');
+            expect(body.headers).to.have.header('x-ratelimit-limit', '10');
             expect(body.headers).to.have.header('connection', '[REDACTED 5]');
             expect(body.headers).to.have.header('content-length', '[REDACTED 1]');
           });
@@ -299,12 +308,13 @@ describe('process-request', function () {
       return request(app)
         .post('/')
         .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
-        .set('a', '1')
+        .set('x-ratelimit-limit', '10')
         .expect(({ body }) => {
+          expect(body.url).to.be.a.url;
           expect(body.headers).to.have.header('host', '[REDACTED 15]');
           expect(body.headers).to.have.header('accept-encoding', '[REDACTED 13]');
           expect(body.headers).to.have.header('content-type', 'application/json');
-          expect(body.headers).to.have.header('a', '1');
+          expect(body.headers).to.have.header('x-ratelimit-limit', '10');
           expect(body.headers).to.have.header('content-length', '[REDACTED 2]');
           expect(body.headers).to.have.header('connection', '[REDACTED 5]');
 
@@ -316,18 +326,19 @@ describe('process-request', function () {
 
     it('should only send allowlisted nested properties in body and headers', function () {
       const app = createApp({
-        allowlist: ['a', 'another', 'content-type'],
+        allowlist: ['x-ratelimit-limit', 'another', 'content-type'],
       });
 
       return request(app)
         .post('/')
         .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
-        .set('a', '1')
+        .set('x-ratelimit-limit', '10')
         .expect(({ body }) => {
+          expect(body.url).to.be.a.url;
           expect(body.headers).to.have.header('host', '[REDACTED 15]');
           expect(body.headers).to.have.header('accept-encoding', '[REDACTED 13]');
           expect(body.headers).to.have.header('content-type', 'application/json');
-          expect(body.headers).to.have.header('a', '1');
+          expect(body.headers).to.have.header('x-ratelimit-limit', '10');
           expect(body.headers).to.have.header('content-length', '[REDACTED 2]');
           expect(body.headers).to.have.header('connection', '[REDACTED 5]');
 
@@ -346,12 +357,13 @@ describe('process-request', function () {
       return request(app)
         .post('/')
         .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
-        .set('a', '1')
+        .set('x-ratelimit-limit', '10')
         .expect(({ body }) => {
+          expect(body.url).to.be.a.url;
           expect(body.headers).to.have.header('host', '[REDACTED 15]');
           expect(body.headers).to.have.header('accept-encoding', '[REDACTED 13]');
           expect(body.headers).to.have.header('content-type', 'application/json');
-          expect(body.headers).to.have.header('a', '1');
+          expect(body.headers).to.have.header('x-ratelimit-limit', '10');
           expect(body.headers).to.have.header('content-length', '[REDACTED 2]');
           expect(body.headers).to.have.header('connection', '[REDACTED 5]');
 
@@ -375,6 +387,7 @@ describe('process-request', function () {
         .post('/')
         .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
         .expect(({ body }) => {
+          expect(body.url).to.be.a.url;
           expect(body.postData.text).to.equal(
             '{"password":"[REDACTED 6]","apiKey":"[REDACTED 3]","another":"Hello world"}'
           );
@@ -389,6 +402,7 @@ describe('process-request', function () {
         .set('content-type', 'application/json')
         .send({ password: '123456', apiKey: 'abc', another: 'Hello world' })
         .expect(({ body }) => {
+          expect(body.url).to.be.a.url;
           expect(body.postData.text).to.equal('{"password":"123456","apiKey":"abc","another":"[REDACTED 11]"}');
         });
     });


### PR DESCRIPTION
## 🧰 Changes

This fixes a quirk in how our `allowlist` works in the Node SDK where it would redact headers we used to construct the `url` that we set into the HAR for Metrics. Like this:

![screen_shot_2022-11-07_at_3 14 58_pm_720](https://user-images.githubusercontent.com/33762/200440736-df68036a-3e90-4d1d-810e-84c4dfa25feb.png)

We're still going to be redacting all non-allowlisted headers by default, we just will do that redaction after we've constructed the URL.
