### PR TITLE
fix(ruby): compatibility issues with rack v3.0.0

### DIFF
--- a/packages/ruby/lib/readme/http_request.rb
+++ b/packages/ruby/lib/readme/http_request.rb
@@ -8,7 +8,7 @@ module Readme
 
     HTTP_NON_HEADERS = [
       Rack::HTTP_COOKIE,
-      Rack::HTTP_VERSION,
+      Rack::SERVER_PROTOCOL,
       Rack::HTTP_HOST,
       Rack::HTTP_PORT
     ].freeze
@@ -30,7 +30,7 @@ module Readme
     end
 
     def http_version
-      @request.get_header(Rack::HTTP_VERSION)
+      @request.get_header(Rack::SERVER_PROTOCOL)
     end
 
     def request_method

--- a/packages/ruby/spec/readme/http_request_spec.rb
+++ b/packages/ruby/spec/readme/http_request_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Readme::HttpRequest do
 
   describe '#http_version' do
     it 'gets the version from the proper Rack header' do
-      env = { 'HTTP_VERSION' => 'HTTP/1.1' }
+      env = { 'SERVER_PROTOCOL' => 'HTTP/1.1' }
       request = described_class.new(env)
 
       expect(request.http_version).to eq 'HTTP/1.1'
@@ -132,24 +132,24 @@ RSpec.describe Readme::HttpRequest do
   describe '#headers' do
     it 'is the normalized Rack HTTP_ keys minus a few non-header ones plus content type and length' do
       env = {
-        'HTTP_COOKIE' => 'cookie1=value1; cookie2=value2',
-        'HTTP_VERSION' => 'HTTP/1.1',
-        'HTTP_X_CUSTOM' => 'custom',
-        'HTTP_ACCEPT' => 'text/plain',
-        'HTTP_PORT' => '8080',
-        'HTTP_HOST' => 'example.com',
-        'CONTENT_TYPE' => 'application/json',
         'CONTENT_LENGTH' => '10'
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_ACCEPT' => 'text/plain',
+        'HTTP_COOKIE' => 'cookie1=value1; cookie2=value2',
+        'HTTP_HOST' => 'example.com',
+        'HTTP_PORT' => '8080',
+        'HTTP_X_CUSTOM' => 'custom',
+        'SERVER_PROTOCOL' => 'HTTP/1.1',
       }
       request = described_class.new(env)
 
       expect(request.headers).to eq(
         {
+          'Accept' => 'text/plain',
+          'Content-Length' => '10'
+          'Content-Type' => 'application/json',
           'Host' => 'example.com',
           'X-Custom' => 'custom',
-          'Accept' => 'text/plain',
-          'Content-Type' => 'application/json',
-          'Content-Length' => '10'
         }
       )
     end

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -27,7 +27,7 @@ class EmptyApp
 end
 # rubocop:enable Lint/UnusedMethodArgument
 
-# Rack::Test doesn't set the HTTP_VERSION header on requests, even though
+# Rack::Test doesn't set the SERVER_PROTOCOL header on requests, even though
 # real-world implementations of Rack servers do so. This middleware adds the
 # proper header to the env.
 class SetHttpVersion
@@ -36,7 +36,7 @@ class SetHttpVersion
   end
 
   def call(env)
-    new_env = env.merge({ 'HTTP_VERSION' => 'HTTP/1.1' })
+    new_env = env.merge({ 'SERVER_PROTOCOL' => 'HTTP/1.1' })
     @app.call(new_env)
   end
 end


### PR DESCRIPTION
| 🚥 Fix https://github.com/readmeio/metrics-sdks/issues/652 |
| :-- |

## 🧰 Changes

Rack v3.0.0 removed the `HTTP_VERSION` environment variable that we use to set `http_version` in our HARs. Thankfully they still expose it to us as `SERVER_PROTOCOL`, so this work updates us to use that.

## 🧬 QA & Testing

* [ ] All Ruby tests passing?