### PR TITLE
feat(snippets): aws gateway snippets

### DIFF
--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -1592,6 +1592,426 @@ Object {
 }
 `;
 
+exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 47,
+      "start": 20,
+    },
+    "verification": Object {
+      "end": 18,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 59,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 47,
+      "start": 20,
+    },
+    "verification": Object {
+      "end": 18,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 62,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 59,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 47,
+      "start": 20,
+    },
+    "verification": Object {
+      "end": 18,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 65,
+      },
+      "basic-auth": Object {
+        "line": 66,
+      },
+      "normal_security_var": Object {
+        "line": 67,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 60,
+      },
+      "2name": Object {
+        "line": 59,
+      },
+      "normal_server_var": Object {
+        "line": 62,
+      },
+      "p*o?r*t": Object {
+        "line": 61,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 47,
+      "start": 20,
+    },
+    "verification": Object {
+      "end": 18,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 64,
+      },
+      "petstore_auth": Object {
+        "line": 63,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 59,
+      },
+      "port": Object {
+        "line": 60,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 47,
+      "start": 20,
+    },
+    "verification": Object {
+      "end": 18,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 59,
+      },
+      "http_basic": Object {
+        "line": 60,
+      },
+      "http_bearer": Object {
+        "line": 61,
+      },
+      "oauth2": Object {
+        "line": 62,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 47,
+      "start": 20,
+    },
+    "verification": Object {
+      "end": 18,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 60,
+      },
+      "petstore_auth": Object {
+        "line": 59,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 47,
+      "start": 20,
+    },
+    "verification": Object {
+      "end": 18,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 63,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 59,
+      },
+      "port": Object {
+        "line": 60,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby snippet generation aws request should match fixture for "empty" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 31,
+      "start": 17,
+    },
+    "verification": Object {
+      "end": 15,
+      "start": 14,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 43,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby snippet generation aws request should match fixture for "empty-default" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 31,
+      "start": 17,
+    },
+    "verification": Object {
+      "end": 15,
+      "start": 14,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 46,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 43,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby snippet generation aws request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 31,
+      "start": 17,
+    },
+    "verification": Object {
+      "end": 15,
+      "start": 14,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 49,
+      },
+      "basic-auth": Object {
+        "line": 50,
+      },
+      "normal_security_var": Object {
+        "line": 51,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 44,
+      },
+      "2name": Object {
+        "line": 43,
+      },
+      "normal_server_var": Object {
+        "line": 46,
+      },
+      "p*o?r*t": Object {
+        "line": 45,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby snippet generation aws request should match fixture for "security-and-server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 31,
+      "start": 17,
+    },
+    "verification": Object {
+      "end": 15,
+      "start": 14,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 48,
+      },
+      "petstore_auth": Object {
+        "line": 47,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 43,
+      },
+      "port": Object {
+        "line": 44,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby snippet generation aws request should match fixture for "security-types" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 31,
+      "start": 17,
+    },
+    "verification": Object {
+      "end": 15,
+      "start": 14,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 43,
+      },
+      "http_basic": Object {
+        "line": 44,
+      },
+      "http_bearer": Object {
+        "line": 45,
+      },
+      "oauth2": Object {
+        "line": 46,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby snippet generation aws request should match fixture for "security-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 31,
+      "start": 17,
+    },
+    "verification": Object {
+      "end": 15,
+      "start": 14,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 44,
+      },
+      "petstore_auth": Object {
+        "line": 43,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Ruby snippet generation aws request should match fixture for "server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 31,
+      "start": 17,
+    },
+    "verification": Object {
+      "end": 15,
+      "start": 14,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 47,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 43,
+      },
+      "port": Object {
+        "line": 44,
+      },
+    },
+  },
+}
+`;
+
 exports[`webhooks Ruby snippet generation rails request should match fixture for "empty" 1`] = `
 Object {
   "sections": Object {

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
+exports[`webhooks C# snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -22,7 +22,7 @@ Object {
 }
 `;
 
-exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
+exports[`webhooks C# snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -49,7 +49,7 @@ Object {
 }
 `;
 
-exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
+exports[`webhooks C# snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -91,7 +91,7 @@ Object {
 }
 `;
 
-exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
+exports[`webhooks C# snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -124,7 +124,7 @@ Object {
 }
 `;
 
-exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
+exports[`webhooks C# snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -155,7 +155,7 @@ Object {
 }
 `;
 
-exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
+exports[`webhooks C# snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -180,7 +180,7 @@ Object {
 }
 `;
 
-exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
+exports[`webhooks C# snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -619,7 +619,7 @@ Object {
 }
 `;
 
-exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
+exports[`webhooks Node.js snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -641,7 +641,7 @@ Object {
 }
 `;
 
-exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
+exports[`webhooks Node.js snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -668,7 +668,7 @@ Object {
 }
 `;
 
-exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
+exports[`webhooks Node.js snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -710,7 +710,7 @@ Object {
 }
 `;
 
-exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
+exports[`webhooks Node.js snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -743,7 +743,7 @@ Object {
 }
 `;
 
-exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
+exports[`webhooks Node.js snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -774,7 +774,7 @@ Object {
 }
 `;
 
-exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
+exports[`webhooks Node.js snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -799,7 +799,7 @@ Object {
 }
 `;
 
-exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
+exports[`webhooks Node.js snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -1437,7 +1437,7 @@ Object {
 }
 `;
 
-exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
+exports[`webhooks Python snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -1459,7 +1459,7 @@ Object {
 }
 `;
 
-exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
+exports[`webhooks Python snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -1486,7 +1486,7 @@ Object {
 }
 `;
 
-exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
+exports[`webhooks Python snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -1528,7 +1528,7 @@ Object {
 }
 `;
 
-exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
+exports[`webhooks Python snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -1561,7 +1561,7 @@ Object {
 }
 `;
 
-exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
+exports[`webhooks Python snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -1592,7 +1592,7 @@ Object {
 }
 `;
 
-exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
+exports[`webhooks Python snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -1617,7 +1617,7 @@ Object {
 }
 `;
 
-exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
+exports[`webhooks Python snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -2056,7 +2056,7 @@ Object {
 }
 `;
 
-exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
+exports[`webhooks Ruby snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -2078,7 +2078,7 @@ Object {
 }
 `;
 
-exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
+exports[`webhooks Ruby snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -2105,7 +2105,7 @@ Object {
 }
 `;
 
-exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
+exports[`webhooks Ruby snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -2147,7 +2147,7 @@ Object {
 }
 `;
 
-exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
+exports[`webhooks Ruby snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -2180,7 +2180,7 @@ Object {
 }
 `;
 
-exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
+exports[`webhooks Ruby snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -2211,7 +2211,7 @@ Object {
 }
 `;
 
-exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
+exports[`webhooks Ruby snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {
@@ -2236,7 +2236,7 @@ Object {
 }
 `;
 
-exports[`webhooks Ruby AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
+exports[`webhooks Ruby snippet generation aws AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
 Object {
   "sections": Object {
     "payload": Object {

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -211,7 +211,13 @@ Object {
       "start": 19,
     },
   },
-  "variables": Object {},
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 63,
+      },
+    },
+  },
 }
 `;
 
@@ -386,6 +392,11 @@ Object {
     },
   },
   "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 67,
+      },
+    },
     "server": Object {
       "name": Object {
         "line": 63,
@@ -410,7 +421,13 @@ Object {
       "start": 11,
     },
   },
-  "variables": Object {},
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 37,
+      },
+    },
+  },
 }
 `;
 
@@ -585,6 +602,11 @@ Object {
     },
   },
   "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 41,
+      },
+    },
     "server": Object {
       "name": Object {
         "line": 37,
@@ -1007,7 +1029,13 @@ Object {
       "start": 20,
     },
   },
-  "variables": Object {},
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 55,
+      },
+    },
+  },
 }
 `;
 
@@ -1182,6 +1210,11 @@ Object {
     },
   },
   "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 59,
+      },
+    },
     "server": Object {
       "name": Object {
         "line": 55,
@@ -1206,7 +1239,13 @@ Object {
       "start": 17,
     },
   },
-  "variables": Object {},
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 41,
+      },
+    },
+  },
 }
 `;
 
@@ -1381,6 +1420,11 @@ Object {
     },
   },
   "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 45,
+      },
+    },
     "server": Object {
       "name": Object {
         "line": 41,

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -995,6 +995,404 @@ Object {
 }
 `;
 
+exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 44,
+      "start": 24,
+    },
+    "verification": Object {
+      "end": 22,
+      "start": 20,
+    },
+  },
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 44,
+      "start": 24,
+    },
+    "verification": Object {
+      "end": 22,
+      "start": 20,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 58,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 55,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 44,
+      "start": 24,
+    },
+    "verification": Object {
+      "end": 22,
+      "start": 20,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 61,
+      },
+      "basic-auth": Object {
+        "line": 62,
+      },
+      "normal_security_var": Object {
+        "line": 63,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 56,
+      },
+      "2name": Object {
+        "line": 55,
+      },
+      "normal_server_var": Object {
+        "line": 58,
+      },
+      "p*o?r*t": Object {
+        "line": 57,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 44,
+      "start": 24,
+    },
+    "verification": Object {
+      "end": 22,
+      "start": 20,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 60,
+      },
+      "petstore_auth": Object {
+        "line": 59,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 55,
+      },
+      "port": Object {
+        "line": 56,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 44,
+      "start": 24,
+    },
+    "verification": Object {
+      "end": 22,
+      "start": 20,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 55,
+      },
+      "http_basic": Object {
+        "line": 56,
+      },
+      "http_bearer": Object {
+        "line": 57,
+      },
+      "oauth2": Object {
+        "line": 58,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 44,
+      "start": 24,
+    },
+    "verification": Object {
+      "end": 22,
+      "start": 20,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 56,
+      },
+      "petstore_auth": Object {
+        "line": 55,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 44,
+      "start": 24,
+    },
+    "verification": Object {
+      "end": 22,
+      "start": 20,
+    },
+  },
+  "variables": Object {
+    "server": Object {
+      "name": Object {
+        "line": 55,
+      },
+      "port": Object {
+        "line": 56,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation aws request should match fixture for "empty" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 30,
+      "start": 21,
+    },
+    "verification": Object {
+      "end": 19,
+      "start": 17,
+    },
+  },
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Python snippet generation aws request should match fixture for "empty-default" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 30,
+      "start": 21,
+    },
+    "verification": Object {
+      "end": 19,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 44,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 41,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation aws request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 30,
+      "start": 21,
+    },
+    "verification": Object {
+      "end": 19,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 47,
+      },
+      "basic-auth": Object {
+        "line": 48,
+      },
+      "normal_security_var": Object {
+        "line": 49,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 42,
+      },
+      "2name": Object {
+        "line": 41,
+      },
+      "normal_server_var": Object {
+        "line": 44,
+      },
+      "p*o?r*t": Object {
+        "line": 43,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation aws request should match fixture for "security-and-server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 30,
+      "start": 21,
+    },
+    "verification": Object {
+      "end": 19,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 46,
+      },
+      "petstore_auth": Object {
+        "line": 45,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 41,
+      },
+      "port": Object {
+        "line": 42,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation aws request should match fixture for "security-types" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 30,
+      "start": 21,
+    },
+    "verification": Object {
+      "end": 19,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 41,
+      },
+      "http_basic": Object {
+        "line": 42,
+      },
+      "http_bearer": Object {
+        "line": 43,
+      },
+      "oauth2": Object {
+        "line": 44,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation aws request should match fixture for "security-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 30,
+      "start": 21,
+    },
+    "verification": Object {
+      "end": 19,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 42,
+      },
+      "petstore_auth": Object {
+        "line": 41,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Python snippet generation aws request should match fixture for "server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 30,
+      "start": 21,
+    },
+    "verification": Object {
+      "end": 19,
+      "start": 17,
+    },
+  },
+  "variables": Object {
+    "server": Object {
+      "name": Object {
+        "line": 41,
+      },
+      "port": Object {
+        "line": 42,
+      },
+    },
+  },
+}
+`;
+
 exports[`webhooks Python snippet generation flask request should match fixture for "empty" 1`] = `
 Object {
   "sections": Object {

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -199,55 +199,6 @@ Object {
 }
 `;
 
-exports[`webhooks Node.js snippet generation aws request should match fixture for "empty" 1`] = `
-Object {
-  "sections": Object {},
-  "variables": Object {},
-}
-`;
-
-exports[`webhooks Node.js snippet generation aws request should match fixture for "empty-default" 1`] = `
-Object {
-  "sections": Object {},
-  "variables": Object {},
-}
-`;
-
-exports[`webhooks Node.js snippet generation aws request should match fixture for "quirky-escaping" 1`] = `
-Object {
-  "sections": Object {},
-  "variables": Object {},
-}
-`;
-
-exports[`webhooks Node.js snippet generation aws request should match fixture for "security-and-server-variables" 1`] = `
-Object {
-  "sections": Object {},
-  "variables": Object {},
-}
-`;
-
-exports[`webhooks Node.js snippet generation aws request should match fixture for "security-types" 1`] = `
-Object {
-  "sections": Object {},
-  "variables": Object {},
-}
-`;
-
-exports[`webhooks Node.js snippet generation aws request should match fixture for "security-variables" 1`] = `
-Object {
-  "sections": Object {},
-  "variables": Object {},
-}
-`;
-
-exports[`webhooks Node.js snippet generation aws request should match fixture for "server-variables" 1`] = `
-Object {
-  "sections": Object {},
-  "variables": Object {},
-}
-`;
-
 exports[`webhooks Node.js snippet generation express request should match fixture for "empty" 1`] = `
 Object {
   "sections": Object {
@@ -1038,6 +989,404 @@ Object {
       },
       "port": Object {
         "line": 31,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "empty" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "empty-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "empty-default" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 40,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 37,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "empty-default-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 66,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 63,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 43,
+      },
+      "basic-auth": Object {
+        "line": 44,
+      },
+      "normal_security_var": Object {
+        "line": 45,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 38,
+      },
+      "2name": Object {
+        "line": 37,
+      },
+      "normal_server_var": Object {
+        "line": 40,
+      },
+      "p*o?r*t": Object {
+        "line": 39,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "quirky-escaping-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 69,
+      },
+      "basic-auth": Object {
+        "line": 70,
+      },
+      "normal_security_var": Object {
+        "line": 71,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 64,
+      },
+      "2name": Object {
+        "line": 63,
+      },
+      "normal_server_var": Object {
+        "line": 66,
+      },
+      "p*o?r*t": Object {
+        "line": 65,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-and-server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 42,
+      },
+      "petstore_auth": Object {
+        "line": 41,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 37,
+      },
+      "port": Object {
+        "line": 38,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-and-server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 68,
+      },
+      "petstore_auth": Object {
+        "line": 67,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 63,
+      },
+      "port": Object {
+        "line": 64,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-types" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 37,
+      },
+      "http_basic": Object {
+        "line": 38,
+      },
+      "http_bearer": Object {
+        "line": 39,
+      },
+      "oauth2": Object {
+        "line": 40,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-types-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 63,
+      },
+      "http_basic": Object {
+        "line": 64,
+      },
+      "http_bearer": Object {
+        "line": 65,
+      },
+      "oauth2": Object {
+        "line": 66,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 38,
+      },
+      "petstore_auth": Object {
+        "line": 37,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 64,
+      },
+      "petstore_auth": Object {
+        "line": 63,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "server": Object {
+      "name": Object {
+        "line": 37,
+      },
+      "port": Object {
+        "line": 38,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "server": Object {
+      "name": Object {
+        "line": 63,
+      },
+      "port": Object {
+        "line": 64,
       },
     },
   },

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -199,6 +199,55 @@ Object {
 }
 `;
 
+exports[`webhooks Node.js snippet generation aws request should match fixture for "empty" 1`] = `
+Object {
+  "sections": Object {},
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "empty-default" 1`] = `
+Object {
+  "sections": Object {},
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "sections": Object {},
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "security-and-server-variables" 1`] = `
+Object {
+  "sections": Object {},
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "security-types" 1`] = `
+Object {
+  "sections": Object {},
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "security-variables" 1`] = `
+Object {
+  "sections": Object {},
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "server-variables" 1`] = `
+Object {
+  "sections": Object {},
+  "variables": Object {},
+}
+`;
+
 exports[`webhooks Node.js snippet generation express request should match fixture for "empty" 1`] = `
 Object {
   "sections": Object {

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -199,6 +199,404 @@ Object {
 }
 `;
 
+exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 66,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 63,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 69,
+      },
+      "basic-auth": Object {
+        "line": 70,
+      },
+      "normal_security_var": Object {
+        "line": 71,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 64,
+      },
+      "2name": Object {
+        "line": 63,
+      },
+      "normal_server_var": Object {
+        "line": 66,
+      },
+      "p*o?r*t": Object {
+        "line": 65,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 68,
+      },
+      "petstore_auth": Object {
+        "line": 67,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 63,
+      },
+      "port": Object {
+        "line": 64,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 63,
+      },
+      "http_basic": Object {
+        "line": 64,
+      },
+      "http_bearer": Object {
+        "line": 65,
+      },
+      "oauth2": Object {
+        "line": 66,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 64,
+      },
+      "petstore_auth": Object {
+        "line": 63,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 52,
+      "start": 23,
+    },
+    "verification": Object {
+      "end": 21,
+      "start": 19,
+    },
+  },
+  "variables": Object {
+    "server": Object {
+      "name": Object {
+        "line": 63,
+      },
+      "port": Object {
+        "line": 64,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "empty" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {},
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "empty-default" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 40,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 37,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 43,
+      },
+      "basic-auth": Object {
+        "line": 44,
+      },
+      "normal_security_var": Object {
+        "line": 45,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 38,
+      },
+      "2name": Object {
+        "line": 37,
+      },
+      "normal_server_var": Object {
+        "line": 40,
+      },
+      "p*o?r*t": Object {
+        "line": 39,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "security-and-server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 42,
+      },
+      "petstore_auth": Object {
+        "line": 41,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 37,
+      },
+      "port": Object {
+        "line": 38,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "security-types" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 37,
+      },
+      "http_basic": Object {
+        "line": 38,
+      },
+      "http_bearer": Object {
+        "line": 39,
+      },
+      "oauth2": Object {
+        "line": 40,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "security-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 38,
+      },
+      "petstore_auth": Object {
+        "line": 37,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks Node.js snippet generation aws request should match fixture for "server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 26,
+      "start": 15,
+    },
+    "verification": Object {
+      "end": 13,
+      "start": 11,
+    },
+  },
+  "variables": Object {
+    "server": Object {
+      "name": Object {
+        "line": 37,
+      },
+      "port": Object {
+        "line": 38,
+      },
+    },
+  },
+}
+`;
+
 exports[`webhooks Node.js snippet generation express request should match fixture for "empty" 1`] = `
 Object {
   "sections": Object {
@@ -989,404 +1387,6 @@ Object {
       },
       "port": Object {
         "line": 31,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "empty" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 26,
-      "start": 15,
-    },
-    "verification": Object {
-      "end": 13,
-      "start": 11,
-    },
-  },
-  "variables": Object {},
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "empty-create" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 52,
-      "start": 23,
-    },
-    "verification": Object {
-      "end": 21,
-      "start": 19,
-    },
-  },
-  "variables": Object {},
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "empty-default" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 26,
-      "start": 15,
-    },
-    "verification": Object {
-      "end": 13,
-      "start": 11,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "petstore_auth": Object {
-        "line": 40,
-      },
-    },
-    "server": Object {
-      "name": Object {
-        "line": 37,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "empty-default-create" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 52,
-      "start": 23,
-    },
-    "verification": Object {
-      "end": 21,
-      "start": 19,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "petstore_auth": Object {
-        "line": 66,
-      },
-    },
-    "server": Object {
-      "name": Object {
-        "line": 63,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "quirky-escaping" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 26,
-      "start": 15,
-    },
-    "verification": Object {
-      "end": 13,
-      "start": 11,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "\\"petstore\\" auth": Object {
-        "line": 43,
-      },
-      "basic-auth": Object {
-        "line": 44,
-      },
-      "normal_security_var": Object {
-        "line": 45,
-      },
-    },
-    "server": Object {
-      "*port": Object {
-        "line": 38,
-      },
-      "2name": Object {
-        "line": 37,
-      },
-      "normal_server_var": Object {
-        "line": 40,
-      },
-      "p*o?r*t": Object {
-        "line": 39,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "quirky-escaping-create" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 52,
-      "start": 23,
-    },
-    "verification": Object {
-      "end": 21,
-      "start": 19,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "\\"petstore\\" auth": Object {
-        "line": 69,
-      },
-      "basic-auth": Object {
-        "line": 70,
-      },
-      "normal_security_var": Object {
-        "line": 71,
-      },
-    },
-    "server": Object {
-      "*port": Object {
-        "line": 64,
-      },
-      "2name": Object {
-        "line": 63,
-      },
-      "normal_server_var": Object {
-        "line": 66,
-      },
-      "p*o?r*t": Object {
-        "line": 65,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-and-server-variables" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 26,
-      "start": 15,
-    },
-    "verification": Object {
-      "end": 13,
-      "start": 11,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "basic_auth": Object {
-        "line": 42,
-      },
-      "petstore_auth": Object {
-        "line": 41,
-      },
-    },
-    "server": Object {
-      "name": Object {
-        "line": 37,
-      },
-      "port": Object {
-        "line": 38,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-and-server-variables-create" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 52,
-      "start": 23,
-    },
-    "verification": Object {
-      "end": 21,
-      "start": 19,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "basic_auth": Object {
-        "line": 68,
-      },
-      "petstore_auth": Object {
-        "line": 67,
-      },
-    },
-    "server": Object {
-      "name": Object {
-        "line": 63,
-      },
-      "port": Object {
-        "line": 64,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-types" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 26,
-      "start": 15,
-    },
-    "verification": Object {
-      "end": 13,
-      "start": 11,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "api_key": Object {
-        "line": 37,
-      },
-      "http_basic": Object {
-        "line": 38,
-      },
-      "http_bearer": Object {
-        "line": 39,
-      },
-      "oauth2": Object {
-        "line": 40,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-types-create" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 52,
-      "start": 23,
-    },
-    "verification": Object {
-      "end": 21,
-      "start": 19,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "api_key": Object {
-        "line": 63,
-      },
-      "http_basic": Object {
-        "line": 64,
-      },
-      "http_bearer": Object {
-        "line": 65,
-      },
-      "oauth2": Object {
-        "line": 66,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-variables" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 26,
-      "start": 15,
-    },
-    "verification": Object {
-      "end": 13,
-      "start": 11,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "basic_auth": Object {
-        "line": 38,
-      },
-      "petstore_auth": Object {
-        "line": 37,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "security-variables-create" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 52,
-      "start": 23,
-    },
-    "verification": Object {
-      "end": 21,
-      "start": 19,
-    },
-  },
-  "variables": Object {
-    "security": Object {
-      "basic_auth": Object {
-        "line": 64,
-      },
-      "petstore_auth": Object {
-        "line": 63,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "server-variables" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 26,
-      "start": 15,
-    },
-    "verification": Object {
-      "end": 13,
-      "start": 11,
-    },
-  },
-  "variables": Object {
-    "server": Object {
-      "name": Object {
-        "line": 37,
-      },
-      "port": Object {
-        "line": 38,
-      },
-    },
-  },
-}
-`;
-
-exports[`webhooks-aws Node.js snippet generation aws request should match fixture for "server-variables-create" 1`] = `
-Object {
-  "sections": Object {
-    "payload": Object {
-      "end": 52,
-      "start": 23,
-    },
-    "verification": Object {
-      "end": 21,
-      "start": 19,
-    },
-  },
-  "variables": Object {
-    "server": Object {
-      "name": Object {
-        "line": 63,
-      },
-      "port": Object {
-        "line": 64,
       },
     },
   },

--- a/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
+++ b/packages/sdk-snippets/src/targets/__snapshots__/targets.test.ts.snap
@@ -1,5 +1,425 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 80,
+      "start": 44,
+    },
+    "verification": Object {
+      "end": 42,
+      "start": 40,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 100,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "empty-default-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 80,
+      "start": 44,
+    },
+    "verification": Object {
+      "end": 42,
+      "start": 40,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 103,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 100,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "quirky-escaping-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 80,
+      "start": 44,
+    },
+    "verification": Object {
+      "end": 42,
+      "start": 40,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 106,
+      },
+      "basic-auth": Object {
+        "line": 107,
+      },
+      "normal_security_var": Object {
+        "line": 108,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 101,
+      },
+      "2name": Object {
+        "line": 100,
+      },
+      "normal_server_var": Object {
+        "line": 103,
+      },
+      "p*o?r*t": Object {
+        "line": 102,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-and-server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 80,
+      "start": 44,
+    },
+    "verification": Object {
+      "end": 42,
+      "start": 40,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 105,
+      },
+      "petstore_auth": Object {
+        "line": 104,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 100,
+      },
+      "port": Object {
+        "line": 101,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-types-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 80,
+      "start": 44,
+    },
+    "verification": Object {
+      "end": 42,
+      "start": 40,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 100,
+      },
+      "http_basic": Object {
+        "line": 101,
+      },
+      "http_bearer": Object {
+        "line": 102,
+      },
+      "oauth2": Object {
+        "line": 103,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "security-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 80,
+      "start": 44,
+    },
+    "verification": Object {
+      "end": 42,
+      "start": 40,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 101,
+      },
+      "petstore_auth": Object {
+        "line": 100,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# AWS snippet generation with automatic creation of new API keys aws request should match fixture for "server-variables-create" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 80,
+      "start": 44,
+    },
+    "verification": Object {
+      "end": 42,
+      "start": 40,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 104,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 100,
+      },
+      "port": Object {
+        "line": 101,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# snippet generation aws request should match fixture for "empty" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 60,
+      "start": 41,
+    },
+    "verification": Object {
+      "end": 39,
+      "start": 37,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 80,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# snippet generation aws request should match fixture for "empty-default" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 60,
+      "start": 41,
+    },
+    "verification": Object {
+      "end": 39,
+      "start": 37,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "petstore_auth": Object {
+        "line": 83,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 80,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# snippet generation aws request should match fixture for "quirky-escaping" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 60,
+      "start": 41,
+    },
+    "verification": Object {
+      "end": 39,
+      "start": 37,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "\\"petstore\\" auth": Object {
+        "line": 86,
+      },
+      "basic-auth": Object {
+        "line": 87,
+      },
+      "normal_security_var": Object {
+        "line": 88,
+      },
+    },
+    "server": Object {
+      "*port": Object {
+        "line": 81,
+      },
+      "2name": Object {
+        "line": 80,
+      },
+      "normal_server_var": Object {
+        "line": 83,
+      },
+      "p*o?r*t": Object {
+        "line": 82,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# snippet generation aws request should match fixture for "security-and-server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 60,
+      "start": 41,
+    },
+    "verification": Object {
+      "end": 39,
+      "start": 37,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 85,
+      },
+      "petstore_auth": Object {
+        "line": 84,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 80,
+      },
+      "port": Object {
+        "line": 81,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# snippet generation aws request should match fixture for "security-types" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 60,
+      "start": 41,
+    },
+    "verification": Object {
+      "end": 39,
+      "start": 37,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "api_key": Object {
+        "line": 80,
+      },
+      "http_basic": Object {
+        "line": 81,
+      },
+      "http_bearer": Object {
+        "line": 82,
+      },
+      "oauth2": Object {
+        "line": 83,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# snippet generation aws request should match fixture for "security-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 60,
+      "start": 41,
+    },
+    "verification": Object {
+      "end": 39,
+      "start": 37,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "basic_auth": Object {
+        "line": 81,
+      },
+      "petstore_auth": Object {
+        "line": 80,
+      },
+    },
+  },
+}
+`;
+
+exports[`webhooks C# snippet generation aws request should match fixture for "server-variables" 1`] = `
+Object {
+  "sections": Object {
+    "payload": Object {
+      "end": 60,
+      "start": 41,
+    },
+    "verification": Object {
+      "end": 39,
+      "start": 37,
+    },
+  },
+  "variables": Object {
+    "security": Object {
+      "apiKey": Object {
+        "line": 84,
+      },
+    },
+    "server": Object {
+      "name": Object {
+        "line": 80,
+      },
+      "port": Object {
+        "line": 81,
+      },
+    },
+  },
+}
+`;
+
 exports[`webhooks C# snippet generation dotnet6 request should match fixture for "empty" 1`] = `
 Object {
   "sections": Object {

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/client.ts
@@ -1,0 +1,220 @@
+// For use with AWS Lambda Runtime: dotnet6
+
+import type { Client } from '../../../targets';
+
+import { CodeBuilder } from '../../../../helpers/code-builder';
+import { escapeForObjectKey, escapeForDoubleQuotes } from '../../../../helpers/escape';
+
+export const aws: Client = {
+  info: {
+    key: 'aws',
+    title: 'AWS API Gateway',
+    link: 'https://aws.amazon.com/api-gateway/',
+    description: 'ReadMe Metrics Webhooks SDK usage on AWS API Gateway',
+  },
+  convert: ({ secret, security, server }, options) => {
+    const opts = {
+      indent: '    ',
+      createKeys: false,
+      // We don't currently provide a value for defaultUsagePlanId in the
+      // ReadMe app, since we don't have any knowledge of our customers' usage
+      // plans -- but we might choose to later, and it's helpful for testing.
+      defaultUsagePlanId: '123abc',
+      ...options,
+    };
+
+    const { blank, endSection, join, push, pushVariable, ranges, startSection } = new CodeBuilder({
+      indent: opts.indent,
+    });
+
+    push('#nullable enable');
+    push('using System;');
+    push('using System.Collections.Generic;');
+    push('using System.Linq;');
+    push('using System.Threading.Tasks;');
+    push('using System.Net.Http;');
+    push('using System.Text.Json;');
+    push('using System.Text.Json.Serialization;');
+    blank();
+    push('using Amazon.Lambda.Core;');
+    push('using Amazon.Lambda.APIGatewayEvents;');
+    push('using Amazon.APIGateway;');
+    push('using Amazon.APIGateway.Model;');
+    blank();
+    push("// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.");
+    push(
+      '[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]'
+    );
+    blank();
+    push('namespace WebhookHandler');
+    push('{');
+    blank();
+    push('public class Handler', 1);
+    push('{', 1);
+    blank();
+    push('// Your ReadMe secret; you may want to store this in AWS Secrets Manager', 2);
+    push(`private const string README_SECRET = "${secret}";`, 2);
+    blank();
+    if (opts.createKeys) {
+      push('// Your default API Gateway usage plan; this will be attached to the API keys that being created', 2);
+      push(`private const string DEFAULT_USAGE_PLAN_ID = "${opts.defaultUsagePlanId}";`, 2);
+      blank();
+    }
+    push(
+      'public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)',
+      2
+    );
+    push('{', 2);
+    blank();
+    push('int statusCode = 0;', 3);
+    push('string email = null;', 3);
+    push('string apiKey = null;', 3);
+    push('string error = null;', 3);
+    blank();
+    push('try', 3);
+    push('{', 3);
+    startSection('verification');
+    push('string signature = apigProxyEvent.Headers["ReadMe-Signature"];', 4);
+    push('string body = apigProxyEvent.Body;', 4);
+    push('ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);', 4);
+    endSection('verification');
+    blank();
+    startSection('payload');
+    push('email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];', 4);
+    push('var client = new AmazonAPIGatewayClient();', 4);
+    const requestName = opts.createKeys ? 'keysRequest' : 'request';
+    push(`var ${requestName} = new GetApiKeysRequest`, 4);
+    push('{', 4);
+    push('NameQuery = email,', 5);
+    push('IncludeValues = true', 5);
+    push('};', 4);
+    push(`var keys = await client.GetApiKeysAsync(${requestName});`, 4);
+    blank();
+    push('if (keys.Items.Count > 0)', 4);
+    push('{', 4);
+    push('// if multiple API keys are returned for the given email, use the first one', 5);
+    push('apiKey = keys.Items[0].Value;', 5);
+    push('statusCode = 200;', 5);
+    push('}', 4);
+    push('else', 4);
+    push('{', 4);
+    if (opts.createKeys) {
+      push('var createKeyRequest = new CreateApiKeyRequest', 5);
+      push('{', 5);
+      push('Name = email,', 6);
+      push('Description = $"API key for ReadMe user {email}",', 6);
+      push('Tags = new Dictionary<string, string> { { "Email", email }, { "Vendor", "ReadMe" } },', 6);
+      push('Enabled = true', 6);
+      push('};', 5);
+      push('var key = await client.CreateApiKeyAsync(createKeyRequest);', 5);
+      blank();
+      push('var usagePlanKeyRequest = new CreateUsagePlanKeyRequest', 5);
+      push('{', 5);
+      push('UsagePlanId = Handler.DEFAULT_USAGE_PLAN_ID,', 6);
+      push('KeyId = key.Id,', 6);
+      push('KeyType = "API_KEY"', 6);
+      push('};', 5);
+      push('await client.CreateUsagePlanKeyAsync(usagePlanKeyRequest);', 5);
+      blank();
+      push('apiKey = key.Value;', 5);
+      push('statusCode = 200;', 5);
+    } else {
+      push('error = "Email not found";', 5);
+      push('statusCode = 404;', 5);
+    }
+    push('}', 4);
+    endSection('payload');
+    push('}', 3);
+    push('catch (Exception ex)', 3);
+    push('{', 3);
+    push('if (ex.Message.Contains("Signature"))', 4);
+    push('{', 4);
+    push('error = ex.Message;', 5);
+    push('statusCode = 404;', 5);
+    push('}', 4);
+    push('else', 4);
+    push('{', 4);
+    push('error = ex.Message;', 5);
+    push('statusCode = 500;', 5);
+    push('}', 4);
+    push('}', 3);
+    blank();
+    push('var output = new Dictionary<string, string> {};', 3);
+    push('if (statusCode == 200)', 3);
+    push('{', 3);
+
+    if (server.length) {
+      push('// OAS Server variables', 4);
+      server.forEach(data => {
+        pushVariable(
+          `output.Add("${escapeForDoubleQuotes(data.name)}", "${escapeForDoubleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}");`,
+          {
+            type: 'server',
+            name: data.name,
+            indentationLevel: 4,
+          }
+        );
+      });
+      blank();
+    }
+
+    if (security.length) {
+      push('// OAS Security variables', 4);
+      security.forEach(data => {
+        if (data.type === 'http') {
+          // Only HTTP Basic auth has any special handling for supplying auth.
+          if (data.scheme === 'basic') {
+            pushVariable(
+              `output.Add("${escapeForDoubleQuotes(
+                data.name
+              )}", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });`,
+              {
+                type: 'security',
+                name: data.name,
+                indentationLevel: 4,
+              }
+            );
+            return;
+          }
+        }
+
+        pushVariable(`output.Add("${escapeForDoubleQuotes(data.name)}", apiKey);`, {
+          type: 'security',
+          name: data.name,
+          indentationLevel: 4,
+        });
+      });
+    } else {
+      push("// The user's API key", 4);
+      pushVariable('output.Add("apiKey", apiKey);', {
+        type: 'security',
+        name: 'apiKey',
+        indentationLevel: 4,
+      });
+    }
+
+    push('}', 3);
+    push('else', 3);
+    push('{', 3);
+    push('output.Add("error", error);', 4);
+    push('}', 3);
+    blank();
+    push('return new APIGatewayProxyResponse', 3);
+    push('{', 3);
+    push('StatusCode = statusCode,', 4);
+    push('Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },', 4);
+    push('Body = JsonSerializer.Serialize(output)', 4);
+    push('};', 3);
+
+    push('}', 2);
+    push('}', 1);
+    push('}');
+
+    return {
+      ranges: ranges(),
+      snippet: join(),
+    };
+  },
+};

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/client.ts
@@ -3,7 +3,7 @@
 import type { Client } from '../../../targets';
 
 import { CodeBuilder } from '../../../../helpers/code-builder';
-import { escapeForObjectKey, escapeForDoubleQuotes } from '../../../../helpers/escape';
+import { escapeForDoubleQuotes } from '../../../../helpers/escape';
 
 export const aws: Client = {
   info: {

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/empty-create.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/empty-create.cs
@@ -1,0 +1,115 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        // Your default API Gateway usage plan; this will be attached to the API keys that being created
+        private const string DEFAULT_USAGE_PLAN_ID = "123abc";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var keysRequest = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(keysRequest);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    var createKeyRequest = new CreateApiKeyRequest
+                    {
+                        Name = email,
+                        Description = $"API key for ReadMe user {email}",
+                        Tags = new Dictionary<string, string> { { "Email", email }, { "Vendor", "ReadMe" } },
+                        Enabled = true
+                    };
+                    var key = await client.CreateApiKeyAsync(createKeyRequest);
+
+                    var usagePlanKeyRequest = new CreateUsagePlanKeyRequest
+                    {
+                        UsagePlanId = Handler.DEFAULT_USAGE_PLAN_ID,
+                        KeyId = key.Id,
+                        KeyType = "API_KEY"
+                    };
+                    await client.CreateUsagePlanKeyAsync(usagePlanKeyRequest);
+
+                    apiKey = key.Value;
+                    statusCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // The user's API key
+                output.Add("apiKey", apiKey);
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/empty-default-create.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/empty-default-create.cs
@@ -1,0 +1,118 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        // Your default API Gateway usage plan; this will be attached to the API keys that being created
+        private const string DEFAULT_USAGE_PLAN_ID = "123abc";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var keysRequest = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(keysRequest);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    var createKeyRequest = new CreateApiKeyRequest
+                    {
+                        Name = email,
+                        Description = $"API key for ReadMe user {email}",
+                        Tags = new Dictionary<string, string> { { "Email", email }, { "Vendor", "ReadMe" } },
+                        Enabled = true
+                    };
+                    var key = await client.CreateApiKeyAsync(createKeyRequest);
+
+                    var usagePlanKeyRequest = new CreateUsagePlanKeyRequest
+                    {
+                        UsagePlanId = Handler.DEFAULT_USAGE_PLAN_ID,
+                        KeyId = key.Id,
+                        KeyType = "API_KEY"
+                    };
+                    await client.CreateUsagePlanKeyAsync(usagePlanKeyRequest);
+
+                    apiKey = key.Value;
+                    statusCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Server variables
+                output.Add("name", "");
+
+                // OAS Security variables
+                output.Add("petstore_auth", apiKey);
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/empty-default.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/empty-default.cs
@@ -1,0 +1,98 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var request = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(request);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    error = "Email not found";
+                    statusCode = 404;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Server variables
+                output.Add("name", "");
+
+                // OAS Security variables
+                output.Add("petstore_auth", apiKey);
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/empty.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/empty.cs
@@ -1,0 +1,95 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var request = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(request);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    error = "Email not found";
+                    statusCode = 404;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // The user's API key
+                output.Add("apiKey", apiKey);
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/quirky-escaping-create.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/quirky-escaping-create.cs
@@ -1,0 +1,123 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        // Your default API Gateway usage plan; this will be attached to the API keys that being created
+        private const string DEFAULT_USAGE_PLAN_ID = "123abc";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var keysRequest = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(keysRequest);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    var createKeyRequest = new CreateApiKeyRequest
+                    {
+                        Name = email,
+                        Description = $"API key for ReadMe user {email}",
+                        Tags = new Dictionary<string, string> { { "Email", email }, { "Vendor", "ReadMe" } },
+                        Enabled = true
+                    };
+                    var key = await client.CreateApiKeyAsync(createKeyRequest);
+
+                    var usagePlanKeyRequest = new CreateUsagePlanKeyRequest
+                    {
+                        UsagePlanId = Handler.DEFAULT_USAGE_PLAN_ID,
+                        KeyId = key.Id,
+                        KeyType = "API_KEY"
+                    };
+                    await client.CreateUsagePlanKeyAsync(usagePlanKeyRequest);
+
+                    apiKey = key.Value;
+                    statusCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Server variables
+                output.Add("2name", "default-name");
+                output.Add("*port", "");
+                output.Add("p*o?r*t", "");
+                output.Add("normal_server_var", "");
+
+                // OAS Security variables
+                output.Add("\"petstore\" auth", apiKey);
+                output.Add("basic-auth", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+                output.Add("normal_security_var", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/quirky-escaping.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/quirky-escaping.cs
@@ -1,0 +1,103 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var request = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(request);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    error = "Email not found";
+                    statusCode = 404;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Server variables
+                output.Add("2name", "default-name");
+                output.Add("*port", "");
+                output.Add("p*o?r*t", "");
+                output.Add("normal_server_var", "");
+
+                // OAS Security variables
+                output.Add("\"petstore\" auth", apiKey);
+                output.Add("basic-auth", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+                output.Add("normal_security_var", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-and-server-variables-create.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-and-server-variables-create.cs
@@ -1,0 +1,120 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        // Your default API Gateway usage plan; this will be attached to the API keys that being created
+        private const string DEFAULT_USAGE_PLAN_ID = "123abc";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var keysRequest = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(keysRequest);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    var createKeyRequest = new CreateApiKeyRequest
+                    {
+                        Name = email,
+                        Description = $"API key for ReadMe user {email}",
+                        Tags = new Dictionary<string, string> { { "Email", email }, { "Vendor", "ReadMe" } },
+                        Enabled = true
+                    };
+                    var key = await client.CreateApiKeyAsync(createKeyRequest);
+
+                    var usagePlanKeyRequest = new CreateUsagePlanKeyRequest
+                    {
+                        UsagePlanId = Handler.DEFAULT_USAGE_PLAN_ID,
+                        KeyId = key.Id,
+                        KeyType = "API_KEY"
+                    };
+                    await client.CreateUsagePlanKeyAsync(usagePlanKeyRequest);
+
+                    apiKey = key.Value;
+                    statusCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Server variables
+                output.Add("name", "default-name");
+                output.Add("port", "");
+
+                // OAS Security variables
+                output.Add("petstore_auth", apiKey);
+                output.Add("basic_auth", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-and-server-variables.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-and-server-variables.cs
@@ -1,0 +1,100 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var request = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(request);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    error = "Email not found";
+                    statusCode = 404;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Server variables
+                output.Add("name", "default-name");
+                output.Add("port", "");
+
+                // OAS Security variables
+                output.Add("petstore_auth", apiKey);
+                output.Add("basic_auth", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-types-create.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-types-create.cs
@@ -1,0 +1,118 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        // Your default API Gateway usage plan; this will be attached to the API keys that being created
+        private const string DEFAULT_USAGE_PLAN_ID = "123abc";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var keysRequest = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(keysRequest);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    var createKeyRequest = new CreateApiKeyRequest
+                    {
+                        Name = email,
+                        Description = $"API key for ReadMe user {email}",
+                        Tags = new Dictionary<string, string> { { "Email", email }, { "Vendor", "ReadMe" } },
+                        Enabled = true
+                    };
+                    var key = await client.CreateApiKeyAsync(createKeyRequest);
+
+                    var usagePlanKeyRequest = new CreateUsagePlanKeyRequest
+                    {
+                        UsagePlanId = Handler.DEFAULT_USAGE_PLAN_ID,
+                        KeyId = key.Id,
+                        KeyType = "API_KEY"
+                    };
+                    await client.CreateUsagePlanKeyAsync(usagePlanKeyRequest);
+
+                    apiKey = key.Value;
+                    statusCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Security variables
+                output.Add("api_key", apiKey);
+                output.Add("http_basic", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+                output.Add("http_bearer", apiKey);
+                output.Add("oauth2", apiKey);
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-types.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-types.cs
@@ -1,0 +1,98 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var request = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(request);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    error = "Email not found";
+                    statusCode = 404;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Security variables
+                output.Add("api_key", apiKey);
+                output.Add("http_basic", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+                output.Add("http_bearer", apiKey);
+                output.Add("oauth2", apiKey);
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-variables-create.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-variables-create.cs
@@ -1,0 +1,116 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        // Your default API Gateway usage plan; this will be attached to the API keys that being created
+        private const string DEFAULT_USAGE_PLAN_ID = "123abc";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var keysRequest = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(keysRequest);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    var createKeyRequest = new CreateApiKeyRequest
+                    {
+                        Name = email,
+                        Description = $"API key for ReadMe user {email}",
+                        Tags = new Dictionary<string, string> { { "Email", email }, { "Vendor", "ReadMe" } },
+                        Enabled = true
+                    };
+                    var key = await client.CreateApiKeyAsync(createKeyRequest);
+
+                    var usagePlanKeyRequest = new CreateUsagePlanKeyRequest
+                    {
+                        UsagePlanId = Handler.DEFAULT_USAGE_PLAN_ID,
+                        KeyId = key.Id,
+                        KeyType = "API_KEY"
+                    };
+                    await client.CreateUsagePlanKeyAsync(usagePlanKeyRequest);
+
+                    apiKey = key.Value;
+                    statusCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Security variables
+                output.Add("petstore_auth", apiKey);
+                output.Add("basic_auth", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-variables.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/security-variables.cs
@@ -1,0 +1,96 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var request = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(request);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    error = "Email not found";
+                    statusCode = 404;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Security variables
+                output.Add("petstore_auth", apiKey);
+                output.Add("basic_auth", new Dictionary<string, string> { { "user", email }, { "pass", apiKey } });
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/server-variables-create.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/server-variables-create.cs
@@ -1,0 +1,119 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        // Your default API Gateway usage plan; this will be attached to the API keys that being created
+        private const string DEFAULT_USAGE_PLAN_ID = "123abc";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var keysRequest = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(keysRequest);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    var createKeyRequest = new CreateApiKeyRequest
+                    {
+                        Name = email,
+                        Description = $"API key for ReadMe user {email}",
+                        Tags = new Dictionary<string, string> { { "Email", email }, { "Vendor", "ReadMe" } },
+                        Enabled = true
+                    };
+                    var key = await client.CreateApiKeyAsync(createKeyRequest);
+
+                    var usagePlanKeyRequest = new CreateUsagePlanKeyRequest
+                    {
+                        UsagePlanId = Handler.DEFAULT_USAGE_PLAN_ID,
+                        KeyId = key.Id,
+                        KeyType = "API_KEY"
+                    };
+                    await client.CreateUsagePlanKeyAsync(usagePlanKeyRequest);
+
+                    apiKey = key.Value;
+                    statusCode = 200;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Server variables
+                output.Add("name", "default-name");
+                output.Add("port", "");
+
+                // The user's API key
+                output.Add("apiKey", apiKey);
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/server-variables.cs
+++ b/packages/sdk-snippets/src/targets/csharp/aws/webhooks/fixtures/server-variables.cs
@@ -1,0 +1,99 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.APIGateway;
+using Amazon.APIGateway.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace WebhookHandler
+{
+
+    public class Handler
+    {
+
+        // Your ReadMe secret; you may want to store this in AWS Secrets Manager
+        private const string README_SECRET = "my-readme-secret";
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            int statusCode = 0;
+            string email = null;
+            string apiKey = null;
+            string error = null;
+
+            try
+            {
+                string signature = apigProxyEvent.Headers["ReadMe-Signature"];
+                string body = apigProxyEvent.Body;
+                ReadMe.Webhook.Verify(body, signature, Handler.README_SECRET);
+
+                email = JsonSerializer.Deserialize<Dictionary<string, string>>(body)["email"];
+                var client = new AmazonAPIGatewayClient();
+                var request = new GetApiKeysRequest
+                {
+                    NameQuery = email,
+                    IncludeValues = true
+                };
+                var keys = await client.GetApiKeysAsync(request);
+
+                if (keys.Items.Count > 0)
+                {
+                    // if multiple API keys are returned for the given email, use the first one
+                    apiKey = keys.Items[0].Value;
+                    statusCode = 200;
+                }
+                else
+                {
+                    error = "Email not found";
+                    statusCode = 404;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Signature"))
+                {
+                    error = ex.Message;
+                    statusCode = 404;
+                }
+                else
+                {
+                    error = ex.Message;
+                    statusCode = 500;
+                }
+            }
+
+            var output = new Dictionary<string, string> {};
+            if (statusCode == 200)
+            {
+                // OAS Server variables
+                output.Add("name", "default-name");
+                output.Add("port", "");
+
+                // The user's API key
+                output.Add("apiKey", apiKey);
+            }
+            else
+            {
+                output.Add("error", error);
+            }
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = statusCode,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                Body = JsonSerializer.Serialize(output)
+            };
+        }
+    }
+}

--- a/packages/sdk-snippets/src/targets/csharp/target.ts
+++ b/packages/sdk-snippets/src/targets/csharp/target.ts
@@ -1,5 +1,6 @@
 import type { Target } from '../targets';
 
+import { aws } from './aws/webhooks/client';
 import { dotnet6 } from './dotnet6/webhooks/client';
 
 export const csharp: Target = {
@@ -13,6 +14,7 @@ export const csharp: Target = {
   services: {
     server: {},
     webhooks: {
+      aws,
       dotnet6,
     },
   },

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/client.ts
@@ -76,6 +76,7 @@ export const aws: Client = {
     if (opts.createKeys) {
       push('const createKeyCommand = new CreateApiKeyCommand({', 3);
       push('name: email,', 4);
+      // eslint-disable-next-line no-template-curly-in-string
       push('description: `API key for ReadMe user ${email}`,', 4);
       push('tags: {', 4);
       push('user: email,', 5);

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/client.ts
@@ -151,7 +151,11 @@ export const aws: Client = {
       });
     } else {
       push("// The user's API key", 3);
-      push('apiKey,', 3);
+      pushVariable('apiKey,', {
+        type: 'security',
+        name: 'apiKey',
+        indentationLevel: 3,
+      });
     }
     blank();
     push('// Error message, if any', 3);

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/client.ts
@@ -1,3 +1,5 @@
+// For use with AWS Lambda Runtime: nodejs16.x
+
 import type { Client } from '../../../targets';
 
 import { CodeBuilder } from '../../../../helpers/code-builder';
@@ -13,7 +15,11 @@ export const aws: Client = {
   convert: ({ secret, security, server }, options) => {
     const opts = {
       indent: '  ',
-      readOnly: true,
+      createKeys: false,
+      // We don't currently provide a value for defaultUsagePlanId in the
+      // ReadMe app, since we don't have any knowledge of our customers' usage
+      // plans -- but we might choose to later, and it's helpful for testing.
+      defaultUsagePlanId: '123abc',
       ...options,
     };
 
@@ -21,121 +27,31 @@ export const aws: Client = {
       indent: opts.indent,
     });
 
-    // push("const express = require('express');");
-    // push("const readme = require('readmeio');");
-
-    // blank();
-
-    // push('const app = express();');
-    // blank();
-
-    // push('// Your ReadMe secret');
-    // push(`const secret = '${secret}';`);
-    // blank();
-
-    // push("app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {");
-    // startSection('verification');
-    // push('// Verify the request is legitimate and came from ReadMe.', 1);
-    // push("const signature = req.headers['readme-signature'];", 1);
-    // blank();
-
-    // push('try {', 1);
-    // push('readme.verifyWebhook(req.body, signature, secret);', 2);
-    // push('} catch (e) {', 1);
-    // push('// Handle invalid requests', 2);
-    // push('return res.status(401).json({ error: e.message });', 2);
-    // push('}', 1);
-    // endSection('verification');
-    // blank();
-
-    // startSection('payload');
-    // push('// Fetch the user from the database and return their data for use with OpenAPI variables.', 1);
-    // push('// const user = await db.find({ email: req.body.email })', 1);
-    // push('return res.json({', 1);
-
-    // if (!server.length && !security.length) {
-    //   push('// Add custom data to return in your webhook call here.', 2);
-    // }
-
-    // if (server.length) {
-    //   push('// OAS Server variables', 2);
-    //   server.forEach(data => {
-    //     pushVariable(
-    //       `${escapeForObjectKey(data.name)}: '${escapeForSingleQuotes(
-    //         data.default || data.default === '' ? data.default : data.name
-    //       )}',`,
-    //       {
-    //         type: 'server',
-    //         name: data.name,
-    //         indentationLevel: 2,
-    //       }
-    //     );
-    //   });
-    // }
-
-    // if (server.length && security.length) {
-    //   blank();
-    // }
-
-    // if (security.length) {
-    //   push('// OAS Security variables', 2);
-    //   security.forEach(data => {
-    //     if (data.type === 'http') {
-    //       // Only HTTP Basic auth has any special handling for supplying auth.
-    //       if (data.scheme === 'basic') {
-    //         pushVariable(`${escapeForObjectKey(data.name)}: { user: 'user', pass: 'pass' },`, {
-    //           type: 'security',
-    //           name: data.name,
-    //           indentationLevel: 2,
-    //         });
-    //         return;
-    //       }
-    //     }
-
-    //     pushVariable(
-    //       `${escapeForObjectKey(data.name)}: '${escapeForSingleQuotes(
-    //         data.default || data.default === '' ? data.default : data.name
-    //       )}',`,
-    //       {
-    //         type: 'security',
-    //         name: data.name,
-    //         indentationLevel: 2,
-    //       }
-    //     );
-    //   });
-    // }
-
-    // push('});', 1);
-    // endSection('payload');
-    // push('});');
-
-    // blank();
-
-    // push("const server = app.listen(8000, '0.0.0.0', () => {");
-    // push("console.log('Example app listening at http://%s:%s', server.address().address, server.address().port);", 1);
-    // push('});');
-    // blank();
-
-    // (Internal ReadMe note) This is an example Personalized Docs webhook handler
-    // for customers using AWS API Gateway. In this example we attempt to lookup the
-    // API key for the user with the given email address by using the AWS SDK method
-    // GetApiKeys. It returns a JSON response with { "apiKey": "whatever" }, or a
-    // 404 if the user doesn't exist.
-
-    // For use with this AWS Lambda Runtime: nodejs16.x
-    // Create API keys: no
-
-    push("const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');");
+    if (opts.createKeys) {
+      push('const {');
+      push('APIGatewayClient,', 1);
+      push('CreateApiKeyCommand,', 1);
+      push('CreateUsagePlanKeyCommand,', 1);
+      push('GetApiKeysCommand,', 1);
+      push("} = require('@aws-sdk/client-api-gateway');");
+    } else {
+      push("const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');");
+    }
     push("const readme = require('readmeio');");
     blank();
 
     push('// Your ReadMe secret; you may want to store this in AWS Secrets Manager');
-    // @todo: This should be populated with the project's JWT secret
     push(`const README_SECRET = '${secret}';`);
     blank();
 
+    if (opts.createKeys) {
+      push('// Your default API Gateway usage plan; this will be attached to the API keys that being created');
+      push(`const DEFAULT_USAGE_PLAN_ID = '${opts.defaultUsagePlanId}';`);
+      blank();
+    }
+
     push('exports.handler = async event => {');
-    push('let statusCode, apiKey, error;', 1);
+    push('let statusCode, email, apiKey, error;', 1);
     blank();
 
     push('try {', 1);
@@ -147,18 +63,41 @@ export const aws: Client = {
     blank();
 
     startSection('payload');
+    const getCommandName = opts.createKeys ? 'getCommand' : 'command';
     push('const email = body.email;', 2);
     push('const client = new APIGatewayClient();', 2);
-    push('const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });', 2);
-    push('const keys = await client.send(command);', 2);
+    push(`const ${getCommandName} = new GetApiKeysCommand({ nameQuery: email, includeValues: true });`, 2);
+    push(`const keys = await client.send(${getCommandName});`, 2);
     push('if (keys.items.length > 0) {', 2);
-    // if multiple API keys are returned for the given email, use the first one
-    // @todo Talk to Gabe about when/whether to return "keys" as an array of { apiKey, id } or { user, id } objects
+    push('// if multiple API keys are returned for the given email, use the first one', 3);
     push('apiKey = keys.items[0].value;', 3);
     push('statusCode = 200;', 3);
     push('} else {', 2);
-    push("error = 'Email not found';", 3);
-    push('statusCode = 404;', 3);
+    if (opts.createKeys) {
+      push('const createKeyCommand = new CreateApiKeyCommand({', 3);
+      push('name: email,', 4);
+      push('description: `API key for ReadMe user ${email}`,', 4);
+      push('tags: {', 4);
+      push('user: email,', 5);
+      push("vendor: 'ReadMe',", 5);
+      push('},', 4);
+      push('enabled: true,', 4);
+      push('});', 3);
+      push('const key = await client.send(createKeyCommand);', 3);
+      blank();
+      push('const usagePlanKeyCommand = new CreateUsagePlanKeyCommand({', 3);
+      push('usagePlanId: DEFAULT_USAGE_PLAN_ID,', 4);
+      push('keyId: key.id,', 4);
+      push("keyType: 'API_KEY',", 4);
+      push('});', 3);
+      push('await client.send(usagePlanKeyCommand);', 3);
+      blank();
+      push('apiKey = key.value;', 3);
+      push('statusCode = 200;', 3);
+    } else {
+      push("error = 'Email not found';", 3);
+      push('statusCode = 404;', 3);
+    }
     push('}', 2);
     endSection('payload');
     push('} catch (e) {', 1);
@@ -170,7 +109,54 @@ export const aws: Client = {
     push('return {', 1);
     push('statusCode,', 2);
     push("headers: { 'Content-Type': 'application/json' },", 2);
-    push('body: JSON.stringify({ apiKey, message: error }),', 2);
+    push('body: JSON.stringify({', 2);
+
+    if (server.length) {
+      push('// OAS Server variables', 3);
+      server.forEach(data => {
+        pushVariable(
+          `${escapeForObjectKey(data.name)}: '${escapeForSingleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}',`,
+          {
+            type: 'server',
+            name: data.name,
+            indentationLevel: 3,
+          }
+        );
+      });
+      blank();
+    }
+
+    if (security.length) {
+      push('// OAS Security variables', 3);
+      security.forEach(data => {
+        if (data.type === 'http') {
+          // Only HTTP Basic auth has any special handling for supplying auth.
+          if (data.scheme === 'basic') {
+            pushVariable(`${escapeForObjectKey(data.name)}: { user: email, pass: apiKey },`, {
+              type: 'security',
+              name: data.name,
+              indentationLevel: 3,
+            });
+            return;
+          }
+        }
+
+        pushVariable(`${escapeForObjectKey(data.name)}: apiKey,`, {
+          type: 'security',
+          name: data.name,
+          indentationLevel: 3,
+        });
+      });
+    } else {
+      push("// The user's API key", 3);
+      push('apiKey,', 3);
+    }
+    blank();
+    push('// Error message, if any', 3);
+    push('message: error,', 3);
+    push('}),', 2);
     push('};', 1);
     push('};');
 

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/client.ts
@@ -1,0 +1,182 @@
+import type { Client } from '../../../targets';
+
+import { CodeBuilder } from '../../../../helpers/code-builder';
+import { escapeForObjectKey, escapeForSingleQuotes } from '../../../../helpers/escape';
+
+export const aws: Client = {
+  info: {
+    key: 'aws',
+    title: 'AWS API Gateway',
+    link: 'https://aws.amazon.com/api-gateway/',
+    description: 'ReadMe Metrics Webhooks SDK usage on AWS API Gateway',
+  },
+  convert: ({ secret, security, server }, options) => {
+    const opts = {
+      indent: '  ',
+      readOnly: true,
+      ...options,
+    };
+
+    const { blank, endSection, join, push, pushVariable, ranges, startSection } = new CodeBuilder({
+      indent: opts.indent,
+    });
+
+    // push("const express = require('express');");
+    // push("const readme = require('readmeio');");
+
+    // blank();
+
+    // push('const app = express();');
+    // blank();
+
+    // push('// Your ReadMe secret');
+    // push(`const secret = '${secret}';`);
+    // blank();
+
+    // push("app.post('/webhook', express.json({ type: 'application/json' }), async (req, res) => {");
+    // startSection('verification');
+    // push('// Verify the request is legitimate and came from ReadMe.', 1);
+    // push("const signature = req.headers['readme-signature'];", 1);
+    // blank();
+
+    // push('try {', 1);
+    // push('readme.verifyWebhook(req.body, signature, secret);', 2);
+    // push('} catch (e) {', 1);
+    // push('// Handle invalid requests', 2);
+    // push('return res.status(401).json({ error: e.message });', 2);
+    // push('}', 1);
+    // endSection('verification');
+    // blank();
+
+    // startSection('payload');
+    // push('// Fetch the user from the database and return their data for use with OpenAPI variables.', 1);
+    // push('// const user = await db.find({ email: req.body.email })', 1);
+    // push('return res.json({', 1);
+
+    // if (!server.length && !security.length) {
+    //   push('// Add custom data to return in your webhook call here.', 2);
+    // }
+
+    // if (server.length) {
+    //   push('// OAS Server variables', 2);
+    //   server.forEach(data => {
+    //     pushVariable(
+    //       `${escapeForObjectKey(data.name)}: '${escapeForSingleQuotes(
+    //         data.default || data.default === '' ? data.default : data.name
+    //       )}',`,
+    //       {
+    //         type: 'server',
+    //         name: data.name,
+    //         indentationLevel: 2,
+    //       }
+    //     );
+    //   });
+    // }
+
+    // if (server.length && security.length) {
+    //   blank();
+    // }
+
+    // if (security.length) {
+    //   push('// OAS Security variables', 2);
+    //   security.forEach(data => {
+    //     if (data.type === 'http') {
+    //       // Only HTTP Basic auth has any special handling for supplying auth.
+    //       if (data.scheme === 'basic') {
+    //         pushVariable(`${escapeForObjectKey(data.name)}: { user: 'user', pass: 'pass' },`, {
+    //           type: 'security',
+    //           name: data.name,
+    //           indentationLevel: 2,
+    //         });
+    //         return;
+    //       }
+    //     }
+
+    //     pushVariable(
+    //       `${escapeForObjectKey(data.name)}: '${escapeForSingleQuotes(
+    //         data.default || data.default === '' ? data.default : data.name
+    //       )}',`,
+    //       {
+    //         type: 'security',
+    //         name: data.name,
+    //         indentationLevel: 2,
+    //       }
+    //     );
+    //   });
+    // }
+
+    // push('});', 1);
+    // endSection('payload');
+    // push('});');
+
+    // blank();
+
+    // push("const server = app.listen(8000, '0.0.0.0', () => {");
+    // push("console.log('Example app listening at http://%s:%s', server.address().address, server.address().port);", 1);
+    // push('});');
+    // blank();
+
+    // (Internal ReadMe note) This is an example Personalized Docs webhook handler
+    // for customers using AWS API Gateway. In this example we attempt to lookup the
+    // API key for the user with the given email address by using the AWS SDK method
+    // GetApiKeys. It returns a JSON response with { "apiKey": "whatever" }, or a
+    // 404 if the user doesn't exist.
+
+    // For use with this AWS Lambda Runtime: nodejs16.x
+    // Create API keys: no
+
+    push("const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');");
+    push("const readme = require('readmeio');");
+    blank();
+
+    push('// Your ReadMe secret; you may want to store this in AWS Secrets Manager');
+    // @todo: This should be populated with the project's JWT secret
+    push(`const README_SECRET = '${secret}';`);
+    blank();
+
+    push('exports.handler = async event => {');
+    push('let statusCode, apiKey, error;', 1);
+    blank();
+
+    push('try {', 1);
+    startSection('verification');
+    push("const signature = event.headers['ReadMe-Signature'];", 2);
+    push('const body = JSON.parse(event.body);', 2);
+    push('readme.verifyWebhook(body, signature, README_SECRET);', 2);
+    endSection('verification');
+    blank();
+
+    startSection('payload');
+    push('const email = body.email;', 2);
+    push('const client = new APIGatewayClient();', 2);
+    push('const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });', 2);
+    push('const keys = await client.send(command);', 2);
+    push('if (keys.items.length > 0) {', 2);
+    // if multiple API keys are returned for the given email, use the first one
+    // @todo Talk to Gabe about when/whether to return "keys" as an array of { apiKey, id } or { user, id } objects
+    push('apiKey = keys.items[0].value;', 3);
+    push('statusCode = 200;', 3);
+    push('} else {', 2);
+    push("error = 'Email not found';", 3);
+    push('statusCode = 404;', 3);
+    push('}', 2);
+    endSection('payload');
+    push('} catch (e) {', 1);
+    push('error = e.message;', 2);
+    push('statusCode = error.match(/Signature/) ? 401 : 500;', 2);
+    push('}', 1);
+    blank();
+
+    push('return {', 1);
+    push('statusCode,', 2);
+    push("headers: { 'Content-Type': 'application/json' },", 2);
+    push('body: JSON.stringify({ apiKey, message: error }),', 2);
+    push('};', 1);
+    push('};');
+
+    return {
+      ranges: ranges(),
+      snippet: join(),
+    };
+  },
+};

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty-create.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty-create.js
@@ -1,0 +1,69 @@
+const {
+  APIGatewayClient,
+  CreateApiKeyCommand,
+  CreateUsagePlanKeyCommand,
+  GetApiKeysCommand,
+} = require('@aws-sdk/client-api-gateway');
+const readme = require('readmeio');
+
+// Your ReadMe secret; you may want to store this in AWS Secrets Manager
+const README_SECRET = 'my-readme-secret';
+
+// Your default API Gateway usage plan; this will be attached to the API keys that being created
+const DEFAULT_USAGE_PLAN_ID = '123abc';
+
+exports.handler = async event => {
+  let statusCode, email, apiKey, error;
+
+  try {
+    const signature = event.headers['ReadMe-Signature'];
+    const body = JSON.parse(event.body);
+    readme.verifyWebhook(body, signature, README_SECRET);
+
+    const email = body.email;
+    const client = new APIGatewayClient();
+    const getCommand = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(getCommand);
+    if (keys.items.length > 0) {
+      // if multiple API keys are returned for the given email, use the first one
+      apiKey = keys.items[0].value;
+      statusCode = 200;
+    } else {
+      const createKeyCommand = new CreateApiKeyCommand({
+        name: email,
+        description: `API key for ReadMe user ${email}`,
+        tags: {
+          user: email,
+          vendor: 'ReadMe',
+        },
+        enabled: true,
+      });
+      const key = await client.send(createKeyCommand);
+
+      const usagePlanKeyCommand = new CreateUsagePlanKeyCommand({
+        usagePlanId: DEFAULT_USAGE_PLAN_ID,
+        keyId: key.id,
+        keyType: 'API_KEY',
+      });
+      await client.send(usagePlanKeyCommand);
+
+      apiKey = key.value;
+      statusCode = 200;
+    }
+  } catch (e) {
+    error = e.message;
+    statusCode = error.match(/Signature/) ? 401 : 500;
+  }
+
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      // The user's API key
+      apiKey,
+
+      // Error message, if any
+      message: error,
+    }),
+  };
+};

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty-default-create.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty-default-create.js
@@ -1,8 +1,16 @@
-const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const {
+  APIGatewayClient,
+  CreateApiKeyCommand,
+  CreateUsagePlanKeyCommand,
+  GetApiKeysCommand,
+} = require('@aws-sdk/client-api-gateway');
 const readme = require('readmeio');
 
 // Your ReadMe secret; you may want to store this in AWS Secrets Manager
 const README_SECRET = 'my-readme-secret';
+
+// Your default API Gateway usage plan; this will be attached to the API keys that being created
+const DEFAULT_USAGE_PLAN_ID = '123abc';
 
 exports.handler = async event => {
   let statusCode, email, apiKey, error;
@@ -14,15 +22,33 @@ exports.handler = async event => {
 
     const email = body.email;
     const client = new APIGatewayClient();
-    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
-    const keys = await client.send(command);
+    const getCommand = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(getCommand);
     if (keys.items.length > 0) {
       // if multiple API keys are returned for the given email, use the first one
       apiKey = keys.items[0].value;
       statusCode = 200;
     } else {
-      error = 'Email not found';
-      statusCode = 404;
+      const createKeyCommand = new CreateApiKeyCommand({
+        name: email,
+        description: `API key for ReadMe user ${email}`,
+        tags: {
+          user: email,
+          vendor: 'ReadMe',
+        },
+        enabled: true,
+      });
+      const key = await client.send(createKeyCommand);
+
+      const usagePlanKeyCommand = new CreateUsagePlanKeyCommand({
+        usagePlanId: DEFAULT_USAGE_PLAN_ID,
+        keyId: key.id,
+        keyType: 'API_KEY',
+      });
+      await client.send(usagePlanKeyCommand);
+
+      apiKey = key.value;
+      statusCode = 200;
     }
   } catch (e) {
     error = e.message;
@@ -34,12 +60,10 @@ exports.handler = async event => {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       // OAS Server variables
-      name: 'default-name',
-      port: '',
+      name: '',
 
       // OAS Security variables
       petstore_auth: apiKey,
-      basic_auth: { user: email, pass: apiKey },
 
       // Error message, if any
       message: error,

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty-default.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty-default.js
@@ -5,7 +5,7 @@ const readme = require('readmeio');
 const README_SECRET = 'my-readme-secret';
 
 exports.handler = async event => {
-  let statusCode, apiKey, error;
+  let statusCode, email, apiKey, error;
 
   try {
     const signature = event.headers['ReadMe-Signature'];
@@ -17,6 +17,7 @@ exports.handler = async event => {
     const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
     const keys = await client.send(command);
     if (keys.items.length > 0) {
+      // if multiple API keys are returned for the given email, use the first one
       apiKey = keys.items[0].value;
       statusCode = 200;
     } else {
@@ -31,6 +32,15 @@ exports.handler = async event => {
   return {
     statusCode,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ apiKey, message: error }),
+    body: JSON.stringify({
+      // OAS Server variables
+      name: '',
+
+      // OAS Security variables
+      petstore_auth: apiKey,
+
+      // Error message, if any
+      message: error,
+    }),
   };
 };

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty-default.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty-default.js
@@ -1,0 +1,36 @@
+const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const readme = require('readmeio');
+
+// Your ReadMe secret; you may want to store this in AWS Secrets Manager
+const README_SECRET = 'my-readme-secret';
+
+exports.handler = async event => {
+  let statusCode, apiKey, error;
+
+  try {
+    const signature = event.headers['ReadMe-Signature'];
+    const body = JSON.parse(event.body);
+    readme.verifyWebhook(body, signature, README_SECRET);
+
+    const email = body.email;
+    const client = new APIGatewayClient();
+    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(command);
+    if (keys.items.length > 0) {
+      apiKey = keys.items[0].value;
+      statusCode = 200;
+    } else {
+      error = 'Email not found';
+      statusCode = 404;
+    }
+  } catch (e) {
+    error = e.message;
+    statusCode = error.match(/Signature/) ? 401 : 500;
+  }
+
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, message: error }),
+  };
+};

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty.js
@@ -5,7 +5,7 @@ const readme = require('readmeio');
 const README_SECRET = 'my-readme-secret';
 
 exports.handler = async event => {
-  let statusCode, apiKey, error;
+  let statusCode, email, apiKey, error;
 
   try {
     const signature = event.headers['ReadMe-Signature'];
@@ -17,6 +17,7 @@ exports.handler = async event => {
     const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
     const keys = await client.send(command);
     if (keys.items.length > 0) {
+      // if multiple API keys are returned for the given email, use the first one
       apiKey = keys.items[0].value;
       statusCode = 200;
     } else {
@@ -31,6 +32,12 @@ exports.handler = async event => {
   return {
     statusCode,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ apiKey, message: error }),
+    body: JSON.stringify({
+      // The user's API key
+      apiKey,
+
+      // Error message, if any
+      message: error,
+    }),
   };
 };

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/empty.js
@@ -1,0 +1,36 @@
+const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const readme = require('readmeio');
+
+// Your ReadMe secret; you may want to store this in AWS Secrets Manager
+const README_SECRET = 'my-readme-secret';
+
+exports.handler = async event => {
+  let statusCode, apiKey, error;
+
+  try {
+    const signature = event.headers['ReadMe-Signature'];
+    const body = JSON.parse(event.body);
+    readme.verifyWebhook(body, signature, README_SECRET);
+
+    const email = body.email;
+    const client = new APIGatewayClient();
+    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(command);
+    if (keys.items.length > 0) {
+      apiKey = keys.items[0].value;
+      statusCode = 200;
+    } else {
+      error = 'Email not found';
+      statusCode = 404;
+    }
+  } catch (e) {
+    error = e.message;
+    statusCode = error.match(/Signature/) ? 401 : 500;
+  }
+
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, message: error }),
+  };
+};

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/quirky-escaping-create.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/quirky-escaping-create.js
@@ -1,8 +1,16 @@
-const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const {
+  APIGatewayClient,
+  CreateApiKeyCommand,
+  CreateUsagePlanKeyCommand,
+  GetApiKeysCommand,
+} = require('@aws-sdk/client-api-gateway');
 const readme = require('readmeio');
 
 // Your ReadMe secret; you may want to store this in AWS Secrets Manager
 const README_SECRET = 'my-readme-secret';
+
+// Your default API Gateway usage plan; this will be attached to the API keys that being created
+const DEFAULT_USAGE_PLAN_ID = '123abc';
 
 exports.handler = async event => {
   let statusCode, email, apiKey, error;
@@ -14,15 +22,33 @@ exports.handler = async event => {
 
     const email = body.email;
     const client = new APIGatewayClient();
-    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
-    const keys = await client.send(command);
+    const getCommand = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(getCommand);
     if (keys.items.length > 0) {
       // if multiple API keys are returned for the given email, use the first one
       apiKey = keys.items[0].value;
       statusCode = 200;
     } else {
-      error = 'Email not found';
-      statusCode = 404;
+      const createKeyCommand = new CreateApiKeyCommand({
+        name: email,
+        description: `API key for ReadMe user ${email}`,
+        tags: {
+          user: email,
+          vendor: 'ReadMe',
+        },
+        enabled: true,
+      });
+      const key = await client.send(createKeyCommand);
+
+      const usagePlanKeyCommand = new CreateUsagePlanKeyCommand({
+        usagePlanId: DEFAULT_USAGE_PLAN_ID,
+        keyId: key.id,
+        keyType: 'API_KEY',
+      });
+      await client.send(usagePlanKeyCommand);
+
+      apiKey = key.value;
+      statusCode = 200;
     }
   } catch (e) {
     error = e.message;

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/quirky-escaping.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/quirky-escaping.js
@@ -1,0 +1,36 @@
+const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const readme = require('readmeio');
+
+// Your ReadMe secret; you may want to store this in AWS Secrets Manager
+const README_SECRET = 'my-readme-secret';
+
+exports.handler = async event => {
+  let statusCode, apiKey, error;
+
+  try {
+    const signature = event.headers['ReadMe-Signature'];
+    const body = JSON.parse(event.body);
+    readme.verifyWebhook(body, signature, README_SECRET);
+
+    const email = body.email;
+    const client = new APIGatewayClient();
+    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(command);
+    if (keys.items.length > 0) {
+      apiKey = keys.items[0].value;
+      statusCode = 200;
+    } else {
+      error = 'Email not found';
+      statusCode = 404;
+    }
+  } catch (e) {
+    error = e.message;
+    statusCode = error.match(/Signature/) ? 401 : 500;
+  }
+
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, message: error }),
+  };
+};

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-and-server-variables-create.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-and-server-variables-create.js
@@ -1,8 +1,16 @@
-const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const {
+  APIGatewayClient,
+  CreateApiKeyCommand,
+  CreateUsagePlanKeyCommand,
+  GetApiKeysCommand,
+} = require('@aws-sdk/client-api-gateway');
 const readme = require('readmeio');
 
 // Your ReadMe secret; you may want to store this in AWS Secrets Manager
 const README_SECRET = 'my-readme-secret';
+
+// Your default API Gateway usage plan; this will be attached to the API keys that being created
+const DEFAULT_USAGE_PLAN_ID = '123abc';
 
 exports.handler = async event => {
   let statusCode, email, apiKey, error;
@@ -14,15 +22,33 @@ exports.handler = async event => {
 
     const email = body.email;
     const client = new APIGatewayClient();
-    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
-    const keys = await client.send(command);
+    const getCommand = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(getCommand);
     if (keys.items.length > 0) {
       // if multiple API keys are returned for the given email, use the first one
       apiKey = keys.items[0].value;
       statusCode = 200;
     } else {
-      error = 'Email not found';
-      statusCode = 404;
+      const createKeyCommand = new CreateApiKeyCommand({
+        name: email,
+        description: `API key for ReadMe user ${email}`,
+        tags: {
+          user: email,
+          vendor: 'ReadMe',
+        },
+        enabled: true,
+      });
+      const key = await client.send(createKeyCommand);
+
+      const usagePlanKeyCommand = new CreateUsagePlanKeyCommand({
+        usagePlanId: DEFAULT_USAGE_PLAN_ID,
+        keyId: key.id,
+        keyType: 'API_KEY',
+      });
+      await client.send(usagePlanKeyCommand);
+
+      apiKey = key.value;
+      statusCode = 200;
     }
   } catch (e) {
     error = e.message;

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-and-server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-and-server-variables.js
@@ -1,0 +1,36 @@
+const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const readme = require('readmeio');
+
+// Your ReadMe secret; you may want to store this in AWS Secrets Manager
+const README_SECRET = 'my-readme-secret';
+
+exports.handler = async event => {
+  let statusCode, apiKey, error;
+
+  try {
+    const signature = event.headers['ReadMe-Signature'];
+    const body = JSON.parse(event.body);
+    readme.verifyWebhook(body, signature, README_SECRET);
+
+    const email = body.email;
+    const client = new APIGatewayClient();
+    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(command);
+    if (keys.items.length > 0) {
+      apiKey = keys.items[0].value;
+      statusCode = 200;
+    } else {
+      error = 'Email not found';
+      statusCode = 404;
+    }
+  } catch (e) {
+    error = e.message;
+    statusCode = error.match(/Signature/) ? 401 : 500;
+  }
+
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, message: error }),
+  };
+};

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-types-create.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-types-create.js
@@ -1,8 +1,16 @@
-const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const {
+  APIGatewayClient,
+  CreateApiKeyCommand,
+  CreateUsagePlanKeyCommand,
+  GetApiKeysCommand,
+} = require('@aws-sdk/client-api-gateway');
 const readme = require('readmeio');
 
 // Your ReadMe secret; you may want to store this in AWS Secrets Manager
 const README_SECRET = 'my-readme-secret';
+
+// Your default API Gateway usage plan; this will be attached to the API keys that being created
+const DEFAULT_USAGE_PLAN_ID = '123abc';
 
 exports.handler = async event => {
   let statusCode, email, apiKey, error;
@@ -14,15 +22,33 @@ exports.handler = async event => {
 
     const email = body.email;
     const client = new APIGatewayClient();
-    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
-    const keys = await client.send(command);
+    const getCommand = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(getCommand);
     if (keys.items.length > 0) {
       // if multiple API keys are returned for the given email, use the first one
       apiKey = keys.items[0].value;
       statusCode = 200;
     } else {
-      error = 'Email not found';
-      statusCode = 404;
+      const createKeyCommand = new CreateApiKeyCommand({
+        name: email,
+        description: `API key for ReadMe user ${email}`,
+        tags: {
+          user: email,
+          vendor: 'ReadMe',
+        },
+        enabled: true,
+      });
+      const key = await client.send(createKeyCommand);
+
+      const usagePlanKeyCommand = new CreateUsagePlanKeyCommand({
+        usagePlanId: DEFAULT_USAGE_PLAN_ID,
+        keyId: key.id,
+        keyType: 'API_KEY',
+      });
+      await client.send(usagePlanKeyCommand);
+
+      apiKey = key.value;
+      statusCode = 200;
     }
   } catch (e) {
     error = e.message;

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-types.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-types.js
@@ -1,0 +1,36 @@
+const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const readme = require('readmeio');
+
+// Your ReadMe secret; you may want to store this in AWS Secrets Manager
+const README_SECRET = 'my-readme-secret';
+
+exports.handler = async event => {
+  let statusCode, apiKey, error;
+
+  try {
+    const signature = event.headers['ReadMe-Signature'];
+    const body = JSON.parse(event.body);
+    readme.verifyWebhook(body, signature, README_SECRET);
+
+    const email = body.email;
+    const client = new APIGatewayClient();
+    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(command);
+    if (keys.items.length > 0) {
+      apiKey = keys.items[0].value;
+      statusCode = 200;
+    } else {
+      error = 'Email not found';
+      statusCode = 404;
+    }
+  } catch (e) {
+    error = e.message;
+    statusCode = error.match(/Signature/) ? 401 : 500;
+  }
+
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, message: error }),
+  };
+};

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-variables-create.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-variables-create.js
@@ -1,8 +1,16 @@
-const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const {
+  APIGatewayClient,
+  CreateApiKeyCommand,
+  CreateUsagePlanKeyCommand,
+  GetApiKeysCommand,
+} = require('@aws-sdk/client-api-gateway');
 const readme = require('readmeio');
 
 // Your ReadMe secret; you may want to store this in AWS Secrets Manager
 const README_SECRET = 'my-readme-secret';
+
+// Your default API Gateway usage plan; this will be attached to the API keys that being created
+const DEFAULT_USAGE_PLAN_ID = '123abc';
 
 exports.handler = async event => {
   let statusCode, email, apiKey, error;
@@ -14,15 +22,33 @@ exports.handler = async event => {
 
     const email = body.email;
     const client = new APIGatewayClient();
-    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
-    const keys = await client.send(command);
+    const getCommand = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(getCommand);
     if (keys.items.length > 0) {
       // if multiple API keys are returned for the given email, use the first one
       apiKey = keys.items[0].value;
       statusCode = 200;
     } else {
-      error = 'Email not found';
-      statusCode = 404;
+      const createKeyCommand = new CreateApiKeyCommand({
+        name: email,
+        description: `API key for ReadMe user ${email}`,
+        tags: {
+          user: email,
+          vendor: 'ReadMe',
+        },
+        enabled: true,
+      });
+      const key = await client.send(createKeyCommand);
+
+      const usagePlanKeyCommand = new CreateUsagePlanKeyCommand({
+        usagePlanId: DEFAULT_USAGE_PLAN_ID,
+        keyId: key.id,
+        keyType: 'API_KEY',
+      });
+      await client.send(usagePlanKeyCommand);
+
+      apiKey = key.value;
+      statusCode = 200;
     }
   } catch (e) {
     error = e.message;
@@ -33,10 +59,6 @@ exports.handler = async event => {
     statusCode,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      // OAS Server variables
-      name: 'default-name',
-      port: '',
-
       // OAS Security variables
       petstore_auth: apiKey,
       basic_auth: { user: email, pass: apiKey },

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-variables.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-variables.js
@@ -1,0 +1,36 @@
+const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const readme = require('readmeio');
+
+// Your ReadMe secret; you may want to store this in AWS Secrets Manager
+const README_SECRET = 'my-readme-secret';
+
+exports.handler = async event => {
+  let statusCode, apiKey, error;
+
+  try {
+    const signature = event.headers['ReadMe-Signature'];
+    const body = JSON.parse(event.body);
+    readme.verifyWebhook(body, signature, README_SECRET);
+
+    const email = body.email;
+    const client = new APIGatewayClient();
+    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(command);
+    if (keys.items.length > 0) {
+      apiKey = keys.items[0].value;
+      statusCode = 200;
+    } else {
+      error = 'Email not found';
+      statusCode = 404;
+    }
+  } catch (e) {
+    error = e.message;
+    statusCode = error.match(/Signature/) ? 401 : 500;
+  }
+
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, message: error }),
+  };
+};

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-variables.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/security-variables.js
@@ -5,7 +5,7 @@ const readme = require('readmeio');
 const README_SECRET = 'my-readme-secret';
 
 exports.handler = async event => {
-  let statusCode, apiKey, error;
+  let statusCode, email, apiKey, error;
 
   try {
     const signature = event.headers['ReadMe-Signature'];
@@ -17,6 +17,7 @@ exports.handler = async event => {
     const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
     const keys = await client.send(command);
     if (keys.items.length > 0) {
+      // if multiple API keys are returned for the given email, use the first one
       apiKey = keys.items[0].value;
       statusCode = 200;
     } else {
@@ -31,6 +32,13 @@ exports.handler = async event => {
   return {
     statusCode,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ apiKey, message: error }),
+    body: JSON.stringify({
+      // OAS Security variables
+      petstore_auth: apiKey,
+      basic_auth: { user: email, pass: apiKey },
+
+      // Error message, if any
+      message: error,
+    }),
   };
 };

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/server-variables-create.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/server-variables-create.js
@@ -1,8 +1,16 @@
-const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const {
+  APIGatewayClient,
+  CreateApiKeyCommand,
+  CreateUsagePlanKeyCommand,
+  GetApiKeysCommand,
+} = require('@aws-sdk/client-api-gateway');
 const readme = require('readmeio');
 
 // Your ReadMe secret; you may want to store this in AWS Secrets Manager
 const README_SECRET = 'my-readme-secret';
+
+// Your default API Gateway usage plan; this will be attached to the API keys that being created
+const DEFAULT_USAGE_PLAN_ID = '123abc';
 
 exports.handler = async event => {
   let statusCode, email, apiKey, error;
@@ -14,15 +22,33 @@ exports.handler = async event => {
 
     const email = body.email;
     const client = new APIGatewayClient();
-    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
-    const keys = await client.send(command);
+    const getCommand = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(getCommand);
     if (keys.items.length > 0) {
       // if multiple API keys are returned for the given email, use the first one
       apiKey = keys.items[0].value;
       statusCode = 200;
     } else {
-      error = 'Email not found';
-      statusCode = 404;
+      const createKeyCommand = new CreateApiKeyCommand({
+        name: email,
+        description: `API key for ReadMe user ${email}`,
+        tags: {
+          user: email,
+          vendor: 'ReadMe',
+        },
+        enabled: true,
+      });
+      const key = await client.send(createKeyCommand);
+
+      const usagePlanKeyCommand = new CreateUsagePlanKeyCommand({
+        usagePlanId: DEFAULT_USAGE_PLAN_ID,
+        keyId: key.id,
+        keyType: 'API_KEY',
+      });
+      await client.send(usagePlanKeyCommand);
+
+      apiKey = key.value;
+      statusCode = 200;
     }
   } catch (e) {
     error = e.message;

--- a/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/server-variables.js
+++ b/packages/sdk-snippets/src/targets/node/aws/webhooks/fixtures/server-variables.js
@@ -1,0 +1,36 @@
+const { APIGatewayClient, GetApiKeysCommand } = require('@aws-sdk/client-api-gateway');
+const readme = require('readmeio');
+
+// Your ReadMe secret; you may want to store this in AWS Secrets Manager
+const README_SECRET = 'my-readme-secret';
+
+exports.handler = async event => {
+  let statusCode, apiKey, error;
+
+  try {
+    const signature = event.headers['ReadMe-Signature'];
+    const body = JSON.parse(event.body);
+    readme.verifyWebhook(body, signature, README_SECRET);
+
+    const email = body.email;
+    const client = new APIGatewayClient();
+    const command = new GetApiKeysCommand({ nameQuery: email, includeValues: true });
+    const keys = await client.send(command);
+    if (keys.items.length > 0) {
+      apiKey = keys.items[0].value;
+      statusCode = 200;
+    } else {
+      error = 'Email not found';
+      statusCode = 404;
+    }
+  } catch (e) {
+    error = e.message;
+    statusCode = error.match(/Signature/) ? 401 : 500;
+  }
+
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ apiKey, message: error }),
+  };
+};

--- a/packages/sdk-snippets/src/targets/node/target.ts
+++ b/packages/sdk-snippets/src/targets/node/target.ts
@@ -1,5 +1,6 @@
 import type { Target } from '../targets';
 
+import { aws } from './aws/webhooks/client';
 import { express } from './express/webhooks/client';
 
 export const node: Target = {
@@ -14,6 +15,7 @@ export const node: Target = {
     server: {},
     webhooks: {
       express,
+      aws,
     },
   },
 };

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
@@ -83,7 +83,7 @@ export const aws: Client = {
       push('api_key = key["value"]', 3);
       push('status_code = 200', 3);
     } else {
-      push("error = 'Email not found'", 3);
+      push('error = "Email not found"', 3);
       push('status_code = 404', 3);
     }
     endSection('payload');

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
@@ -62,7 +62,7 @@ export const aws: Client = {
     startSection('payload');
     push('email = body.get("email")', 2);
     push('client = boto3.client("apigateway")', 2);
-    push(`keys = client.get_api_keys(nameQuery=email, includeValues=True)`, 2);
+    push('keys = client.get_api_keys(nameQuery=email, includeValues=True)', 2);
     push('if len(keys.get("items", [])) > 0:', 2);
     push('# if multiple API keys are returned for the given email, use the first one', 3);
     push('api_key = keys["items"][0]["value"]', 3);

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
@@ -83,7 +83,7 @@ export const aws: Client = {
       push('api_key = key["value"]', 3);
       push('status_code = 200', 3);
     } else {
-      push("error = 'Email not found'", 3);
+      push('error = "Email not found"', 3);
       push('status_code = 404', 3);
     }
     endSection('payload');
@@ -138,7 +138,11 @@ export const aws: Client = {
       });
     } else {
       push("# The user's API key", 3);
-      push('"apiKey": api_key', 3);
+      pushVariable('"apiKey": api_key', {
+        type: 'security',
+        name: 'apiKey',
+        indentationLevel: 3,
+      });
     }
     push('}', 2);
     push('else:', 1);

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
@@ -83,7 +83,7 @@ export const aws: Client = {
       push('api_key = key["value"]', 3);
       push('status_code = 200', 3);
     } else {
-      push('error = "Email not found"', 3);
+      push("error = 'Email not found'", 3);
       push('status_code = 404', 3);
     }
     endSection('payload');

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/client.ts
@@ -1,0 +1,159 @@
+// For use with AWS Lambda Runtime: python3.9
+
+import type { Client } from '../../../targets';
+
+import { CodeBuilder } from '../../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../../helpers/escape';
+
+export const aws: Client = {
+  info: {
+    key: 'aws',
+    title: 'AWS API Gateway',
+    link: 'https://aws.amazon.com/api-gateway/',
+    description: 'ReadMe Metrics Webhooks SDK usage on AWS API Gateway',
+  },
+  convert: ({ secret, security, server }, options) => {
+    const opts = {
+      indent: '    ',
+      createKeys: false,
+      // We don't currently provide a value for defaultUsagePlanId in the
+      // ReadMe app, since we don't have any knowledge of our customers' usage
+      // plans -- but we might choose to later, and it's helpful for testing.
+      defaultUsagePlanId: '123abc',
+      ...options,
+    };
+
+    const { blank, endSection, join, push, pushVariable, ranges, startSection } = new CodeBuilder({
+      indent: opts.indent,
+    });
+
+    push('import json');
+    blank();
+    push('import boto3');
+    push('from readme_metrics.VerifyWebhook import VerifyWebhook');
+    blank();
+
+    push('# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager');
+    push(`README_SECRET = b"${secret}"`);
+
+    if (opts.createKeys) {
+      blank();
+      push('# Your default API Gateway usage plan; this will be attached to the API keys that being created');
+      push(`DEFAULT_USAGE_PLAN_ID = "${opts.defaultUsagePlanId}"`);
+    }
+
+    blank();
+    blank();
+    push('def handler(event, lambda_context):');
+    push('status_code = None', 1);
+    push('email = None', 1);
+    push('api_key = None', 1);
+    push('error = None', 1);
+    blank();
+
+    push('try:', 1);
+    startSection('verification');
+    push('signature = event.get("headers", {}).get("ReadMe-Signature")', 2);
+    push('body = json.loads(event.get("body", "{}"))', 2);
+    push('VerifyWebhook(body, signature, README_SECRET)', 2);
+    endSection('verification');
+    blank();
+
+    startSection('payload');
+    push('email = body.get("email")', 2);
+    push('client = boto3.client("apigateway")', 2);
+    push(`keys = client.get_api_keys(nameQuery=email, includeValues=True)`, 2);
+    push('if len(keys.get("items", [])) > 0:', 2);
+    push('# if multiple API keys are returned for the given email, use the first one', 3);
+    push('api_key = keys["items"][0]["value"]', 3);
+    push('status_code = 200', 3);
+    push('else:', 2);
+    if (opts.createKeys) {
+      push('key = client.create_api_key(', 3);
+      push('name=email,', 4);
+      push('description=f"API key for ReadMe user {email}",', 4);
+      push('tags={"user": email, "vendor": "ReadMe"},', 4);
+      push('enabled=True,', 4);
+      push(')', 3);
+      blank();
+      push('client.create_usage_plan_key(', 3);
+      push('usagePlanId=DEFAULT_USAGE_PLAN_ID, keyId=key["id"], keyType="API_KEY"', 4);
+      push(')', 3);
+      blank();
+      push('api_key = key["value"]', 3);
+      push('status_code = 200', 3);
+    } else {
+      push("error = 'Email not found'", 3);
+      push('status_code = 404', 3);
+    }
+    endSection('payload');
+    push('except Exception as e:', 1);
+    push('error = str(e)', 2);
+    push('if error.find("Signature") > -1:', 2);
+    push('status_code = 401', 3);
+    push('else:', 2);
+    push('status_code = 500', 3);
+    blank();
+
+    push('if status_code == 200:', 1);
+    push('body = {', 2);
+
+    if (server.length) {
+      push('# OAS Server variables', 3);
+      server.forEach(data => {
+        pushVariable(
+          `"${escapeForDoubleQuotes(data.name)}": "${escapeForDoubleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}",`,
+          {
+            type: 'server',
+            name: data.name,
+            indentationLevel: 3,
+          }
+        );
+      });
+      blank();
+    }
+
+    if (security.length) {
+      push('# OAS Security variables', 3);
+      security.forEach(data => {
+        if (data.type === 'http') {
+          // Only HTTP Basic auth has any special handling for supplying auth.
+          if (data.scheme === 'basic') {
+            pushVariable(`"${escapeForDoubleQuotes(data.name)}": { "user": email, "pass": api_key },`, {
+              type: 'security',
+              name: data.name,
+              indentationLevel: 3,
+            });
+            return;
+          }
+        }
+
+        pushVariable(`"${escapeForDoubleQuotes(data.name)}": api_key,`, {
+          type: 'security',
+          name: data.name,
+          indentationLevel: 3,
+        });
+      });
+    } else {
+      push("# The user's API key", 3);
+      push('"apiKey": api_key', 3);
+    }
+    push('}', 2);
+    push('else:', 1);
+    push('body = {"message": error}', 2);
+    blank();
+
+    push('return {', 1);
+    push('"statusCode": status_code,', 2);
+    push('"headers": {"Content-Type": "application/json"},', 2);
+    push('"body": json.dumps(body),', 2);
+    push('}', 1);
+
+    return {
+      ranges: ranges(),
+      snippet: join(),
+    };
+  },
+};

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty-create.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty-create.py
@@ -1,0 +1,64 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            key = client.create_api_key(
+                name=email,
+                description=f"API key for ReadMe user {email}",
+                tags={"user": email, "vendor": "ReadMe"},
+                enabled=True,
+            )
+
+            client.create_usage_plan_key(
+                usagePlanId=DEFAULT_USAGE_PLAN_ID, keyId=key["id"], keyType="API_KEY"
+            )
+
+            api_key = key["value"]
+            status_code = 200
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # The user's API key
+            "apiKey": api_key
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty-default-create.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty-default-create.py
@@ -1,0 +1,67 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            key = client.create_api_key(
+                name=email,
+                description=f"API key for ReadMe user {email}",
+                tags={"user": email, "vendor": "ReadMe"},
+                enabled=True,
+            )
+
+            client.create_usage_plan_key(
+                usagePlanId=DEFAULT_USAGE_PLAN_ID, keyId=key["id"], keyType="API_KEY"
+            )
+
+            api_key = key["value"]
+            status_code = 200
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Server variables
+            "name": "",
+
+            # OAS Security variables
+            "petstore_auth": api_key,
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty-default.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty-default.py
@@ -26,7 +26,7 @@ def handler(event, lambda_context):
             api_key = keys["items"][0]["value"]
             status_code = 200
         else:
-            error = 'Email not found'
+            error = "Email not found"
             status_code = 404
     except Exception as e:
         error = str(e)

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty-default.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty-default.py
@@ -1,0 +1,53 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            error = 'Email not found'
+            status_code = 404
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Server variables
+            "name": "",
+
+            # OAS Security variables
+            "petstore_auth": api_key,
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty.py
@@ -26,7 +26,7 @@ def handler(event, lambda_context):
             api_key = keys["items"][0]["value"]
             status_code = 200
         else:
-            error = 'Email not found'
+            error = "Email not found"
             status_code = 404
     except Exception as e:
         error = str(e)

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/empty.py
@@ -1,0 +1,50 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            error = 'Email not found'
+            status_code = 404
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # The user's API key
+            "apiKey": api_key
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/quirky-escaping-create.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/quirky-escaping-create.py
@@ -1,0 +1,72 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            key = client.create_api_key(
+                name=email,
+                description=f"API key for ReadMe user {email}",
+                tags={"user": email, "vendor": "ReadMe"},
+                enabled=True,
+            )
+
+            client.create_usage_plan_key(
+                usagePlanId=DEFAULT_USAGE_PLAN_ID, keyId=key["id"], keyType="API_KEY"
+            )
+
+            api_key = key["value"]
+            status_code = 200
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Server variables
+            "2name": "default-name",
+            "*port": "",
+            "p*o?r*t": "",
+            "normal_server_var": "",
+
+            # OAS Security variables
+            "\"petstore\" auth": api_key,
+            "basic-auth": { "user": email, "pass": api_key },
+            "normal_security_var": { "user": email, "pass": api_key },
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/quirky-escaping.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/quirky-escaping.py
@@ -26,7 +26,7 @@ def handler(event, lambda_context):
             api_key = keys["items"][0]["value"]
             status_code = 200
         else:
-            error = 'Email not found'
+            error = "Email not found"
             status_code = 404
     except Exception as e:
         error = str(e)

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/quirky-escaping.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/quirky-escaping.py
@@ -1,0 +1,58 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            error = 'Email not found'
+            status_code = 404
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Server variables
+            "2name": "default-name",
+            "*port": "",
+            "p*o?r*t": "",
+            "normal_server_var": "",
+
+            # OAS Security variables
+            "\"petstore\" auth": api_key,
+            "basic-auth": { "user": email, "pass": api_key },
+            "normal_security_var": { "user": email, "pass": api_key },
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-and-server-variables-create.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-and-server-variables-create.py
@@ -1,0 +1,69 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            key = client.create_api_key(
+                name=email,
+                description=f"API key for ReadMe user {email}",
+                tags={"user": email, "vendor": "ReadMe"},
+                enabled=True,
+            )
+
+            client.create_usage_plan_key(
+                usagePlanId=DEFAULT_USAGE_PLAN_ID, keyId=key["id"], keyType="API_KEY"
+            )
+
+            api_key = key["value"]
+            status_code = 200
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Server variables
+            "name": "default-name",
+            "port": "",
+
+            # OAS Security variables
+            "petstore_auth": api_key,
+            "basic_auth": { "user": email, "pass": api_key },
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-and-server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-and-server-variables.py
@@ -1,0 +1,55 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            error = 'Email not found'
+            status_code = 404
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Server variables
+            "name": "default-name",
+            "port": "",
+
+            # OAS Security variables
+            "petstore_auth": api_key,
+            "basic_auth": { "user": email, "pass": api_key },
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-and-server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-and-server-variables.py
@@ -26,7 +26,7 @@ def handler(event, lambda_context):
             api_key = keys["items"][0]["value"]
             status_code = 200
         else:
-            error = 'Email not found'
+            error = "Email not found"
             status_code = 404
     except Exception as e:
         error = str(e)

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-types-create.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-types-create.py
@@ -1,0 +1,67 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            key = client.create_api_key(
+                name=email,
+                description=f"API key for ReadMe user {email}",
+                tags={"user": email, "vendor": "ReadMe"},
+                enabled=True,
+            )
+
+            client.create_usage_plan_key(
+                usagePlanId=DEFAULT_USAGE_PLAN_ID, keyId=key["id"], keyType="API_KEY"
+            )
+
+            api_key = key["value"]
+            status_code = 200
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Security variables
+            "api_key": api_key,
+            "http_basic": { "user": email, "pass": api_key },
+            "http_bearer": api_key,
+            "oauth2": api_key,
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-types.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-types.py
@@ -26,7 +26,7 @@ def handler(event, lambda_context):
             api_key = keys["items"][0]["value"]
             status_code = 200
         else:
-            error = 'Email not found'
+            error = "Email not found"
             status_code = 404
     except Exception as e:
         error = str(e)

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-types.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-types.py
@@ -1,0 +1,53 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            error = 'Email not found'
+            status_code = 404
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Security variables
+            "api_key": api_key,
+            "http_basic": { "user": email, "pass": api_key },
+            "http_bearer": api_key,
+            "oauth2": api_key,
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-variables-create.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-variables-create.py
@@ -1,0 +1,65 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            key = client.create_api_key(
+                name=email,
+                description=f"API key for ReadMe user {email}",
+                tags={"user": email, "vendor": "ReadMe"},
+                enabled=True,
+            )
+
+            client.create_usage_plan_key(
+                usagePlanId=DEFAULT_USAGE_PLAN_ID, keyId=key["id"], keyType="API_KEY"
+            )
+
+            api_key = key["value"]
+            status_code = 200
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Security variables
+            "petstore_auth": api_key,
+            "basic_auth": { "user": email, "pass": api_key },
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-variables.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-variables.py
@@ -26,7 +26,7 @@ def handler(event, lambda_context):
             api_key = keys["items"][0]["value"]
             status_code = 200
         else:
-            error = 'Email not found'
+            error = "Email not found"
             status_code = 404
     except Exception as e:
         error = str(e)

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-variables.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/security-variables.py
@@ -1,0 +1,51 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            error = 'Email not found'
+            status_code = 404
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Security variables
+            "petstore_auth": api_key,
+            "basic_auth": { "user": email, "pass": api_key },
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/server-variables-create.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/server-variables-create.py
@@ -1,0 +1,68 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            key = client.create_api_key(
+                name=email,
+                description=f"API key for ReadMe user {email}",
+                tags={"user": email, "vendor": "ReadMe"},
+                enabled=True,
+            )
+
+            client.create_usage_plan_key(
+                usagePlanId=DEFAULT_USAGE_PLAN_ID, keyId=key["id"], keyType="API_KEY"
+            )
+
+            api_key = key["value"]
+            status_code = 200
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Server variables
+            "name": "default-name",
+            "port": "",
+
+            # The user's API key
+            "apiKey": api_key
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/server-variables.py
@@ -26,7 +26,7 @@ def handler(event, lambda_context):
             api_key = keys["items"][0]["value"]
             status_code = 200
         else:
-            error = 'Email not found'
+            error = "Email not found"
             status_code = 404
     except Exception as e:
         error = str(e)

--- a/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/server-variables.py
+++ b/packages/sdk-snippets/src/targets/python/aws/webhooks/fixtures/server-variables.py
@@ -1,0 +1,54 @@
+import json
+
+import boto3
+from readme_metrics.VerifyWebhook import VerifyWebhook
+
+# Your ReadMe secret as a bytes object; you may want to store this in AWS Secrets Manager
+README_SECRET = b"my-readme-secret"
+
+
+def handler(event, lambda_context):
+    status_code = None
+    email = None
+    api_key = None
+    error = None
+
+    try:
+        signature = event.get("headers", {}).get("ReadMe-Signature")
+        body = json.loads(event.get("body", "{}"))
+        VerifyWebhook(body, signature, README_SECRET)
+
+        email = body.get("email")
+        client = boto3.client("apigateway")
+        keys = client.get_api_keys(nameQuery=email, includeValues=True)
+        if len(keys.get("items", [])) > 0:
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys["items"][0]["value"]
+            status_code = 200
+        else:
+            error = 'Email not found'
+            status_code = 404
+    except Exception as e:
+        error = str(e)
+        if error.find("Signature") > -1:
+            status_code = 401
+        else:
+            status_code = 500
+
+    if status_code == 200:
+        body = {
+            # OAS Server variables
+            "name": "default-name",
+            "port": "",
+
+            # The user's API key
+            "apiKey": api_key
+        }
+    else:
+        body = {"message": error}
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }

--- a/packages/sdk-snippets/src/targets/python/target.ts
+++ b/packages/sdk-snippets/src/targets/python/target.ts
@@ -1,5 +1,6 @@
 import type { Target } from '../targets';
 
+import { aws } from './aws/webhooks/client';
 import { flask } from './flask/webhooks/client';
 
 export const python: Target = {
@@ -14,6 +15,7 @@ export const python: Target = {
     server: {},
     webhooks: {
       flask,
+      aws,
     },
   },
 };

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/client.ts
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/client.ts
@@ -1,0 +1,171 @@
+// For use with AWS Lambda Runtime: ruby2.7
+
+import type { Client } from '../../../targets';
+
+import { CodeBuilder } from '../../../../helpers/code-builder';
+import { escapeForObjectKey, escapeForDoubleQuotes } from '../../../../helpers/escape';
+
+export const aws: Client = {
+  info: {
+    key: 'aws',
+    title: 'AWS API Gateway',
+    link: 'https://aws.amazon.com/api-gateway/',
+    description: 'ReadMe Metrics Webhooks SDK usage on AWS API Gateway',
+  },
+  convert: ({ secret, security, server }, options) => {
+    const opts = {
+      indent: '    ',
+      createKeys: false,
+      // We don't currently provide a value for defaultUsagePlanId in the
+      // ReadMe app, since we don't have any knowledge of our customers' usage
+      // plans -- but we might choose to later, and it's helpful for testing.
+      defaultUsagePlanId: '123abc',
+      ...options,
+    };
+
+    const { blank, endSection, join, push, pushVariable, ranges, startSection } = new CodeBuilder({
+      indent: opts.indent,
+    });
+
+    push("require 'aws-sdk-apigateway'");
+    push("require 'json'");
+    push("require 'readme/webhook'");
+    blank();
+
+    push('# Your ReadMe secret; you may want to store this in AWS Secrets Manager');
+    push(`README_SECRET = "${secret}"`);
+    blank();
+
+    if (opts.createKeys) {
+      push('# Your default API Gateway usage plan; this will be attached to the API keys that being created');
+      push(`DEFAULT_USAGE_PLAN_ID = "${opts.defaultUsagePlanId}"`);
+      blank();
+    }
+
+    push('def handler(event:, context:)');
+    push('status_code = nil', 1);
+    push('api_key = nil', 1);
+    push('error = nil', 1);
+    blank();
+
+    push('begin', 1);
+    startSection('verification');
+    push("signature = event['headers']['ReadMe-Signature'];", 2);
+    push("Readme::Webhook.verify(event['body'], signature, README_SECRET)", 2);
+    endSection('verification');
+    blank();
+
+    startSection('payload');
+    push("body = JSON.parse(event['body']);", 2);
+    push("email = body['email']", 2);
+    push('client = Aws::APIGateway::Client.new()', 2);
+    push('keys = client.get_api_keys({', 2);
+    push('name_query: email,', 3);
+    push('include_values: true', 3);
+    push('})', 2);
+    push('if keys.items.length > 0', 2);
+    push('# if multiple API keys are returned for the given email, use the first one', 3);
+    push('api_key = keys.items[0].value', 3);
+    push('status_code = 200', 3);
+    push('else', 2);
+    if (opts.createKeys) {
+      push('key = client.create_api_key(', 3);
+      push('name: email,', 4);
+      push('description: "API key for ReadMe user #{email}",', 4);
+      push('tags: {"user": email, "vendor": "ReadMe"},', 4);
+      push('enabled: true', 4);
+      push(')', 3);
+      blank();
+      push('client.create_usage_plan_key(', 3);
+      push('usage_plan_id: DEFAULT_USAGE_PLAN_ID,', 4);
+      push('key_id: key.id,', 4);
+      push('key_type: "API_KEY"', 4);
+      push(')', 3);
+      blank();
+      push('api_key = key.value', 3);
+      push('status_code = 200', 3);
+    } else {
+      push('error = "Email not found"', 3);
+      push('status_code = 404', 3);
+    }
+    push('end', 2);
+    endSection('payload');
+
+    push('rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e', 1);
+    push('error = e.message', 2);
+    push('status_code = 401', 2);
+    push('rescue => e', 1);
+    push('error = e.message', 2);
+    push('status_code = 500', 2);
+    push('end', 1);
+    blank();
+
+    push('if status_code == 200', 1);
+    push('body = {', 2);
+
+    if (server.length) {
+      push('# OAS Server variables', 3);
+      server.forEach(data => {
+        pushVariable(
+          `${escapeForObjectKey(data.name)}: "${escapeForDoubleQuotes(
+            data.default || data.default === '' ? data.default : data.name
+          )}",`,
+          {
+            type: 'server',
+            name: data.name,
+            indentationLevel: 3,
+          }
+        );
+      });
+      blank();
+    }
+
+    if (security.length) {
+      push('# OAS Security variables', 3);
+      security.forEach(data => {
+        if (data.type === 'http') {
+          // Only HTTP Basic auth has any special handling for supplying auth.
+          if (data.scheme === 'basic') {
+            pushVariable(`${escapeForObjectKey(data.name)}: { user: email, pass: api_key },`, {
+              type: 'security',
+              name: data.name,
+              indentationLevel: 3,
+            });
+            return;
+          }
+        }
+
+        pushVariable(`${escapeForObjectKey(data.name)}: api_key,`, {
+          type: 'security',
+          name: data.name,
+          indentationLevel: 3,
+        });
+      });
+    } else {
+      push("# The user's API key", 3);
+      pushVariable('apiKey: api_key', {
+        type: 'security',
+        name: 'apiKey',
+        indentationLevel: 3,
+      });
+    }
+
+    push('}', 2);
+    push('else', 1);
+    push('body = {message: error}', 2);
+    push('end', 1);
+    blank();
+
+    push('return {', 1);
+    push('statusCode: status_code,', 2);
+    push("headers: {'Content-Type': 'application/json'},", 2);
+    push('body: body.to_json', 2);
+    push('}', 1);
+    push('end');
+
+    return {
+      ranges: ranges(),
+      snippet: join(),
+    };
+  },
+};

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/empty-create.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/empty-create.rb
@@ -1,0 +1,70 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            key = client.create_api_key(
+                name: email,
+                description: "API key for ReadMe user #{email}",
+                tags: {"user": email, "vendor": "ReadMe"},
+                enabled: true
+            )
+
+            client.create_usage_plan_key(
+                usage_plan_id: DEFAULT_USAGE_PLAN_ID,
+                key_id: key.id,
+                key_type: "API_KEY"
+            )
+
+            api_key = key.value
+            status_code = 200
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # The user's API key
+            apiKey: api_key
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/empty-default-create.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/empty-default-create.rb
@@ -1,0 +1,73 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            key = client.create_api_key(
+                name: email,
+                description: "API key for ReadMe user #{email}",
+                tags: {"user": email, "vendor": "ReadMe"},
+                enabled: true
+            )
+
+            client.create_usage_plan_key(
+                usage_plan_id: DEFAULT_USAGE_PLAN_ID,
+                key_id: key.id,
+                key_type: "API_KEY"
+            )
+
+            api_key = key.value
+            status_code = 200
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Server variables
+            name: "",
+
+            # OAS Security variables
+            petstore_auth: api_key,
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/empty-default.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/empty-default.rb
@@ -1,0 +1,57 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            error = "Email not found"
+            status_code = 404
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Server variables
+            name: "",
+
+            # OAS Security variables
+            petstore_auth: api_key,
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/empty.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/empty.rb
@@ -1,0 +1,54 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            error = "Email not found"
+            status_code = 404
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # The user's API key
+            apiKey: api_key
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/quirky-escaping-create.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/quirky-escaping-create.rb
@@ -1,0 +1,78 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            key = client.create_api_key(
+                name: email,
+                description: "API key for ReadMe user #{email}",
+                tags: {"user": email, "vendor": "ReadMe"},
+                enabled: true
+            )
+
+            client.create_usage_plan_key(
+                usage_plan_id: DEFAULT_USAGE_PLAN_ID,
+                key_id: key.id,
+                key_type: "API_KEY"
+            )
+
+            api_key = key.value
+            status_code = 200
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Server variables
+            '2name': "default-name",
+            '*port': "",
+            'p*o?r*t': "",
+            normal_server_var: "",
+
+            # OAS Security variables
+            '"petstore" auth': api_key,
+            'basic-auth': { user: email, pass: api_key },
+            normal_security_var: { user: email, pass: api_key },
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/quirky-escaping.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/quirky-escaping.rb
@@ -1,0 +1,62 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            error = "Email not found"
+            status_code = 404
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Server variables
+            '2name': "default-name",
+            '*port': "",
+            'p*o?r*t': "",
+            normal_server_var: "",
+
+            # OAS Security variables
+            '"petstore" auth': api_key,
+            'basic-auth': { user: email, pass: api_key },
+            normal_security_var: { user: email, pass: api_key },
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-and-server-variables-create.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-and-server-variables-create.rb
@@ -1,0 +1,75 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            key = client.create_api_key(
+                name: email,
+                description: "API key for ReadMe user #{email}",
+                tags: {"user": email, "vendor": "ReadMe"},
+                enabled: true
+            )
+
+            client.create_usage_plan_key(
+                usage_plan_id: DEFAULT_USAGE_PLAN_ID,
+                key_id: key.id,
+                key_type: "API_KEY"
+            )
+
+            api_key = key.value
+            status_code = 200
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Server variables
+            name: "default-name",
+            port: "",
+
+            # OAS Security variables
+            petstore_auth: api_key,
+            basic_auth: { user: email, pass: api_key },
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-and-server-variables.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-and-server-variables.rb
@@ -1,0 +1,59 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            error = "Email not found"
+            status_code = 404
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Server variables
+            name: "default-name",
+            port: "",
+
+            # OAS Security variables
+            petstore_auth: api_key,
+            basic_auth: { user: email, pass: api_key },
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-types-create.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-types-create.rb
@@ -1,0 +1,73 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            key = client.create_api_key(
+                name: email,
+                description: "API key for ReadMe user #{email}",
+                tags: {"user": email, "vendor": "ReadMe"},
+                enabled: true
+            )
+
+            client.create_usage_plan_key(
+                usage_plan_id: DEFAULT_USAGE_PLAN_ID,
+                key_id: key.id,
+                key_type: "API_KEY"
+            )
+
+            api_key = key.value
+            status_code = 200
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Security variables
+            api_key: api_key,
+            http_basic: { user: email, pass: api_key },
+            http_bearer: api_key,
+            oauth2: api_key,
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-types.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-types.rb
@@ -1,0 +1,57 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            error = "Email not found"
+            status_code = 404
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Security variables
+            api_key: api_key,
+            http_basic: { user: email, pass: api_key },
+            http_bearer: api_key,
+            oauth2: api_key,
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-variables-create.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-variables-create.rb
@@ -1,0 +1,71 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            key = client.create_api_key(
+                name: email,
+                description: "API key for ReadMe user #{email}",
+                tags: {"user": email, "vendor": "ReadMe"},
+                enabled: true
+            )
+
+            client.create_usage_plan_key(
+                usage_plan_id: DEFAULT_USAGE_PLAN_ID,
+                key_id: key.id,
+                key_type: "API_KEY"
+            )
+
+            api_key = key.value
+            status_code = 200
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Security variables
+            petstore_auth: api_key,
+            basic_auth: { user: email, pass: api_key },
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-variables.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/security-variables.rb
@@ -1,0 +1,55 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            error = "Email not found"
+            status_code = 404
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Security variables
+            petstore_auth: api_key,
+            basic_auth: { user: email, pass: api_key },
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/server-variables-create.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/server-variables-create.rb
@@ -1,0 +1,74 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+# Your default API Gateway usage plan; this will be attached to the API keys that being created
+DEFAULT_USAGE_PLAN_ID = "123abc"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            key = client.create_api_key(
+                name: email,
+                description: "API key for ReadMe user #{email}",
+                tags: {"user": email, "vendor": "ReadMe"},
+                enabled: true
+            )
+
+            client.create_usage_plan_key(
+                usage_plan_id: DEFAULT_USAGE_PLAN_ID,
+                key_id: key.id,
+                key_type: "API_KEY"
+            )
+
+            api_key = key.value
+            status_code = 200
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Server variables
+            name: "default-name",
+            port: "",
+
+            # The user's API key
+            apiKey: api_key
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/server-variables.rb
+++ b/packages/sdk-snippets/src/targets/ruby/aws/webhooks/fixtures/server-variables.rb
@@ -1,0 +1,58 @@
+require 'aws-sdk-apigateway'
+require 'json'
+require 'readme/webhook'
+
+# Your ReadMe secret; you may want to store this in AWS Secrets Manager
+README_SECRET = "my-readme-secret"
+
+def handler(event:, context:)
+    status_code = nil
+    api_key = nil
+    error = nil
+
+    begin
+        signature = event['headers']['ReadMe-Signature'];
+        Readme::Webhook.verify(event['body'], signature, README_SECRET)
+
+        body = JSON.parse(event['body']);
+        email = body['email']
+        client = Aws::APIGateway::Client.new()
+        keys = client.get_api_keys({
+            name_query: email,
+            include_values: true
+        })
+        if keys.items.length > 0
+            # if multiple API keys are returned for the given email, use the first one
+            api_key = keys.items[0].value
+            status_code = 200
+        else
+            error = "Email not found"
+            status_code = 404
+        end
+    rescue Readme::MissingSignatureError, Readme::ExpiredSignatureError, Readme::InvalidSignatureError => e
+        error = e.message
+        status_code = 401
+    rescue => e
+        error = e.message
+        status_code = 500
+    end
+
+    if status_code == 200
+        body = {
+            # OAS Server variables
+            name: "default-name",
+            port: "",
+
+            # The user's API key
+            apiKey: api_key
+        }
+    else
+        body = {message: error}
+    end
+
+    return {
+        statusCode: status_code,
+        headers: {'Content-Type': 'application/json'},
+        body: body.to_json
+    }
+end

--- a/packages/sdk-snippets/src/targets/ruby/target.ts
+++ b/packages/sdk-snippets/src/targets/ruby/target.ts
@@ -1,5 +1,6 @@
 import type { Target } from '../targets';
 
+import { aws } from './aws/webhooks/client';
 import { rails } from './rails/webhooks/client';
 
 export const ruby: Target = {
@@ -13,6 +14,7 @@ export const ruby: Target = {
   services: {
     server: {},
     webhooks: {
+      aws,
       rails,
     },
   },

--- a/packages/sdk-snippets/src/targets/targets.test.ts
+++ b/packages/sdk-snippets/src/targets/targets.test.ts
@@ -61,61 +61,141 @@ describe('webhooks', function () {
       const snippetType: SnippetType = 'webhooks';
 
       describe(`${title} snippet generation`, function () {
-        clients.filter(testFilter('key', clientFilter)).forEach(({ key: clientId }) => {
-          fixtures.filter(testFilter(0, fixtureFilter)).forEach(([fixture, variables]) => {
-            const fixturePath = path.join(
-              'src',
-              'targets',
-              targetId,
-              clientId,
-              snippetType,
-              'fixtures',
-              `${fixture}${extname(targetId)}`
-            );
+        clients
+          .filter(c => c.key !== 'aws')
+          .filter(testFilter('key', clientFilter))
+          .forEach(({ key: clientId }) => {
+            fixtures.filter(testFilter(0, fixtureFilter)).forEach(([fixture, variables]) => {
+              const fixturePath = path.join(
+                'src',
+                'targets',
+                targetId,
+                clientId,
+                snippetType,
+                'fixtures',
+                `${fixture}${extname(targetId)}`
+              );
 
-            let expectedOutput: string;
-            try {
-              expectedOutput = readFileSync(fixturePath).toString();
-            } catch (err) {
-              if (OVERWRITE_EVERYTHING) {
-                writeFileSync(fixturePath, '');
+              let expectedOutput: string;
+              try {
+                expectedOutput = readFileSync(fixturePath).toString();
+              } catch (err) {
+                if (OVERWRITE_EVERYTHING) {
+                  writeFileSync(fixturePath, '');
+                  return;
+                }
+                throw new Error(
+                  `Missing a ${snippetType} test file for ${targetId}:${clientId} for the ${fixture} fixture.\nExpected to find the output fixture: \`/${fixturePath}\``
+                );
+              }
+
+              const { convert } = new MetricsSDKSnippet(variables);
+              const result = convert(snippetType, targetId, clientId);
+
+              if (OVERWRITE_EVERYTHING && result) {
+                writeFileSync(fixturePath, String(result.snippet));
                 return;
               }
-              throw new Error(
-                `Missing a ${snippetType} test file for ${targetId}:${clientId} for the ${fixture} fixture.\nExpected to find the output fixture: \`/${fixturePath}\``
-              );
-            }
 
-            const { convert } = new MetricsSDKSnippet(variables);
-            const result = convert(snippetType, targetId, clientId);
+              it(`${clientId} request should match fixture for "${fixture}"`, function () {
+                if (!result) {
+                  throw new Error(`Generated ${fixture} snippet for ${clientId} was \`false\``);
+                }
 
-            if (OVERWRITE_EVERYTHING && result) {
-              writeFileSync(fixturePath, String(result.snippet));
-              return;
-            }
+                /*
+                 * This test is to make sure that our generated snippets
+                 * actually do any variable outputting vs being static
+                 */
+                if (fixture !== 'empty') {
+                  expect(Object.keys(result.ranges).length).to.be.greaterThan(0);
+                }
 
-            it(`${clientId} request should match fixture for "${fixture}"`, function () {
-              if (!result) {
-                throw new Error(`Generated ${fixture} snippet for ${clientId} was \`false\``);
-              }
+                expect(result.ranges).toMatchSnapshot();
+                expect(result.snippet).to.deep.equal(expectedOutput);
 
-              /*
-               * This test is to make sure that our generated snippets
-               * actually do any variable outputting vs being static
-               */
-              if (fixture !== 'empty') {
-                expect(Object.keys(result.ranges).length).to.be.greaterThan(0);
-              }
-
-              expect(result.ranges).toMatchSnapshot();
-              expect(result.snippet).to.deep.equal(expectedOutput);
-
-              // This is making sure that there is an actual secret in the
-              // generated output
-              expect(result.snippet).to.match(/my-readme-secret/);
+                // This is making sure that there is an actual secret in the
+                // generated output
+                expect(result.snippet).to.match(/my-readme-secret/);
+              });
             });
           });
-        });
+      });
+    });
+});
+
+// AWS API Gateway webhook snippets need to be tested separately to account for
+// the createKeys flag. Every fixture in src/fixtures has two corresponding
+// output fixtures, for example src/fixtures/webhooks/empty.js corresponds to
+// src/targets/**/aws/webhooks/fixtures/empty.js (createKeys=false) and
+// src/targets/**/aws/webhooks/fixtures/empty-create.js (createKeys = true).
+describe('webhooks-aws', function () {
+  availableWebhookTargets()
+    .filter(testFilter('key', targetFilter))
+    .forEach(({ key: targetId, title, clients }) => {
+      const snippetType: SnippetType = 'webhooks';
+
+      describe(`${title} snippet generation`, function () {
+        clients
+          .filter(c => c.key === 'aws')
+          .filter(testFilter('key', clientFilter))
+          .forEach(({ key: clientId }) => {
+            fixtures.filter(testFilter(0, fixtureFilter)).forEach(([fixture, variables]) => {
+              [false, true].forEach(createKeys => {
+                const suffix = createKeys ? '-create' : '';
+                const fixturePath = path.join(
+                  'src',
+                  'targets',
+                  targetId,
+                  clientId,
+                  snippetType,
+                  'fixtures',
+                  `${fixture}${suffix}${extname(targetId)}`
+                );
+
+                let expectedOutput: string;
+                try {
+                  expectedOutput = readFileSync(fixturePath).toString();
+                } catch (err) {
+                  if (OVERWRITE_EVERYTHING) {
+                    writeFileSync(fixturePath, '');
+                    return;
+                  }
+                  throw new Error(
+                    `Missing a ${snippetType} test file for ${targetId}:${clientId} for the ${fixture} fixture.\nExpected to find the output fixture: \`/${fixturePath}\``
+                  );
+                }
+
+                const { convert } = new MetricsSDKSnippet(variables);
+                const result = convert(snippetType, targetId, clientId, { createKeys });
+
+                if (OVERWRITE_EVERYTHING && result) {
+                  writeFileSync(fixturePath, String(result.snippet));
+                  return;
+                }
+
+                it(`${clientId} request should match fixture for "${fixture}${suffix}"`, function () {
+                  if (!result) {
+                    throw new Error(`Generated ${fixture} snippet for ${clientId} was \`false\``);
+                  }
+
+                  /*
+                   * This test is to make sure that our generated snippets
+                   * actually do any variable outputting vs being static
+                   */
+                  if (fixture !== 'empty') {
+                    expect(Object.keys(result.ranges).length).to.be.greaterThan(0);
+                  }
+
+                  expect(result.ranges).toMatchSnapshot();
+                  expect(result.snippet).to.deep.equal(expectedOutput);
+
+                  // This is making sure that there is an actual secret in the
+                  // generated output
+                  expect(result.snippet).to.match(/my-readme-secret/);
+                });
+              });
+            });
+          });
       });
     });
 });

--- a/packages/sdk-snippets/src/targets/targets.test.ts
+++ b/packages/sdk-snippets/src/targets/targets.test.ts
@@ -61,11 +61,77 @@ describe('webhooks', function () {
       const snippetType: SnippetType = 'webhooks';
 
       describe(`${title} snippet generation`, function () {
+        clients.filter(testFilter('key', clientFilter)).forEach(({ key: clientId }) => {
+          fixtures.filter(testFilter(0, fixtureFilter)).forEach(([fixture, variables]) => {
+            const fixturePath = path.join(
+              'src',
+              'targets',
+              targetId,
+              clientId,
+              snippetType,
+              'fixtures',
+              `${fixture}${extname(targetId)}`
+            );
+
+            let expectedOutput: string;
+            try {
+              expectedOutput = readFileSync(fixturePath).toString();
+            } catch (err) {
+              if (OVERWRITE_EVERYTHING) {
+                writeFileSync(fixturePath, '');
+                return;
+              }
+              throw new Error(
+                `Missing a ${snippetType} test file for ${targetId}:${clientId} for the ${fixture} fixture.\nExpected to find the output fixture: \`/${fixturePath}\``
+              );
+            }
+
+            const { convert } = new MetricsSDKSnippet(variables);
+            const result = convert(snippetType, targetId, clientId);
+
+            if (OVERWRITE_EVERYTHING && result) {
+              writeFileSync(fixturePath, String(result.snippet));
+              return;
+            }
+
+            it(`${clientId} request should match fixture for "${fixture}"`, function () {
+              if (!result) {
+                throw new Error(`Generated ${fixture} snippet for ${clientId} was \`false\``);
+              }
+
+              /*
+               * This test is to make sure that our generated snippets
+               * actually do any variable outputting vs being static
+               */
+              if (fixture !== 'empty') {
+                expect(Object.keys(result.ranges).length).to.be.greaterThan(0);
+              }
+
+              expect(result.ranges).toMatchSnapshot();
+              expect(result.snippet).to.deep.equal(expectedOutput);
+
+              // This is making sure that there is an actual secret in the
+              // generated output
+              expect(result.snippet).to.match(/my-readme-secret/);
+            });
+          });
+        });
+      });
+    });
+
+  availableWebhookTargets()
+    .filter(testFilter('key', targetFilter))
+    .forEach(({ key: targetId, title, clients }) => {
+      const snippetType: SnippetType = 'webhooks';
+
+      describe(`${title} AWS snippet generation with automatic creation of new API keys`, function () {
         clients
-          .filter(c => c.key !== 'aws')
+          .filter(c => c.key === 'aws')
           .filter(testFilter('key', clientFilter))
           .forEach(({ key: clientId }) => {
             fixtures.filter(testFilter(0, fixtureFilter)).forEach(([fixture, variables]) => {
+              const createKeys = true;
+              const suffix = createKeys ? '-create' : '';
               const fixturePath = path.join(
                 'src',
                 'targets',
@@ -73,7 +139,7 @@ describe('webhooks', function () {
                 clientId,
                 snippetType,
                 'fixtures',
-                `${fixture}${extname(targetId)}`
+                `${fixture}${suffix}${extname(targetId)}`
               );
 
               let expectedOutput: string;
@@ -90,14 +156,14 @@ describe('webhooks', function () {
               }
 
               const { convert } = new MetricsSDKSnippet(variables);
-              const result = convert(snippetType, targetId, clientId);
+              const result = convert(snippetType, targetId, clientId, { createKeys });
 
               if (OVERWRITE_EVERYTHING && result) {
                 writeFileSync(fixturePath, String(result.snippet));
                 return;
               }
 
-              it(`${clientId} request should match fixture for "${fixture}"`, function () {
+              it(`${clientId} request should match fixture for "${fixture}${suffix}"`, function () {
                 if (!result) {
                   throw new Error(`Generated ${fixture} snippet for ${clientId} was \`false\``);
                 }
@@ -116,83 +182,6 @@ describe('webhooks', function () {
                 // This is making sure that there is an actual secret in the
                 // generated output
                 expect(result.snippet).to.match(/my-readme-secret/);
-              });
-            });
-          });
-      });
-    });
-});
-
-// AWS API Gateway webhook snippets need to be tested separately to account for
-// the createKeys flag. Every fixture in src/fixtures has two corresponding
-// output fixtures, for example src/fixtures/webhooks/empty.js corresponds to
-// src/targets/**/aws/webhooks/fixtures/empty.js (createKeys=false) and
-// src/targets/**/aws/webhooks/fixtures/empty-create.js (createKeys = true).
-describe('webhooks-aws', function () {
-  availableWebhookTargets()
-    .filter(testFilter('key', targetFilter))
-    .forEach(({ key: targetId, title, clients }) => {
-      const snippetType: SnippetType = 'webhooks';
-
-      describe(`${title} snippet generation`, function () {
-        clients
-          .filter(c => c.key === 'aws')
-          .filter(testFilter('key', clientFilter))
-          .forEach(({ key: clientId }) => {
-            fixtures.filter(testFilter(0, fixtureFilter)).forEach(([fixture, variables]) => {
-              [false, true].forEach(createKeys => {
-                const suffix = createKeys ? '-create' : '';
-                const fixturePath = path.join(
-                  'src',
-                  'targets',
-                  targetId,
-                  clientId,
-                  snippetType,
-                  'fixtures',
-                  `${fixture}${suffix}${extname(targetId)}`
-                );
-
-                let expectedOutput: string;
-                try {
-                  expectedOutput = readFileSync(fixturePath).toString();
-                } catch (err) {
-                  if (OVERWRITE_EVERYTHING) {
-                    writeFileSync(fixturePath, '');
-                    return;
-                  }
-                  throw new Error(
-                    `Missing a ${snippetType} test file for ${targetId}:${clientId} for the ${fixture} fixture.\nExpected to find the output fixture: \`/${fixturePath}\``
-                  );
-                }
-
-                const { convert } = new MetricsSDKSnippet(variables);
-                const result = convert(snippetType, targetId, clientId, { createKeys });
-
-                if (OVERWRITE_EVERYTHING && result) {
-                  writeFileSync(fixturePath, String(result.snippet));
-                  return;
-                }
-
-                it(`${clientId} request should match fixture for "${fixture}${suffix}"`, function () {
-                  if (!result) {
-                    throw new Error(`Generated ${fixture} snippet for ${clientId} was \`false\``);
-                  }
-
-                  /*
-                   * This test is to make sure that our generated snippets
-                   * actually do any variable outputting vs being static
-                   */
-                  if (fixture !== 'empty') {
-                    expect(Object.keys(result.ranges).length).to.be.greaterThan(0);
-                  }
-
-                  expect(result.ranges).toMatchSnapshot();
-                  expect(result.snippet).to.deep.equal(expectedOutput);
-
-                  // This is making sure that there is an actual secret in the
-                  // generated output
-                  expect(result.snippet).to.match(/my-readme-secret/);
-                });
               });
             });
           });


### PR DESCRIPTION
## 🧰 Changes

This adds new `aws` library targets for languages that we support Webhooks on that are also supported in AWS Lambdas for AWS API Gateway.

* [x] C#
* [x] Node
* [x] Python
* [x] Ruby

## 🧬 QA & Testing

I generated output for each of the 8 variants (4 languages × 2 `createKeys` settings) and I confirmed that all 8 are identical to the source in the `api-gateway-example-webhooks` repo.

There are 56 output samples in this PR (7 tests × 4 languages × 2 `createKeys` settings). I very briefly checked the output samples to confirm they look right, and I paid special attention to the `quirky-escaping` variants. I didn't try to actually run all 56 fixtures in API Gateway. I also didn't try to run them all through a linter, because they'll have some minor linting errors. For example, in the Node code generation we might always output `{ foo: 'default for foo' }` even though occasionally this results in an eslint warning on `{ foo: 'default for \'foo\'' }`.