### PR TITLE
fix(docs): update versions/categories

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -13,6 +13,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Sync docs to ReadMe
-        uses: readmeio/rdme@8.0.4
+        uses: readmeio/rdme@8.1.1
         with:
           rdme: docs ./docs --key=${{ secrets.README_API_KEY }} --version=2.0

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Sync docs to ReadMe
         uses: readmeio/rdme@8.1.1
         with:
-          rdme: docs ./docs --key=${{ secrets.README_API_KEY }} --version=2.0
+          rdme: docs ./docs --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ secrets.README_DEVELOPERS_MAIN_VERSION }}

--- a/docs/alternative-methods.md
+++ b/docs/alternative-methods.md
@@ -1,7 +1,7 @@
 ---
 title: Other Ways to Send API Requests
 slug: other-ways-to-use-api-metrics
-category: 5f7cefc76b6e5e04c3a4c74c
+category: 62292aea889520008ed0113b
 ---
 
 Are you interested in insights on your users and API request logs in your documentation, but using a language or API gateway that we don't yet support? [Let us know](https://docs.readme.com/docs/contact-support) what you're using! We're actively working on new integrations and would love to support your API.

--- a/docs/cloudflare-workers.md
+++ b/docs/cloudflare-workers.md
@@ -1,7 +1,7 @@
 ---
 title: Cloudflare Workers
 slug: sending-logs-to-readme-with-cloudflare
-category: 5f7cefc76b6e5e04c3a4c74c
+category: 62292aea889520008ed0113b
 ---
 
 > 🚧 Any issues?

--- a/docs/dotnet-setup.md
+++ b/docs/dotnet-setup.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Setup
 slug: net-setup
-category: 5f7cefc76b6e5e04c3a4c74c
+category: 62292aea889520008ed0113b
 ---
 
 > 🚧 Any issues?

--- a/docs/nodejs-setup.md
+++ b/docs/nodejs-setup.md
@@ -6,7 +6,7 @@ category: 62292aea889520008ed0113b
 
 > 🚀 Upgrading to v6.0?
 >
-> Please see our [upgrade path documentation](#section--how-can-i-upgrade-to-v6-0-).
+> Please see our [upgrade path documentation](#how-can-i-upgrade-to-v60).
 
 > 🚧 Any issues?
 >

--- a/docs/nodejs-setup.md
+++ b/docs/nodejs-setup.md
@@ -1,7 +1,7 @@
 ---
 title: Node.js Setup
 slug: sending-logs-to-readme-with-nodejs
-category: 5f7cefc76b6e5e04c3a4c74c
+category: 62292aea889520008ed0113b
 ---
 
 > 🚀 Upgrading to v6.0?

--- a/docs/php-laravel-setup.md
+++ b/docs/php-laravel-setup.md
@@ -1,7 +1,7 @@
 ---
 title: PHP (Laravel) Setup
 slug: sending-logs-to-readme-with-php-laravel
-category: 5f7cefc76b6e5e04c3a4c74c
+category: 62292aea889520008ed0113b
 ---
 
 > 🚀 Upgrading to v2.0?

--- a/docs/python-django-setup.md
+++ b/docs/python-django-setup.md
@@ -1,7 +1,7 @@
 ---
 title: Python (Django) Setup
 slug: python-django-api-metrics
-category: 5f7cefc76b6e5e04c3a4c74c
+category: 62292aea889520008ed0113b
 ---
 
 > 🚧 Any issues?

--- a/docs/python-flask-setup.md
+++ b/docs/python-flask-setup.md
@@ -1,7 +1,7 @@
 ---
 title: Python (Flask) Setup
 slug: python-flask-api-metrics
-category: 5f7cefc76b6e5e04c3a4c74c
+category: 62292aea889520008ed0113b
 ---
 
 > 🚧 Any issues?

--- a/docs/python-wsgi-setup.md
+++ b/docs/python-wsgi-setup.md
@@ -1,7 +1,7 @@
 ---
 title: Python (Flask) Setup
 slug: python-wsgi-api-metrics
-category: 5f7cefc76b6e5e04c3a4c74c
+category: 62292aea889520008ed0113b
 ---
 
 > 🚧 Any issues?

--- a/docs/ruby-setup.md
+++ b/docs/ruby-setup.md
@@ -1,7 +1,7 @@
 ---
 title: Ruby (Rails/Rack) Setup
 slug: ruby-api-metrics-set-up
-category: 5f7cefc76b6e5e04c3a4c74c
+category: 62292aea889520008ed0113b
 ---
 
 > 🚧 Any issues?


### PR DESCRIPTION
## 🧰 Changes
- [x] Migrates doc categories to reflect new location in knowledge base
- [x] Bumps `rdme` GitHub Action to latest version
- [x] Fixes broken hash link on [this page](https://docs.readme.com/docs/sending-logs-to-readme-with-nodejs)
- [x] Updates project version and API key to use org-level secret (see #dev for more info on the latter)
- [ ] **TODO once this is merged**: remove `README_API_KEY` from this repo's secrets in favor of org-level secret.

## 🧬 QA & Testing

We won't know if the syncing works until it's merged into `main`, but a local dry run appears to work fine:

<img width="1859" alt="image" src="https://user-images.githubusercontent.com/8854718/203358655-3911af71-c950-49bf-ac4e-2c0c81461fc6.png">

