### PR TITLE
fix: fix secret type when use hmac func

### DIFF
--- a/packages/python/readme_metrics/VerifyWebhook.py
+++ b/packages/python/readme_metrics/VerifyWebhook.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 
 class VerifyWebhook:
-    def __init__(self, body, signature, secret):
+    def __init__(self, body: dict, signature: str, secret: str):
         if signature is None:
             raise Exception("Missing Signature")
 
@@ -22,7 +22,7 @@ class VerifyWebhook:
 
         unsigned = time + "." + json.dumps(body, separators=(",", ":"))
         verify_signature = hmac.new(
-            secret,
+            secret.encode("utf-8", errors="ignore"),
             unsigned.encode("utf8"),
             "sha256",
         ).hexdigest()


### PR DESCRIPTION
| 🚥 Fix https://github.com/readmeio/metrics-sdks/issues/663 |
| :-- |

## 🧰 Changes

Fix type error when verifying the webhook request. See https://github.com/readmeio/metrics-sdks/issues/663 for more details.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.

Here is how I test the code: 
- Link webhook to Readme
- Rebuild and install the fixed python package locally.
- Start the flask server that Readme officially provided.
- Post a request from Readme and verify the request body.

**Screenshot**

![image](https://user-images.githubusercontent.com/31848542/203761247-4a3f1053-e389-43d6-afa2-939259dca23d.png)

