### PR TITLE
feat: dynamically support rack v2 and v3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,6 +37,11 @@ jobs:
           - 2.7 # EOL: March 31st, 2023
           - '3.0' # EOL: March 31st, 2024
           - 3.1 # EOL: December 25th, 2025
+        rack-version:
+          - 2.x
+          - 3.x
+
+    name: build (${{ matrix.ruby-version }} w/ Rack ${{ matrix.rack-version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +50,9 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
 
       - name: Install dependencies
-        run: make install
+        run: |
+          make install
+          gem install rack -v ${{ matrix.rack-version }}
 
       - name: Run linter
         run: make lint

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,8 +38,8 @@ jobs:
           - '3.0' # EOL: March 31st, 2024
           - 3.1 # EOL: December 25th, 2025
         rack-version:
-          - 2.x
-          - 3.x
+          - 2
+          - 3
 
     name: build (${{ matrix.ruby-version }} w/ Rack ${{ matrix.rack-version }}
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           make install
           gem install rack ${{ matrix.rack-version }}
+          bundle update
 
       - name: Run linter
         run: make lint

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,8 +38,10 @@ jobs:
           - '3.0' # EOL: March 31st, 2024
           - 3.1 # EOL: December 25th, 2025
         rack-version:
-          - 2
-          - 3
+          # This will install the latest v2
+          - -v '>= 2.2' -v '< 3'
+          # This will install the latest v3
+          - -v '>= 2.2' -v '< 4'
 
     name: build (${{ matrix.ruby-version }} w/ Rack ${{ matrix.rack-version }}
 
@@ -52,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           make install
-          gem install rack -v ${{ matrix.rack-version }}
+          gem install rack ${{ matrix.rack-version }}
 
       - name: Run linter
         run: make lint

--- a/packages/ruby/Gemfile.lock
+++ b/packages/ruby/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     readme-metrics (2.2.0)
       httparty (~> 0.18)
+      rack (>= 2.2, < 4.x)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/ruby/Gemfile.lock
+++ b/packages/ruby/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     readme-metrics (2.2.0)
       httparty (~> 0.18)
-      rack (>= 2.2, < 4.x)
+      rack (>= 2.2, < 4)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/ruby/examples/metrics-rails/Gemfile.lock
+++ b/packages/ruby/examples/metrics-rails/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     readme-metrics (2.2.0)
       httparty (~> 0.18)
+      rack (>= 2.2, < 4)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/ruby/examples/metrics-rails/config/environments/production.rb
+++ b/packages/ruby/examples/metrics-rails/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"

--- a/packages/ruby/lib/readme/http_request.rb
+++ b/packages/ruby/lib/readme/http_request.rb
@@ -6,15 +6,27 @@ module Readme
   class HttpRequest
     include ContentTypeHelper
 
+    IS_RACK_V3 = Gem.loaded_specs["rack"].version > Gem::Version.create('3.0')
+
     HTTP_NON_HEADERS = [
       Rack::HTTP_COOKIE,
-      Rack::HTTP_VERSION,
       Rack::HTTP_HOST,
       Rack::HTTP_PORT
-    ].freeze
+    ]
+
+    if IS_RACK_V3
+      HTTP_NON_HEADERS.push(Rack::SERVER_PROTOCOL)
+    else
+      HTTP_NON_HEADERS.push(Rack::HTTP_VERSION)
+    end
+
+    HTTP_NON_HEADERS.freeze
 
     def initialize(env)
       @request = Rack::Request.new(env)
+      if IS_RACK_V3
+        @input = Rack::RewindableInput.new(@request.body)
+      end
     end
 
     def url
@@ -30,7 +42,11 @@ module Readme
     end
 
     def http_version
-      @request.get_header(Rack::HTTP_VERSION)
+      if IS_RACK_V3
+        @request.get_header(Rack::SERVER_PROTOCOL)
+      else
+        @request.get_header(Rack::HTTP_VERSION)
+      end
     end
 
     def request_method
@@ -64,11 +80,17 @@ module Readme
     end
 
     def body
-      @request.body.rewind
-      content = @request.body.read
-      @request.body.rewind
+      if IS_RACK_V3
+        body = @input.read
+        @input.rewind
+        body
+      else
+        @request.body.rewind
+        content = @request.body.read
+        @request.body.rewind
 
-      content
+        content
+      end
     end
 
     def parsed_form_data

--- a/packages/ruby/lib/readme/http_request.rb
+++ b/packages/ruby/lib/readme/http_request.rb
@@ -6,13 +6,15 @@ module Readme
   class HttpRequest
     include ContentTypeHelper
 
-    IS_RACK_V3 = Gem.loaded_specs["rack"].version > Gem::Version.create('3.0')
+    IS_RACK_V3 = Gem.loaded_specs['rack'].version > Gem::Version.create('3.0')
 
+    # rubocop:disable Style/MutableConstant
     HTTP_NON_HEADERS = [
       Rack::HTTP_COOKIE,
       Rack::HTTP_HOST,
       Rack::HTTP_PORT
     ]
+    # rubocop:enable Style/MutableConstant
 
     if IS_RACK_V3
       HTTP_NON_HEADERS.push(Rack::SERVER_PROTOCOL)
@@ -24,9 +26,9 @@ module Readme
 
     def initialize(env)
       @request = Rack::Request.new(env)
-      if IS_RACK_V3
-        @input = Rack::RewindableInput.new(@request.body)
-      end
+      return unless IS_RACK_V3
+
+      @input = Rack::RewindableInput.new(@request.body)
     end
 
     def url

--- a/packages/ruby/readme-metrics.gemspec
+++ b/packages/ruby/readme-metrics.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'httparty', '~> 0.18'
-  spec.add_runtime_dependency 'rack', ">= 2.2", "< 4.x"
+  spec.add_runtime_dependency 'rack', '>= 2.2', '< 4.x'
 end

--- a/packages/ruby/readme-metrics.gemspec
+++ b/packages/ruby/readme-metrics.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'httparty', '~> 0.18'
-  spec.add_runtime_dependency 'rack', '>= 2.2', '< 4.x'
+  spec.add_runtime_dependency 'rack', '>= 2.2', '< 4'
 end

--- a/packages/ruby/readme-metrics.gemspec
+++ b/packages/ruby/readme-metrics.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'httparty', '~> 0.18'
+  spec.add_runtime_dependency 'rack', ">= 2.2", "< 4.x"
 end

--- a/packages/ruby/spec/readme/har/request_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/request_serializer_spec.rb
@@ -27,22 +27,16 @@ RSpec.describe Readme::Har::RequestSerializer do
       expect(json[:headersSize]).to eq(-1)
       expect(json[:bodySize]).to eq http_request.content_length
       expect(json[:headers]).to contain_exactly(
-        [
-          { name: 'Authorization', value: 'Basic abc123' },
-          { name: 'X-Custom', value: 'custom' }
-        ]
+        { name: 'Authorization', value: 'Basic abc123' },
+        { name: 'X-Custom', value: 'custom' }
       )
       expect(json[:queryString]).to contain_exactly(
-        [
-          { name: 'id', value: '1' },
-          { name: 'name', value: 'joel' }
-        ]
+        { name: 'id', value: '1' },
+        { name: 'name', value: 'joel' }
       )
       expect(json[:cookies]).to contain_exactly(
-        [
-          { name: 'cookie1', value: 'value1' },
-          { name: 'cookie2', value: 'value2' }
-        ]
+        { name: 'cookie1', value: 'value1' },
+        { name: 'cookie2', value: 'value2' }
       )
     end
 
@@ -89,11 +83,9 @@ RSpec.describe Readme::Har::RequestSerializer do
       expect(json[:postData]).not_to have_key(:text)
       expect(json.dig(:postData, :mimeType)).to eq http_request.content_type
       expect(json.dig(:postData, :params)).to contain_exactly(
-        [
-          { name: 'item', value: '1' },
-          { name: 'other', value: '2' },
-          { name: 'reject', value: '[REDACTED 1]' }
-        ]
+        { name: 'item', value: '1' },
+        { name: 'other', value: '2' },
+        { name: 'reject', value: '[REDACTED 1]' }
       )
     end
 

--- a/packages/ruby/spec/readme/har/request_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/request_serializer_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe Readme::Har::RequestSerializer do
       expect(json.dig(:postData, :mimeType)).to eq http_request.content_type
       expect(json[:headersSize]).to eq(-1)
       expect(json[:bodySize]).to eq http_request.content_length
-      expect(json[:headers]).to match_array(
+      expect(json[:headers]).to contain_exactly(
         [
           { name: 'Authorization', value: 'Basic abc123' },
           { name: 'X-Custom', value: 'custom' }
         ]
       )
-      expect(json[:queryString]).to match_array(
+      expect(json[:queryString]).to contain_exactly(
         [
           { name: 'id', value: '1' },
           { name: 'name', value: 'joel' }
         ]
       )
-      expect(json[:cookies]).to match_array(
+      expect(json[:cookies]).to contain_exactly(
         [
           { name: 'cookie1', value: 'value1' },
           { name: 'cookie2', value: 'value2' }
@@ -88,7 +88,7 @@ RSpec.describe Readme::Har::RequestSerializer do
 
       expect(json[:postData]).not_to have_key(:text)
       expect(json.dig(:postData, :mimeType)).to eq http_request.content_type
-      expect(json.dig(:postData, :params)).to match_array(
+      expect(json.dig(:postData, :params)).to contain_exactly(
         [
           { name: 'item', value: '1' },
           { name: 'other', value: '2' },

--- a/packages/ruby/spec/readme/har/response_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/response_serializer_spec.rb
@@ -32,19 +32,15 @@ RSpec.describe Readme::Har::ResponseSerializer do
       expect(json[:statusText]).to eq 'OK'
       expect(json[:httpVersion]).to eq request.http_version
       expect(json[:headers]).to contain_exactly(
-        [
-          { name: 'X-Custom', value: 'custom' },
-          { name: 'reject', value: '[REDACTED 6]' }
-        ]
+        { name: 'X-Custom', value: 'custom' },
+        { name: 'reject', value: '[REDACTED 6]' }
       )
       expect(json[:headersSize]).to eq(-1)
       expect(json[:bodySize]).to eq response.content_length
       expect(json[:redirectURL]).to eq ''
       expect(json[:cookies]).to contain_exactly(
-        [
-          { name: 'cookie1', value: 'value1' },
-          { name: 'reject', value: '[REDACTED 6]' }
-        ]
+        { name: 'cookie1', value: 'value1' },
+        { name: 'reject', value: '[REDACTED 6]' }
       )
       expect(json.dig(:content, :text)).to eq 'OK'
       expect(json.dig(:content, :size)).to eq response.content_length

--- a/packages/ruby/spec/readme/har/response_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/response_serializer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       expect(json[:status]).to eq 200
       expect(json[:statusText]).to eq 'OK'
       expect(json[:httpVersion]).to eq request.http_version
-      expect(json[:headers]).to match_array(
+      expect(json[:headers]).to contain_exactly(
         [
           { name: 'X-Custom', value: 'custom' },
           { name: 'reject', value: '[REDACTED 6]' }
@@ -40,7 +40,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       expect(json[:headersSize]).to eq(-1)
       expect(json[:bodySize]).to eq response.content_length
       expect(json[:redirectURL]).to eq ''
-      expect(json[:cookies]).to match_array(
+      expect(json[:cookies]).to contain_exactly(
         [
           { name: 'cookie1', value: 'value1' },
           { name: 'reject', value: '[REDACTED 6]' }

--- a/packages/ruby/spec/readme/http_request_spec.rb
+++ b/packages/ruby/spec/readme/http_request_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe Readme::HttpRequest do
 
   describe '#http_version' do
     it 'gets the version from the proper Rack header' do
-      if Readme::HttpRequest::IS_RACK_V3
-        env = { 'SERVER_PROTOCOL' => 'HTTP/1.1' }
-      else
-        env = { 'HTTP_VERSION' => 'HTTP/1.1' }
-      end
+      env = if Readme::HttpRequest::IS_RACK_V3
+              { 'SERVER_PROTOCOL' => 'HTTP/1.1' }
+            else
+              { 'HTTP_VERSION' => 'HTTP/1.1' }
+            end
       request = described_class.new(env)
 
       expect(request.http_version).to eq 'HTTP/1.1'
@@ -145,9 +145,7 @@ RSpec.describe Readme::HttpRequest do
         'CONTENT_LENGTH' => '10'
       }
 
-      if not Readme::HttpRequest::IS_RACK_V3
-        env['HTTP_VERSION'] = 'HTTP/1.1'
-      end
+      env['HTTP_VERSION'] = 'HTTP/1.1' unless Readme::HttpRequest::IS_RACK_V3
 
       request = described_class.new(env)
 
@@ -165,15 +163,15 @@ RSpec.describe Readme::HttpRequest do
 
   describe '#body' do
     it 'reads the body from the rack.input key' do
-      if Readme::HttpRequest::IS_RACK_V3
-        env = {
-          'rack.input' => Rack::Lint::Wrapper::InputWrapper.new(StringIO.new('[BODY]'))
-        }
-      else
-        env = {
-          'rack.input' => Rack::Lint::InputWrapper.new(StringIO.new('[BODY]'))
-        }
-      end
+      env = if Readme::HttpRequest::IS_RACK_V3
+              {
+                'rack.input' => Rack::Lint::Wrapper::InputWrapper.new(StringIO.new('[BODY]'))
+              }
+            else
+              {
+                'rack.input' => Rack::Lint::InputWrapper.new(StringIO.new('[BODY]'))
+              }
+            end
 
       request = described_class.new(env)
 
@@ -181,15 +179,15 @@ RSpec.describe Readme::HttpRequest do
     end
 
     it 'can be read safely multiple times' do
-      if Readme::HttpRequest::IS_RACK_V3
-        env = {
-          'rack.input' => Rack::Lint::Wrapper::InputWrapper.new(StringIO.new('[BODY]'))
-        }
-      else
-        env = {
-          'rack.input' => Rack::Lint::InputWrapper.new(StringIO.new('[BODY]'))
-        }
-      end
+      env = if Readme::HttpRequest::IS_RACK_V3
+              {
+                'rack.input' => Rack::Lint::Wrapper::InputWrapper.new(StringIO.new('[BODY]'))
+              }
+            else
+              {
+                'rack.input' => Rack::Lint::InputWrapper.new(StringIO.new('[BODY]'))
+              }
+            end
       request = described_class.new(env)
 
       expect(request.body).to eq '[BODY]'
@@ -199,17 +197,17 @@ RSpec.describe Readme::HttpRequest do
 
   describe '#parsed_form_data' do
     it 'returns the parsed form-encoded body as a hash' do
-      if Readme::HttpRequest::IS_RACK_V3
-        env = {
-          'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-          'rack.input' => Rack::Lint::Wrapper::InputWrapper.new(StringIO.new('first=1&second=2'))
-        }
-      else
-        env = {
-          'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-          'rack.input' => Rack::Lint::InputWrapper.new(StringIO.new('first=1&second=2'))
-        }
-      end
+      env = if Readme::HttpRequest::IS_RACK_V3
+              {
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'rack.input' => Rack::Lint::Wrapper::InputWrapper.new(StringIO.new('first=1&second=2'))
+              }
+            else
+              {
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'rack.input' => Rack::Lint::InputWrapper.new(StringIO.new('first=1&second=2'))
+              }
+            end
 
       request = described_class.new(env)
 

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -44,11 +44,11 @@ class SetHttpVersion
   end
 
   def call(env)
-    if Readme::HttpRequest::IS_RACK_V3
-      new_env = env.merge({ 'SERVER_PROTOCOL' => 'HTTP/1.1' })
-    else
-      new_env = env.merge({ 'HTTP_VERSION' => 'HTTP/1.1' })
-    end
+    new_env = if Readme::HttpRequest::IS_RACK_V3
+                env.merge({ 'SERVER_PROTOCOL' => 'HTTP/1.1' })
+              else
+                env.merge({ 'HTTP_VERSION' => 'HTTP/1.1' })
+              end
 
     @app.call(new_env)
   end

--- a/packages/ruby/spec/readme/webhook_spec.rb
+++ b/packages/ruby/spec/readme/webhook_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe Readme::Webhook do
       hmac = OpenSSL::HMAC.hexdigest('SHA256', random_api_key, unsigned)
       signature = "t=#{time},v0=#{hmac}"
 
-      described_class.verify({ email: 'dom@readme.io' }.to_json, signature, random_api_key)
+      expect {
+        described_class.verify({ email: 'dom@readme.io' }.to_json, signature, random_api_key)
+      }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## 🧰 Changes

Over in #653 we added support for Rack 3, but in doing so we unintentionally removed support for Rails which does not yet support Rack 3. I (slowly) reverted the work in #763 then decided to make this module work with both rack v2 and v3.

We can do this at runtime using a looser runtime dependency in the gemspec: `'rack', '>= 2.2', '< 4'`
https://github.com/readmeio/metrics-sdks/blob/980f92dc50c5cecab167de85681e753b56c1847e/packages/ruby/readme-metrics.gemspec#L30

Then check for the version at runtime using `Gem.loaded_specs['rack'].version > Gem::Version.create('3.0')`
https://github.com/readmeio/metrics-sdks/blob/980f92dc50c5cecab167de85681e753b56c1847e/packages/ruby/lib/readme/http_request.rb#L9

I had to add a bunch of conditionals both in the code and tests to make this work, i'm sure it could be tidied up some more but this is okay for now if we're eventually gunna deprecate rack@2.

## 🧬 QA & Testing

Do the tests pass? ✅