### PR TITLE
[bug] Secret should be bytes for Python3 versions

### DIFF
--- a/packages/python/examples/flask/webhooks.py
+++ b/packages/python/examples/flask/webhooks.py
@@ -20,7 +20,7 @@ def webhook():
     signature = request.headers.get("readme-signature", None)
 
     try:
-        VerifyWebhook(request.get_json(), signature, secret)
+        VerifyWebhook(request.get_json(), signature, bytes(secret,encoding='utf-8'))
     except Exception as error:
         return (
             {"error": str(error)},


### PR DESCRIPTION
convert String to Bytes object for hmac.new() in python 3 to satisfy VerifyWebHook function

| 🚥 Fixes ISSUE_ID |  #663 
| :---------------- |

## 🧰 Changes

Describe in detail what this PR is for.

## 🧬 QA & Testing

Hi - not sure if this might be a versioning difference, but to satisfy the newest version of hmac.new in VerifyWebHook in python 3, the secret should be a bytes object not a string. 

This fixed the issue for me in setup against issue #663 in Python 3.7.9+. Feel free to revert / close PR if this isn't relevant. 