### PR TITLE
feat: backoff requests to the ReadMe server after certain HTTP responses

### DIFF
--- a/packages/node/src/lib/metrics-log.ts
+++ b/packages/node/src/lib/metrics-log.ts
@@ -41,6 +41,37 @@ export interface LogResponse {
   ids: string | string[];
 }
 
+const BACKOFF_SECONDS = 15; // when we need to backoff HTTP requests, pause for seconds
+
+let backoffExpiresAt: Date;
+
+// Exported for use in unit tests
+export function setBackoff(expiresAt: Date | undefined) {
+  backoffExpiresAt = expiresAt;
+}
+
+function shouldBackoff(response: Response) {
+  // Some HTTP error codes indicate a problem with the API key, like the key is
+  // invalid or it's being rate limited. To avoid pointless requests to the
+  // ReadMe server, pause outgoing requests for a few seconds before trying
+  // again. Logs will be silently discarded while requests are paused, which is
+  // acceptable since the server wouldn't accept them anyway.
+  switch (response.status) {
+    case 401: // Unauthorized, i.e. this API key is invalid
+      return true;
+    case 403: // Forbidden, i.e. this API key is blocked by the server
+      return true;
+    case 429: // Too Many Requests, i.e. this API key is currently being rate limited
+      return true;
+    case 500: // Internal Server Error; give the ReadMe server a chance to recover
+      return true;
+    case 503: // Service Unavailable; same thing
+      return true;
+    default:
+      return false;
+  }
+}
+
 function getLogIds(body: OutgoingLogBody | OutgoingLogBody[]): string | string[] {
   if (Array.isArray(body)) {
     return body.map(value => value._id);
@@ -58,6 +89,13 @@ export function metricsAPICall(
   const encodedKey = Buffer.from(`${readmeAPIKey}:`).toString('base64');
 
   const makeRequest = () => {
+    if (backoffExpiresAt) {
+      if (backoffExpiresAt > new Date()) {
+        return Promise.resolve();
+      }
+      // after the backoff expires, erase the old expiration time
+      backoffExpiresAt = undefined;
+    }
     return fetch(new URL('/v1/request', config.host), {
       method: 'post',
       body: JSON.stringify(body),
@@ -67,9 +105,20 @@ export function metricsAPICall(
         'User-Agent': `${pkg.name}/${pkg.version}`,
       },
       signal,
-    }).finally(() => {
-      timeoutSignal.clear(signal);
-    });
+    })
+      .then(response => {
+        if (shouldBackoff(response)) {
+          // backoff for a few seconds, but not if another callback has already started backing off
+          if (!backoffExpiresAt) {
+            backoffExpiresAt = new Date();
+            backoffExpiresAt.setSeconds(backoffExpiresAt.getSeconds() + BACKOFF_SECONDS);
+          }
+        }
+        return response;
+      })
+      .finally(() => {
+        timeoutSignal.clear(signal);
+      });
   };
 
   if (fireAndForget) {


### PR DESCRIPTION
## 🧰 Changes

Some metrics users are sending invalid traffic (like with an invalid API key) at a rate of tens or even hundreds of requests per second. This change updates the metrics client to pay attention to the HTTP response's status code as sent from the metrics server. If it receives an HTTP error, this stops sending logs for 15 seconds to avoid bombarding our server with bad requests. Only certain errors trigger a backoff; they're documented in the code.

## 📖 Frequently Asked Questions

1. **Why 15 seconds?** That's enough to dramatically reduce the amount of invalid traffic coming to the server. It's short enough that the client will recover quickly if it pauses due to a server error, like a one-off HTTP 500.
2. **Do we buffer the requests and try again?** No. For HTTP 401/403/429 there's essentially no way for the client to recover without updating their API key and restarting the process, or waiting until the 1st of the following month. For HTTP 500/503 I suppose buffering a few requests could be valuable, but this PR doesn't currently do that.
3. **Do we notify the user that their requests are not being logged?** No. I didn't want to add any kind of `console.log` statements since we don't do that elsewhere in the client.
4. **What about other SDKs?** I wanted to start with a single SDK but I'll add Python next. Anyone else want to help with the rest?

## 🧬 QA & Testing

Tested locally, confirms it backs off for 15 seconds as expected. Also added unit tests.