### PR TITLE
feat(python): backoff requests to the ReadMe server after certain HTTP responses

### DIFF
--- a/packages/python/readme_metrics/publisher.py
+++ b/packages/python/readme_metrics/publisher.py
@@ -1,11 +1,47 @@
 import os
 import importlib
 import json
+import time
 
 from queue import Empty
 from urllib.parse import urljoin
 
 import requests
+
+
+# when we need to backoff HTTP requests, pause for this many seconds
+BACKOFF_SECONDS = 15
+
+backoff_expires_at = None
+
+
+def start_backoff():
+    global backoff_expires_at  # pylint: disable=global-statement
+    # Backoff for a few seconds, but not if another concurrent request has
+    # already triggered a backoff
+    if backoff_expires_at is None:
+        backoff_expires_at = time.time() + BACKOFF_SECONDS
+
+
+def clear_backoff():
+    global backoff_expires_at  # pylint: disable=global-statement
+    backoff_expires_at = None
+
+
+def should_backoff(response):
+    # Some HTTP error codes indicate a problem with the API key, like the key is
+    # invalid or it's being rate limited. To avoid pointless requests to the
+    # ReadMe server, pause outgoing requests for a few seconds before trying
+    # again. Logs will be silently discarded while requests are paused, which is
+    # acceptable since the server wouldn't accept them anyway.
+    backoff_codes = [
+        401,  # Unauthorized, i.e. this API key is invalid
+        403,  # Forbidden, i.e. this API key is blocked by the server
+        429,  # Too Many Requests, i.e. this API key is currently being rate limited
+        500,  # Internal Server Error; give the ReadMe server a chance to recover
+        503,  # Service Unavailable; same thing
+    ]
+    return response.status_code in backoff_codes
 
 
 def publish_batch(config, queue):
@@ -20,6 +56,16 @@ def publish_batch(config, queue):
 
         if len(result_list) == 0:
             return
+
+        if backoff_expires_at is not None:
+            if backoff_expires_at > time.time():
+                config.LOGGER.info(
+                    "Publishing to ReadMe is temporarily paused; "
+                    + f"skipping {len(result_list)} request(s)"
+                )
+                return
+            # After the backoff expires, erase the old expiration time
+            clear_backoff()
 
         version = importlib.import_module(__package__).__version__
         url = urljoin(
@@ -39,6 +85,14 @@ def publish_batch(config, queue):
         config.LOGGER.info(
             f"POST to {url} with {len(result_list)} items returned {readme_result.status_code}"
         )
+
+        if should_backoff(readme_result) and backoff_expires_at is None:
+            config.LOGGER.warning(
+                f"ReadMe API returned HTTP status {readme_result.status_code}; "
+                + f"pausing publishing for {BACKOFF_SECONDS} seconds"
+            )
+            start_backoff()
+
         if not readme_result.ok:
             config.LOGGER.exception(readme_result.text)
             raise Exception(f"POST to {url} returned {readme_result.status_code}")

--- a/packages/python/readme_metrics/tests/publisher_test.py
+++ b/packages/python/readme_metrics/tests/publisher_test.py
@@ -1,0 +1,109 @@
+from queue import Queue
+
+import requests_mock  # pylint: disable=unused-import
+
+from readme_metrics import MetricsApiConfig
+from readme_metrics import publisher
+
+
+mock_config = MetricsApiConfig(
+    "README_API_KEY",
+    lambda req: {"id": "123", "label": "testuser", "email": "user@email.com"},
+    buffer_length=2,
+)
+mock_config.METRICS_API = "https://readme.metrics.test"
+
+
+class TestPublisher:
+    def setUp(self):
+        pass
+
+    # pylint: disable-next=redefined-outer-name
+    def test_posts_to_readme(self, requests_mock):
+        queued_payload = {"foo": "bar"}
+        queue = Queue()
+        queue.put(queued_payload)
+
+        requests_mock.real_http = False  # disables unmocked HTTP requests
+        requests_mock.post("https://readme.metrics.test/v1/request", status_code=202)
+
+        publisher.publish_batch(mock_config, queue)
+        assert (
+            requests_mock.call_count == 1
+        ), "should POST to the ReadMe Metrics API once"
+        assert queue.qsize() == 0, "should remove the item from the queue"
+
+        request_payload = requests_mock.request_history[0].json()
+        assert len(request_payload) == 1, "payload should match the enqueued item"
+        assert (
+            request_payload[0] == queued_payload
+        ), "payload should match the enqueued item"
+
+    # pylint: disable-next=redefined-outer-name
+    def test_respects_buffer_length(self, requests_mock):
+        queued_payload_1 = {"foo": "bar1"}
+        queued_payload_2 = {"foo": "bar2"}
+        queued_payload_3 = {"foo": "bar3"}
+        queue = Queue()
+        queue.put(queued_payload_1)
+        queue.put(queued_payload_2)
+        queue.put(queued_payload_3)
+
+        requests_mock.real_http = False  # disables unmocked HTTP requests
+        requests_mock.post("https://readme.metrics.test/v1/request", status_code=202)
+
+        publisher.publish_batch(mock_config, queue)
+        assert (
+            requests_mock.call_count == 1
+        ), "should POST to the ReadMe Metrics API once"
+
+        request_payload = requests_mock.request_history[0].json()
+        assert len(request_payload) == 2, "payload size should not exceed batch_size"
+        assert (
+            queued_payload_1 in request_payload
+        ), "payload should match the first 2 enqueued items"
+        assert (
+            queued_payload_2 in request_payload
+        ), "payload should match the first 2 enqueued items"
+
+        # after 2 items were published, the third should still be enqueued
+        assert queue.qsize() == 1, "should have dequeued 2 items, leaving 1 enqueued"
+        assert (
+            queue.get_nowait() == queued_payload_3
+        ), "last item enqueued should still be in the queue"
+
+    # pylint: disable-next=redefined-outer-name
+    def test_ignores_empty_queue(self, requests_mock):
+        queue = Queue()
+
+        requests_mock.real_http = False  # disables unmocked HTTP requests
+        requests_mock.post("https://readme.metrics.test/v1/request", status_code=202)
+
+        publisher.publish_batch(mock_config, queue)
+        assert (
+            requests_mock.call_count == 0
+        ), "should not POST to ReadMe when the queue is empty"
+
+    # pylint: disable-next=redefined-outer-name
+    def test_respects_backoff(self, requests_mock):
+        queued_payload = {"foo": "bar"}
+        queue = Queue()
+
+        requests_mock.real_http = False  # disables unmocked HTTP requests
+        requests_mock.post("https://readme.metrics.test/v1/request", status_code=429)
+
+        queue.put(queued_payload)
+        publisher.publish_batch(mock_config, queue)
+        assert (
+            requests_mock.call_count == 1
+        ), "should POST to the ReadMe Metrics API once"
+        assert queue.qsize() == 0
+
+        queue.put(queued_payload)
+        queue.put(queued_payload)
+        queue.put(queued_payload)
+        publisher.publish_batch(mock_config, queue)
+        assert (
+            requests_mock.call_count == 1
+        ), "should not POST to ReadMe while backoff is enabled"
+        assert queue.qsize() == 1, "should still dequeue up to batch_size items"

--- a/packages/python/requirements.dev.txt
+++ b/packages/python/requirements.dev.txt
@@ -2,3 +2,4 @@ black==22.3.0
 pylint==2.14.5
 pytest-mock==3.6.1
 pytest==7.1.2
+requests-mock==1.10.0


### PR DESCRIPTION
## 🧰 Changes

Porting #788 to the Python SDK.


## 🧬 QA & Testing

Tested locally, confirms it backs off for 15 seconds as expected. Added unit tests for `publisher.py`, testing backoff and generally how it manages the queue.