### PR TITLE
chore(cloudflare-worker): set User-Agent on POSTs to ReadMe Metrics API

### DIFF
--- a/packages/cloudflare-worker/src/index.js
+++ b/packages/cloudflare-worker/src/index.js
@@ -123,6 +123,7 @@ module.exports.metrics = function readme(apiKey, group, req, har) {
     headers: {
       authorization: `Basic ${btoa(`${apiKey}:`)}`,
       'content-type': 'application/json',
+      'User-Agent': `@readme/cloudflare-worker@${version}`,
     },
     body: JSON.stringify([
       {


### PR DESCRIPTION
Sets the user-agent when the Cloudflare worker POSTs to the ReadMe metrics API.

It's not urgent we get this out, but I'm not familiar with how to release this.