### PR TITLE
fix: prettier-ignore virtualenv directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ packages/node/dist/
 packages/php/examples/
 packages/php/vendor/
 packages/python/.pytest_cache/
+packages/python/.venv/
 packages/sdk-snippets/src/targets/**/fixtures/
 CHANGELOG.md
 dist


### PR DESCRIPTION
| 🚥 Fixes n/a |
| :----------- |

## 🧰 Changes

- Ignore `packages/python/.venv/` because our instructions suggest creating it and prettier tries to format a whole bunch of stuff in there

## 🧬 QA & Testing

none
