### PR TITLE
fix: remove `HAS_HTTP_QUIRKS` flag from integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,12 @@ test-webhooks-php-laravel: ## Run webhooks tests against the PHP SDK + Laravel
 
 test-metrics-python-django: ## Run Metrics tests against the Python SDK + Django
 	docker-compose up --build --detach integration_metrics_python_django
-	HAS_HTTP_QUIRKS=true npm run test:integration-metrics || make cleanup-failure
+	npm run test:integration-metrics || make cleanup-failure
 	@make cleanup
 
 test-metrics-python-flask: ## Run Metrics tests against the Python SDK + Flask
 	docker-compose up --build --detach integration_python_flask_metrics
-	HAS_HTTP_QUIRKS=true npm run test:integration-metrics || make cleanup-failure
+	npm run test:integration-metrics || make cleanup-failure
 	@make cleanup
 
 test-webhooks-python-flask: ## Run webhooks tests against the Python SDK + Flask

--- a/test/integration-metrics.test.js
+++ b/test/integration-metrics.test.js
@@ -44,9 +44,12 @@ function isListening(port, attempt = 0) {
   });
 }
 
-describe('Metrics SDK Integration Tests', function () {
-  // this.retries(2);
+function sleep(ms) {
+  // eslint-disable-next-line no-promise-executor-return
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
+describe('Metrics SDK Integration Tests', function () {
   const sockets = new Set();
 
   let server;
@@ -55,24 +58,14 @@ describe('Metrics SDK Integration Tests', function () {
     body: {},
   };
 
-  async function getBody(response) {
-    let responseBody = '';
-    for await (const chunk of response) {
-      responseBody += chunk;
-    }
-
-    expect(responseBody).not.to.equal('');
-    return JSON.parse(responseBody);
-  }
-
   async function getRequest() {
-    if (process.env.HAS_HTTP_QUIRKS) {
-      return [sdkCall.req, sdkCall.body];
+    // Make sure the request has completed and the body has been
+    // parsed before returning
+    if (!sdkCall.req.complete) {
+      await sleep(300);
+      return getRequest();
     }
-
-    const [req] = await once(server, 'request');
-    const body = await getBody(req);
-    return [req, body];
+    return [sdkCall.req, sdkCall.body];
   }
 
   beforeEach(function () {
@@ -87,28 +80,18 @@ describe('Metrics SDK Integration Tests', function () {
 
     server = http
       .createServer((req, res) => {
-        // Frameworks are funny. If we run this test suite with PHP we can access our Metrics
-        // request payload via a `request` event immediately on the HTTP server however if we run
-        // this same suite with Python, the `request` event sometimes gets emitted **after** we've
-        // already returned a response and closed the connection, resulting in our request payload
-        // being empty and the SDK in question crapping out with a connection read error.
-        //
-        // This quirk doesn't make sense and this logic here is extremely yikes but hey this test
-        // suite works now across all of our SDKs and is no longer flaky.
-        if (process.env.HAS_HTTP_QUIRKS) {
-          sdkCall.req = req;
+        sdkCall.req = req;
 
-          let body = '';
-          req.on('data', chunk => {
-            body += chunk;
-          });
+        let body = '';
+        req.on('data', chunk => {
+          body += chunk;
+        });
 
-          req.on('end', () => {
-            sdkCall.body = JSON.parse(body);
-            res.writeHead(200);
-            res.end();
-          });
-        }
+        req.on('end', () => {
+          sdkCall.body = JSON.parse(body);
+          res.writeHead(200);
+          res.end();
+        });
       })
       .listen(8001, '0.0.0.0');
 


### PR DESCRIPTION
**_Cherrypicked this commit from #653, seeing if it fixes flaky integration tests_**

OK here's where this PR gets interesting... I spent a bunch of time debugging the test failures here: https://github.com/readmeio/metrics-sdks/pull/653#pullrequestreview-1309362560

I eventually settled on some code that was working, committed here: 224e2ad54c9bef641db39e650bfdc464a55c929b

But that was causing a bunch of `EOFErrors` from Ruby when sending the HTTP request out to the metrics server:

```
#<Thread:0x000000010c67e488 /Users/domh/Sites/readmeio/metrics-sdks/packages/ruby/lib/readme/request_queue.rb:30 run> terminated with exception (report_on_exception is true):
/opt/homebrew/lib/ruby/gems/3.1.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:227:in `rbuf_fill': end of file reached (EOFError)
	from /opt/homebrew/lib/ruby/gems/3.1.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:193:in `readuntil'
<long stack trace omitted>
```

It turns out that this wasn't a problem on the Ruby side, but in fact a problem from the Node.js testing side, because when not in "quirks" mode our fake metrics server happily accepted requests but just ignored them and never responded to anything.

https://github.com/readmeio/metrics-sdks/blob/7728160f522847b9a59ce7a565eca35610c6e015/test/integration-metrics.test.js#L88-L113

Some languages are okay with this (node, PHP) and some are not okay with this (python, and Ruby with rack@3.0.0 evidently).

Since it is kinda janky for us to create an HTTP server and just ignore everything and not respond with anything, I've opted to make the quirks behaviour the default with this PR! This seems to work for all languages I've tested locally but lets see if it passes for all of them on CI 🤞

I also had to add another fix here where the body was being returned empty to the test because the HTTP request from Ruby wasn't complete yet, so if we hit this race condition, I've opted to just sleep for 300ms and try again. Using this property:

https://nodejs.org/docs/latest/api/http.html#messagecomplete

Oh don't you just love HTTP.