### PR TITLE
fix(python): dont use `os.uname()`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,19 +25,24 @@ jobs:
         run: docker-compose down
 
   build:
-    runs-on: ubuntu-latest
+    name: ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: packages/python
 
     strategy:
       matrix:
+       os:
+          - ubuntu-latest
+          - windows-latest
         python-version:
           # https://endoflife.date/python
           - 3.7 # EOL: June 27th, 2023
           - 3.8 # EOL: October 14th, 2024
           - 3.9 # EOL: October 5rd, 2025
           - '3.10' # EOL: October 4rd, 2026
+          - '3.11' # EOL: October 24th, 2027
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-       os:
+        os:
           - ubuntu-latest
           - windows-latest
         python-version:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ jobs:
           - 3.8 # EOL: October 14th, 2024
           - 3.9 # EOL: October 5rd, 2025
           - '3.10' # EOL: October 4rd, 2026
-          - '3.11' # EOL: October 24th, 2027
+          # - '3.11' # EOL: October 24th, 2027
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -3,7 +3,6 @@ import importlib
 import json
 from json import JSONDecodeError
 from logging import Logger
-import os
 import platform
 import time
 
@@ -101,7 +100,7 @@ class PayloadBuilder:
             platform.machine()
             + "-"
             + platform.system().lower()
-            + os.uname().release
+            + platform.uname().release
             + "/"
             + platform.python_version()
         )


### PR DESCRIPTION
## 🧰 Changes

`os.uname()` is not available on all builds of Python[^1]. We're using this to generate the `creator.comment` field in our payloads to the Metrics API so as long as we get an *approximate* release version, which is apparently available with `platform.uname()`[^2], that should be good enough.  

I'm also expanding our Python unit test suite to run on Windows. I would like to also run our framework integration suite on Windows but that isn't going to be possible without some major overhauls to our Docker system that that utilzes. 

[^1]: https://docs.python.org/3.8/library/os.html#os.uname
[^2]: It falls back to an empty string if not available so it shouldn't break anything. https://docs.python.org/3.8/library/platform.html#platform.uname
