### PR TITLE
fix(integration): django metrics dont work when content-length header…

### DIFF
--- a/packages/python/readme_metrics/django.py
+++ b/packages/python/readme_metrics/django.py
@@ -19,8 +19,8 @@ class MetricsMiddleware:
         try:
             request.rm_start_dt = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             request.rm_start_ts = int(time.time() * 1000)
-            if request.headers["Content-Length"] or request.body:
-                request.rm_content_length = request.headers["Content-Length"] or "0"
+            if request.headers.get("Content-Length") or request.body:
+                request.rm_content_length = request.headers.get("Content-Length") or "0"
                 request.rm_body = request.body or ""
         except Exception as e:
             # Errors in the Metrics SDK should never cause the application to

--- a/packages/python/readme_metrics/tests/django_test.py
+++ b/packages/python/readme_metrics/tests/django_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 import time
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 
 from readme_metrics import MetricsApiConfig
 from readme_metrics.django import MetricsMiddleware
@@ -13,6 +13,7 @@ mock_config = MetricsApiConfig(
     buffer_length=1000,
 )
 
+
 class TestDjangoMiddleware:
     def test(self):
         response = Mock()
@@ -24,7 +25,7 @@ class TestDjangoMiddleware:
         middleware.metrics_core = Mock()
 
         request = Mock()
-        request.headers = {'Content-Length': '123'}
+        request.headers = {"Content-Length": "123"}
         middleware(request)
         # the middleware should call get_response(request)
         get_response.assert_called_once_with(request)
@@ -52,11 +53,13 @@ class TestDjangoMiddleware:
         assert call_args[0][0] == request
         assert isinstance(call_args[0][1], ResponseInfoWrapper)
         assert call_args[0][1].headers.get("X-Header") == "X Value!"
-        assert getattr(request, 'rm_content_length') == request.headers['Content-Length']
+        assert (
+            getattr(request, "rm_content_length") == request.headers["Content-Length"]
+        )
 
     def test_missing_content_length(self):
         middleware = MetricsMiddleware(Mock(), config=mock_config)
         request = Mock()
         request.headers = {}
         middleware(request)
-        assert getattr(request, 'rm_content_length') == "0"
+        assert getattr(request, "rm_content_length") == "0"


### PR DESCRIPTION
🚥 Fixes https://github.com/readmeio/metrics-sdks/issues/884

## 🧰 Changes

I changed the getting content-length header to using the `.get()` method, that return `None` if the header doesn't set.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
