### PR TITLE
fix(node): TypeError when parsing empty POST body

### DIFF
--- a/packages/node/src/lib/process-request.ts
+++ b/packages/node/src/lib/process-request.ts
@@ -157,8 +157,8 @@ export default function processRequest(
   if (mimeType === 'application/x-www-form-urlencoded') {
     postData = {
       mimeType,
-      // By being an `application/x-www-form-urlencoded` request `reqBody` will always be an object.
-      params: objectToArray(reqBody as Record<string, unknown>),
+      // `reqBody` is likely to be an object, but can be empty if no HTTP body sent
+      params: objectToArray((reqBody || {}) as Record<string, unknown>),
     };
   } else if (isApplicationJson(mimeType)) {
     postData = {

--- a/packages/node/test/lib/process-request.test.ts
+++ b/packages/node/test/lib/process-request.test.ts
@@ -29,7 +29,10 @@ function createApp(reqOptions?: LogOptions, shouldPreParse = false, bodyOverride
         body = JSON.parse(body);
       }
 
-      res.end(JSON.stringify(processRequest(req, bodyOverride || body, reqOptions)));
+      res.end(
+        // This typeof check allows us to override the body with `null`
+        JSON.stringify(processRequest(req, typeof bodyOverride !== 'undefined' ? bodyOverride : body, reqOptions))
+      );
     });
   };
 
@@ -509,6 +512,13 @@ describe('process-request', function () {
             { name: 'b', value: '2' },
           ])
         );
+    });
+
+    it('should not error with no body', function () {
+      return request(createApp({}, false, null))
+        .post('/')
+        .set('content-type', 'application/x-www-form-urlencoded')
+        .expect(res => expect(res.body.postData.params).to.deep.equal([]));
     });
 
     it('#mimeType should properly parse content-type header', function () {


### PR DESCRIPTION
| 🚥 Resolves #883 |
| :---------------- |

## 🧰 Changes

We were wrongly assuming that POST bodies will always be set for `application/x-www-form-urlencoded` requests. This fixes that!

## 🧬 QA & Testing

Do the tests pass? ✅
