### PR TITLE
fix(python): x-doc-url support wip

### DIFF
--- a/packages/python/examples/metrics_django/metrics_django/settings.py
+++ b/packages/python/examples/metrics_django/metrics_django/settings.py
@@ -132,6 +132,7 @@ README_METRICS_CONFIG = MetricsApiConfig(
     api_key=os.getenv("README_API_KEY"),
     grouping_function="metrics.views.grouping_function",
     background_worker_mode=False,
+    base_log_url="https://docs.readme.com"
     buffer_length=1,
     timeout=5,
 )

--- a/packages/python/examples/metrics_django/metrics_django/settings.py
+++ b/packages/python/examples/metrics_django/metrics_django/settings.py
@@ -132,7 +132,6 @@ README_METRICS_CONFIG = MetricsApiConfig(
     api_key=os.getenv("README_API_KEY"),
     grouping_function="metrics.views.grouping_function",
     background_worker_mode=False,
-    # base_log_url="https://example.com",
     buffer_length=1,
     timeout=5,
 )

--- a/packages/python/examples/metrics_django/metrics_django/settings.py
+++ b/packages/python/examples/metrics_django/metrics_django/settings.py
@@ -132,7 +132,7 @@ README_METRICS_CONFIG = MetricsApiConfig(
     api_key=os.getenv("README_API_KEY"),
     grouping_function="metrics.views.grouping_function",
     background_worker_mode=False,
-    base_log_url="https://docs.readme.com"
+    # base_log_url="https://example.com",
     buffer_length=1,
     timeout=5,
 )

--- a/packages/python/readme_metrics/GetProjectBaseUrl.py
+++ b/packages/python/readme_metrics/GetProjectBaseUrl.py
@@ -1,24 +1,20 @@
 import requests, base64
+from typing import Dict
 
 from functools import lru_cache
 from urllib.parse import urljoin
 
 
-def auth(readme_api_key: str):
-    encodedAuth = base64.b64encode(f"{readme_api_key}:".encode('utf8'))
+def auth(readme_api_key: str) -> Dict[str, str]:
+    encodedAuth = base64.b64encode(f"{readme_api_key}:".encode("utf8")).decode("utf8")
     return {"Authorization": f"Basic {encodedAuth}"}
 
 
 @lru_cache(maxsize=None)
-def get_project_base_url(readme_api_url: str, readme_api_key: str):
-
-    url = urljoin(readme_api_url, "/v1")
-    headers = auth(readme_api_key)
-
-    try:
-        response = requests.get(url, headers=headers, timeout=1)
-        response.raise_for_status()
-        return response.baseUrl
-    except:
-        return ""
-
+def get_project_base_url(readme_api_url: str, readme_api_key: str) -> str:
+    """returns the baseUrl for the current API key"""
+    response = requests.get(
+        urljoin(readme_api_url, "/v1"), headers=auth(readme_api_key), timeout=1
+    )
+    response.raise_for_status()
+    return response.json()["baseUrl"]

--- a/packages/python/readme_metrics/GetProjectBaseUrl.py
+++ b/packages/python/readme_metrics/GetProjectBaseUrl.py
@@ -5,8 +5,8 @@ from urllib.parse import urljoin
 
 
 def auth(readme_api_key: str):
-    encodedAuth = base64.b64encode(f"{readme_api_key}:")
-    return {"Authorization": "Basic %s" % encodedAuth}
+    encodedAuth = base64.b64encode(f"{readme_api_key}:".encode('utf8'))
+    return {"Authorization": f"Basic {encodedAuth}"}
 
 
 @lru_cache(maxsize=None)

--- a/packages/python/readme_metrics/GetProjectBaseUrl.py
+++ b/packages/python/readme_metrics/GetProjectBaseUrl.py
@@ -1,0 +1,18 @@
+import requests, base64
+
+from functools import lru_cache
+
+
+def auth(readme_api_key: str):
+    encodedAuth = base64.b64encode("%s:" % readme_api_key)
+    return {"Authorization": "Basic %s" % encodedAuth}
+
+
+@lru_cache(maxsize = 512)
+def get_project_base_url(readme_api_url: str, readme_api_key: str):
+    url = "%s/v1" % readme_api_url
+    headers = auth(readme_api_key)
+
+    project = requests.get(url, headers=headers).json()
+    return project.baseUrl
+

--- a/packages/python/readme_metrics/GetProjectBaseUrl.py
+++ b/packages/python/readme_metrics/GetProjectBaseUrl.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 import base64
 import requests
 
+
 def auth(readme_api_key: str) -> Dict[str, str]:
     encodedAuth = base64.b64encode(f"{readme_api_key}:".encode("utf8")).decode("utf8")
     return {"Authorization": f"Basic {encodedAuth}"}
@@ -13,14 +14,15 @@ def auth(readme_api_key: str) -> Dict[str, str]:
 
 @lru_cache(maxsize=None)
 def get_project_base_url(
-    readme_api_url: str, readme_api_key: str,
-    timeout: int, logger: Logger
+    readme_api_url: str, readme_api_key: str, timeout: int, logger: Logger
 ) -> str:
     """returns the baseUrl for the current API key"""
 
     try:
         response = requests.get(
-            urljoin(readme_api_url, "/v1"), headers=auth(readme_api_key), timeout=timeout
+            urljoin(readme_api_url, "/v1"),
+            headers=auth(readme_api_key),
+            timeout=timeout,
         )
         response.raise_for_status()
         return response.json()["baseUrl"]

--- a/packages/python/readme_metrics/GetProjectBaseUrl.py
+++ b/packages/python/readme_metrics/GetProjectBaseUrl.py
@@ -1,18 +1,24 @@
 import requests, base64
 
 from functools import lru_cache
+from urllib.parse import urljoin
 
 
 def auth(readme_api_key: str):
-    encodedAuth = base64.b64encode("%s:" % readme_api_key)
+    encodedAuth = base64.b64encode(f"{readme_api_key}:")
     return {"Authorization": "Basic %s" % encodedAuth}
 
 
-@lru_cache(maxsize = 512)
+@lru_cache(maxsize=None)
 def get_project_base_url(readme_api_url: str, readme_api_key: str):
-    url = "%s/v1" % readme_api_url
+
+    url = urljoin(readme_api_url, "/v1")
     headers = auth(readme_api_key)
 
-    project = requests.get(url, headers=headers).json()
-    return project.baseUrl
+    try:
+        response = requests.get(url, headers=headers, timeout=1)
+        response.raise_for_status()
+        return response.baseUrl
+    except:
+        return ""
 

--- a/packages/python/readme_metrics/GetProjectBaseUrl.py
+++ b/packages/python/readme_metrics/GetProjectBaseUrl.py
@@ -17,6 +17,7 @@ def build_project_base_url_f(
 ) -> Callable[[str], str]:
     """returns a function that takes an API key and returns the baseUrl for
     that key"""
+
     @lru_cache(maxsize=512)
     def _build_project_base_url_f(readme_api_key):
         try:

--- a/packages/python/readme_metrics/GetProjectBaseUrl.py
+++ b/packages/python/readme_metrics/GetProjectBaseUrl.py
@@ -1,9 +1,10 @@
-import requests, base64
-from typing import Dict
-
 from functools import lru_cache
+from logging import Logger
+from typing import Dict
 from urllib.parse import urljoin
 
+import base64
+import requests
 
 def auth(readme_api_key: str) -> Dict[str, str]:
     encodedAuth = base64.b64encode(f"{readme_api_key}:".encode("utf8")).decode("utf8")
@@ -11,10 +12,18 @@ def auth(readme_api_key: str) -> Dict[str, str]:
 
 
 @lru_cache(maxsize=None)
-def get_project_base_url(readme_api_url: str, readme_api_key: str) -> str:
+def get_project_base_url(
+    readme_api_url: str, readme_api_key: str,
+    timeout: int, logger: Logger
+) -> str:
     """returns the baseUrl for the current API key"""
-    response = requests.get(
-        urljoin(readme_api_url, "/v1"), headers=auth(readme_api_key), timeout=1
-    )
-    response.raise_for_status()
-    return response.json()["baseUrl"]
+
+    try:
+        response = requests.get(
+            urljoin(readme_api_url, "/v1"), headers=auth(readme_api_key), timeout=timeout
+        )
+        response.raise_for_status()
+        return response.json()["baseUrl"]
+    except Exception as e:
+        logger.debug(e)
+        return ""

--- a/packages/python/readme_metrics/GetProjectBaseUrl.py
+++ b/packages/python/readme_metrics/GetProjectBaseUrl.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 from logging import Logger
-from typing import Dict
+from typing import Dict, Callable
 from urllib.parse import urljoin
 
 import base64
@@ -12,20 +12,23 @@ def auth(readme_api_key: str) -> Dict[str, str]:
     return {"Authorization": f"Basic {encodedAuth}"}
 
 
-@lru_cache(maxsize=None)
-def get_project_base_url(
-    readme_api_url: str, readme_api_key: str, timeout: int, logger: Logger
-) -> str:
-    """returns the baseUrl for the current API key"""
+def build_project_base_url_f(
+    readme_api_url: str, timeout: int, logger: Logger
+) -> Callable[[str], str]:
+    """returns a function that takes an API key and returns the baseUrl for
+    that key"""
+    @lru_cache(maxsize=512)
+    def _build_project_base_url_f(readme_api_key):
+        try:
+            response = requests.get(
+                urljoin(readme_api_url, "/v1"),
+                headers=auth(readme_api_key),
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return response.json()["baseUrl"]
+        except Exception as e:
+            logger.debug(e)
+            return ""
 
-    try:
-        response = requests.get(
-            urljoin(readme_api_url, "/v1"),
-            headers=auth(readme_api_key),
-            timeout=timeout,
-        )
-        response.raise_for_status()
-        return response.json()["baseUrl"]
-    except Exception as e:
-        logger.debug(e)
-        return ""
+    return _build_project_base_url_f

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -4,11 +4,13 @@ import queue
 import threading
 import traceback
 import importlib
+import uuid
 
 from readme_metrics import MetricsApiConfig
 from readme_metrics.publisher import publish_batch
 from readme_metrics.PayloadBuilder import PayloadBuilder
 from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
+from readme_metrics.GetProjectBaseUrl import get_project_base_url
 
 
 class Metrics:
@@ -63,7 +65,12 @@ class Metrics:
             return
 
         try:
-            payload = self.payload_builder(request, response)
+            base_url = self.config.BASE_LOG_URL or get_project_base_url(self.config.README_API_URL, self.config.README_API_KEY)
+            logId = str(uuid.uuid4())
+
+            response.headers['x-documentation-url'] = f"{base_url}/logs/{logId}"
+
+            payload = self.payload_builder(request, response, logId)
             if payload is None:
                 # PayloadBuilder returns None when the grouping function returns
                 # None (an indication that the request should not be logged.)

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -10,7 +10,7 @@ from readme_metrics import MetricsApiConfig
 from readme_metrics.publisher import publish_batch
 from readme_metrics.PayloadBuilder import PayloadBuilder
 from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
-from readme_metrics.GetProjectBaseUrl import get_project_base_url
+from readme_metrics.GetProjectBaseUrl import build_project_base_url_f
 
 
 class Metrics:
@@ -39,6 +39,11 @@ class Metrics:
         else:
             self.grouping_function = self.config.GROUPING_FUNCTION
 
+        self.get_project_base_url = build_project_base_url_f(
+            self.config.README_API_URL,
+            self.config.METRICS_API_TIMEOUT,
+            self.config.LOGGER,
+        )
         self.payload_builder = PayloadBuilder(
             config.DENYLIST,
             config.ALLOWLIST,
@@ -68,11 +73,8 @@ class Metrics:
             # Generate logId for enqueued API log and documentation URL generation
             logId = str(uuid.uuid4())
             # Reference base_url from config, or from ReadMe project metadata
-            base_url = self.config.BASE_LOG_URL or get_project_base_url(
-                self.config.README_API_URL,
+            base_url = self.config.BASE_LOG_URL or self.get_project_base_url(
                 self.config.README_API_KEY,
-                self.config.METRICS_API_TIMEOUT,
-                self.config.LOGGER,
             )
             # Construct header link from base_url and logId
             response.headers["x-documentation-url"] = f"{base_url}/logs/{logId}"

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -65,9 +65,16 @@ class Metrics:
             return
 
         try:
-            base_url = self.config.BASE_LOG_URL or get_project_base_url(self.config.README_API_URL, self.config.README_API_KEY)
+            # Generate logId for enqueued API log and documentation URL generation
             logId = str(uuid.uuid4())
-
+            # Reference base_url from config, or from ReadMe project metadata
+            base_url = self.config.BASE_LOG_URL or get_project_base_url(
+                self.config.README_API_URL,
+                self.config.README_API_KEY,
+                self.config.METRICS_API_TIMEOUT,
+                self.config.LOGGER
+            )
+            # Construct header link from base_url and logId
             response.headers['x-documentation-url'] = f"{base_url}/logs/{logId}"
 
             payload = self.payload_builder(request, response, logId)

--- a/packages/python/readme_metrics/Metrics.py
+++ b/packages/python/readme_metrics/Metrics.py
@@ -72,10 +72,10 @@ class Metrics:
                 self.config.README_API_URL,
                 self.config.README_API_KEY,
                 self.config.METRICS_API_TIMEOUT,
-                self.config.LOGGER
+                self.config.LOGGER,
             )
             # Construct header link from base_url and logId
-            response.headers['x-documentation-url'] = f"{base_url}/logs/{logId}"
+            response.headers["x-documentation-url"] = f"{base_url}/logs/{logId}"
 
             payload = self.payload_builder(request, response, logId)
             if payload is None:

--- a/packages/python/readme_metrics/MetricsApiConfig.py
+++ b/packages/python/readme_metrics/MetricsApiConfig.py
@@ -15,6 +15,7 @@ class MetricsApiConfig:
             "label" and "email" fields.
 
             The main purpose of the identity object is to identify the API's caller.
+        BASE_LOG_URL (str): URL for your documentation site
         BUFFER_LENGTH (int): Number of requests to buffer before sending data
             to ReadMe. Defaults to 1.
         IS_DEVELOPMENT_MODE (bool): Determines whether you are running in
@@ -31,6 +32,7 @@ class MetricsApiConfig:
             If this option is configured, ONLY the allowlisted properties will be sent.
         ALLOWED_HTTP_HOSTS (List[str]): A list of allowed http hosts for sending
             data to the ReadMe API.
+        README_API_URL (str): Base URL of ReadMe's documentation API
         METRICS_API (str): Base URL of the ReadMe metrics API.
         METRICS_API_TIMEOUT (int): Timeout (in seconds) for metrics API calls.
         LOGGER (logging.Logger): Logger used by all classes and methods in the
@@ -42,6 +44,7 @@ class MetricsApiConfig:
     """
 
     README_API_KEY: str = None
+    BASE_LOG_URL: str = None
     BUFFER_LENGTH: int = 1
     GROUPING_FUNCTION: Callable[[Any], None] = lambda req: None
     IS_DEVELOPMENT_MODE: bool = False
@@ -49,6 +52,7 @@ class MetricsApiConfig:
     DENYLIST: List[str] = []
     ALLOWLIST: List[str] = []
     ALLOWED_HTTP_HOSTS: List[str] = []
+    README_API_URL: str = "https://dash.readme.com/api"
     METRICS_API: str = "https://metrics.readme.io"
     METRICS_API_TIMEOUT: int = 3
 
@@ -56,6 +60,7 @@ class MetricsApiConfig:
         self,
         api_key: str,
         grouping_function,
+        base_log_url: str = None,
         buffer_length: int = 1,
         development_mode: bool = False,
         background_worker_mode: bool = True,
@@ -80,6 +85,7 @@ class MetricsApiConfig:
                 You can optionally pass the path of the function to the MetricsApiConfig
                 constructor, in which case it will automatically be resolved and imported
                 when this object is initialized.
+            base_log_url (str): URL for your documentation site
             buffer_length (int, optional): Number of requests to buffer before sending
                 data to ReadMe. Defaults to 1.
             development_mode (bool, optional): Determines whether you are running in
@@ -112,6 +118,7 @@ class MetricsApiConfig:
         """
         self.README_API_KEY = api_key
         self.GROUPING_FUNCTION = grouping_function
+        self.BASE_LOG_URL = base_log_url
         self.BUFFER_LENGTH = buffer_length
         self.IS_DEVELOPMENT_MODE = development_mode
         self.IS_BACKGROUND_MODE = background_worker_mode

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -57,7 +57,7 @@ class PayloadBuilder:
         self.grouping_function = grouping_function
         self.logger = logger
 
-    def __call__(self, request, response: ResponseInfoWrapper, logId) -> dict:
+    def __call__(self, request, response: ResponseInfoWrapper, logId: str) -> Optional[dict]:
         """Builds a HAR payload encompassing the request & response data
 
         Args:

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -57,7 +57,9 @@ class PayloadBuilder:
         self.grouping_function = grouping_function
         self.logger = logger
 
-    def __call__(self, request, response: ResponseInfoWrapper, logId: str) -> Optional[dict]:
+    def __call__(
+        self, request, response: ResponseInfoWrapper, logId: str
+    ) -> Optional[dict]:
         """Builds a HAR payload encompassing the request & response data
 
         Args:

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -8,8 +8,6 @@ import time
 
 from typing import List, Optional
 from urllib import parse
-import uuid
-
 from readme_metrics import ResponseInfoWrapper
 
 
@@ -59,7 +57,7 @@ class PayloadBuilder:
         self.grouping_function = grouping_function
         self.logger = logger
 
-    def __call__(self, request, response: ResponseInfoWrapper) -> dict:
+    def __call__(self, request, response: ResponseInfoWrapper, logId) -> dict:
         """Builds a HAR payload encompassing the request & response data
 
         Args:
@@ -76,7 +74,7 @@ class PayloadBuilder:
             return None
 
         payload = {
-            "_id": str(uuid.uuid4()),
+            "_id": logId,
             "group": group,
             "clientIPAddress": request.environ.get("REMOTE_ADDR"),
             "development": self.development_mode,

--- a/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
+++ b/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
@@ -51,11 +51,11 @@ def fixture_readme_api_v1_http_error(monkeypatch):
     )
 
 
-def test_get_project_base_url(readme_api_v1_success):
+def test_get_project_base_url(readme_api_v1_success): # pylint: disable=unused-argument
     assert get_project_base_url("", "secretkey", 3, FakeLogger) == "https://zombo.com"
 
 
-def test_get_project_base_url_exception(readme_api_v1_http_error):
+def test_get_project_base_url_exception(readme_api_v1_http_error): # pylint: disable=unused-argument
     try:
         get_project_base_url("", "secretkey", 3, FakeLogger)
         assert False

--- a/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
+++ b/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 import pytest
 import requests
 
@@ -38,6 +36,22 @@ class MockResponse:
         return
 
 
+def FakeLogger():
+    return
+
+
+def test_get_project_base_url(readme_api_v1_success):
+    assert get_project_base_url("", "secretkey", 3, FakeLogger) == "https://zombo.com"
+
+
+def test_get_project_base_url_exception(readme_api_v1_http_error):
+    try:
+        get_project_base_url("", "secretkey", 3, FakeLogger)
+        assert False
+    except: # pylint: disable=bare-except
+        # Do nothing
+
+
 @pytest.fixture
 def readme_api_v1_success(monkeypatch):
     monkeypatch.setattr(requests, "get", lambda *_, **__: MockResponse())
@@ -48,15 +62,3 @@ def readme_api_v1_http_error(monkeypatch):
     monkeypatch.setattr(
         requests, "get", lambda *_, **__: MockResponse(throw=requests.HTTPError)
     )
-
-
-def test_get_project_base_url(readme_api_v1_success):
-    assert get_project_base_url("", "secretkey") == "https://zombo.com"
-
-
-def test_get_project_base_url_exception(readme_api_v1_http_error):
-    try:
-        get_project_base_url("", "secretkey")
-        assert False
-    except:
-        return

--- a/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
+++ b/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
@@ -51,11 +51,13 @@ def fixture_readme_api_v1_http_error(monkeypatch):
     )
 
 
-def test_get_project_base_url(readme_api_v1_success): # pylint: disable=unused-argument
+def test_get_project_base_url(readme_api_v1_success):  # pylint: disable=unused-argument
     assert get_project_base_url("", "secretkey", 3, FakeLogger) == "https://zombo.com"
 
 
-def test_get_project_base_url_exception(readme_api_v1_http_error): # pylint: disable=unused-argument
+def test_get_project_base_url_exception(
+    readme_api_v1_http_error,
+):  # pylint: disable=unused-argument
     try:
         get_project_base_url("", "secretkey", 3, FakeLogger)
         assert False

--- a/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
+++ b/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 
-from readme_metrics.GetProjectBaseUrl import auth,build_project_base_url_f 
+from readme_metrics.GetProjectBaseUrl import auth, build_project_base_url_f
 
 
 def test_auth():
@@ -52,7 +52,9 @@ def fixture_readme_api_v1_http_error(monkeypatch):
 
 
 def test_get_project_base_url(readme_api_v1_success):  # pylint: disable=unused-argument
-    assert build_project_base_url_f("", 3, FakeLogger)("secretkey") == "https://zombo.com"
+    assert (
+        build_project_base_url_f("", 3, FakeLogger)("secretkey") == "https://zombo.com"
+    )
 
 
 def test_get_project_base_url_exception(

--- a/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
+++ b/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
@@ -33,11 +33,22 @@ class MockResponse:
     def raise_for_status(self):
         if self.throw:
             raise self.throw("oh no")
-        return
 
 
 def FakeLogger():
     return
+
+
+@pytest.fixture(name="readme_api_v1_success")
+def fixture_readme_api_v1_success(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda *_, **__: MockResponse())
+
+
+@pytest.fixture(name="readme_api_v1_http_error")
+def fixture_readme_api_v1_http_error(monkeypatch):
+    monkeypatch.setattr(
+        requests, "get", lambda *_, **__: MockResponse(throw=requests.HTTPError)
+    )
 
 
 def test_get_project_base_url(readme_api_v1_success):
@@ -48,17 +59,5 @@ def test_get_project_base_url_exception(readme_api_v1_http_error):
     try:
         get_project_base_url("", "secretkey", 3, FakeLogger)
         assert False
-    except: # pylint: disable=bare-except
-        # Do nothing
-
-
-@pytest.fixture
-def readme_api_v1_success(monkeypatch):
-    monkeypatch.setattr(requests, "get", lambda *_, **__: MockResponse())
-
-
-@pytest.fixture
-def readme_api_v1_http_error(monkeypatch):
-    monkeypatch.setattr(
-        requests, "get", lambda *_, **__: MockResponse(throw=requests.HTTPError)
-    )
+    except Exception:
+        assert True

--- a/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
+++ b/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
@@ -1,0 +1,63 @@
+from typing import List, Tuple
+
+import pytest
+import requests
+
+from readme_metrics.GetProjectBaseUrl import auth, get_project_base_url
+
+
+def test_auth():
+    # b'Og=='
+    tests = [
+        ("", "Og=="),
+        ("some_api_key", "c29tZV9hcGlfa2V5Og=="),
+    ]
+
+    for inp, expected in tests:
+        assert auth(inp)["Authorization"] == f"Basic {expected}"
+
+
+class MockResponse:
+    def __init__(self, throw=None):
+        self.throw = throw
+
+    @staticmethod
+    def json():
+        return {
+            "name": "ReadMe",
+            "subdomain": "abelincoln",
+            "jwtSecret": "abcdefghijklmnopqrstuvwxyz",
+            "baseUrl": "https://zombo.com",
+            "plan": "enterprise",
+            "metrics": {"limit": 50000000},
+            "token": "token",
+        }
+
+    def raise_for_status(self):
+        if self.throw:
+            raise self.throw("oh no")
+        return
+
+
+@pytest.fixture
+def readme_api_v1_success(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda *_, **__: MockResponse())
+
+
+@pytest.fixture
+def readme_api_v1_http_error(monkeypatch):
+    monkeypatch.setattr(
+        requests, "get", lambda *_, **__: MockResponse(throw=requests.HTTPError)
+    )
+
+
+def test_get_project_base_url(readme_api_v1_success):
+    assert get_project_base_url("", "secretkey") == "https://zombo.com"
+
+
+def test_get_project_base_url_exception(readme_api_v1_http_error):
+    try:
+        get_project_base_url("", "secretkey")
+        assert False
+    except:
+        return

--- a/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
+++ b/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 
-from readme_metrics.GetProjectBaseUrl import auth, get_project_base_url
+from readme_metrics.GetProjectBaseUrl import auth,build_project_base_url_f 
 
 
 def test_auth():
@@ -52,14 +52,14 @@ def fixture_readme_api_v1_http_error(monkeypatch):
 
 
 def test_get_project_base_url(readme_api_v1_success):  # pylint: disable=unused-argument
-    assert get_project_base_url("", "secretkey", 3, FakeLogger) == "https://zombo.com"
+    assert build_project_base_url_f("", 3, FakeLogger)("secretkey") == "https://zombo.com"
 
 
 def test_get_project_base_url_exception(
     readme_api_v1_http_error,
 ):  # pylint: disable=unused-argument
     try:
-        get_project_base_url("", "secretkey", 3, FakeLogger)
+        build_project_base_url_f("", 3, FakeLogger)("secretkey")
         assert False
     except Exception:
-        assert True
+        pass

--- a/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
+++ b/packages/python/readme_metrics/tests/GetProjectBaseUrl_test.py
@@ -7,7 +7,6 @@ from readme_metrics.GetProjectBaseUrl import auth, get_project_base_url
 
 
 def test_auth():
-    # b'Og=='
     tests = [
         ("", "Og=="),
         ("some_api_key", "c29tZV9hcGlfa2V5Og=="),

--- a/packages/python/readme_metrics/tests/Metrics_test.py
+++ b/packages/python/readme_metrics/tests/Metrics_test.py
@@ -9,6 +9,7 @@ from readme_metrics import MetricsApiConfig
 from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
 from .fixtures import Environ
 
+
 def mock_request():
     body = json.dumps({"ok": 123, "password": 456}).encode()
     environ = Environ.MockEnviron().getEnvironForRequest(body, "POST")
@@ -17,6 +18,7 @@ def mock_request():
     req.rm_start_ts = int(time.time() * 1000)
     req.rm_body = body
     return req
+
 
 class TestMetrics:
     def test_grouping_function_import(self):

--- a/packages/python/readme_metrics/tests/Metrics_test.py
+++ b/packages/python/readme_metrics/tests/Metrics_test.py
@@ -1,12 +1,53 @@
+import datetime
+import json
+import time
 import types
 
-from readme_metrics.Metrics import Metrics
+from readme_metrics import Metrics
 from readme_metrics import MetricsApiConfig
+from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
+from .fixtures import Environ
 
+from werkzeug import Request
+
+def mock_request():
+    body = json.dumps({"ok": 123, "password": 456}).encode()
+    environ = Environ.MockEnviron().getEnvironForRequest(body, "POST")
+    req = Request(environ)
+    req.rm_start_dt = str(datetime.datetime.utcnow())
+    req.rm_start_ts = int(time.time() * 1000)
+    req.rm_body = body
+    return req
 
 class TestMetrics:
     def test_grouping_function_import(self):
         config = MetricsApiConfig(api_key=123456, grouping_function="json.loads")
         assert isinstance(config.GROUPING_FUNCTION, str)
-        metrics = Metrics(config)
+        metrics = Metrics.Metrics(config)
         assert isinstance(metrics.grouping_function, types.FunctionType)
+
+    def test_base_log_url(self):
+        # don't publish batch
+        old_publish_batch = Metrics.publish_batch
+        Metrics.publish_batch = lambda *_: None
+
+        # configure Metrics
+        base_log_url = "https://example.com"
+        config = MetricsApiConfig(
+            api_key="123456",
+            base_log_url=base_log_url,
+            grouping_function=lambda *_: {"id": "123456"},
+            background_worker_mode=False,
+        )
+        metrics = Metrics.Metrics(config)
+
+        res = ResponseInfoWrapper({}, 200, "application/json", 2, "{}")
+        metrics.process(mock_request(), res)
+
+        assert "x-documentation-url" in res.headers
+        assert res.headers["x-documentation-url"].startswith(f"{base_log_url}/logs/")
+        assert len(res.headers["x-documentation-url"]) == (
+            len(f"{base_log_url}/logs/") + 36
+        )
+
+        Metrics.publish_batch = old_publish_batch

--- a/packages/python/readme_metrics/tests/Metrics_test.py
+++ b/packages/python/readme_metrics/tests/Metrics_test.py
@@ -3,12 +3,11 @@ import json
 import time
 import types
 
+from werkzeug import Request
 from readme_metrics import Metrics
 from readme_metrics import MetricsApiConfig
 from readme_metrics.ResponseInfoWrapper import ResponseInfoWrapper
 from .fixtures import Environ
-
-from werkzeug import Request
 
 def mock_request():
     body = json.dumps({"ok": 123, "password": 456}).encode()

--- a/packages/python/readme_metrics/tests/PayloadBuilder_test.py
+++ b/packages/python/readme_metrics/tests/PayloadBuilder_test.py
@@ -91,7 +91,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
         text = data["request"]["log"]["entries"][0]["request"]["postData"]["text"]
 
         assert text == '{"ok": 123, "password": "[REDACTED]"}'
@@ -110,7 +110,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
         text = data["request"]["log"]["entries"][0]["request"]["postData"]["text"]
 
         assert text == '{"ok": 123, "password": "[REDACTED]"}'
@@ -129,7 +129,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
         text = data["request"]["log"]["entries"][0]["request"]["postData"]["text"]
 
         assert "ok" in text
@@ -152,7 +152,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
         text = data["request"]["log"]["entries"][0]["request"]["postData"]["text"]
 
         assert "ok" in text
@@ -180,7 +180,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
         group = data["group"]
 
         assert group["id"] == "spam"
@@ -202,7 +202,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload_builder = self.createPayload(config)
-        payload = payload_builder(metrics.req, metrics.res)
+        payload = payload_builder(metrics.req, metrics.res, uuid.uuid4())
 
         assert payload is None
 
@@ -225,7 +225,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
         group = data["group"]
 
         assert group["id"] == "spam"
@@ -250,7 +250,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
 
         # When the `id` and `api_key` fields are both missing, the payload should be `None`
         assert data is None
@@ -277,7 +277,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
 
         assert isinstance(data, dict)
         assert "group" in data
@@ -309,7 +309,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
 
         assert data["_id"] == str(uuid.UUID(data["_id"], version=4))
 
@@ -326,7 +326,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload = self.createPayload(config)
-        data = payload(metrics.req, metrics.res)
+        data = payload(metrics.req, metrics.res, str(uuid.uuid4()))
         creator = data["request"]["log"]["creator"]
 
         assert creator["name"] == "readme-metrics (python)"

--- a/packages/python/readme_metrics/tests/PayloadBuilder_test.py
+++ b/packages/python/readme_metrics/tests/PayloadBuilder_test.py
@@ -202,7 +202,7 @@ class TestPayloadBuilder:
         next(middleware(environ, app.mockStartResponse))
 
         payload_builder = self.createPayload(config)
-        payload = payload_builder(metrics.req, metrics.res, uuid.uuid4())
+        payload = payload_builder(metrics.req, metrics.res, str(uuid.uuid4()))
 
         assert payload is None
 

--- a/test/integration-metrics.test.js
+++ b/test/integration-metrics.test.js
@@ -197,6 +197,25 @@ describe('Metrics SDK Integration Tests', function () {
     expect(response.content.mimeType).toMatch(/application\/json(;\s?charset=utf-8)?/);
   });
 
+  it.only('should include an _id UUID in har payload', async function () {
+    await fetch(`http://localhost:${PORT}`, { method: 'get' });
+
+    const [, body] = await getRequest();
+    const [har] = body;
+    expect(typeof har._id).toBe('string');
+  });
+
+  it.only('should add `x-documentation-url` to response headers', async function () {
+    await fetch(`http://localhost:${PORT}`, { method: 'get' });
+
+    const [, body] = await getRequest();
+    const [har] = body;
+
+    const { response } = har.request.log.entries[0];
+    const docHeader = response.headers.find(h => h.name.toLowerCase() === 'x-documentation-url');
+    expect(docHeader.value).toContain('/logs');
+  });
+
   it('should mask `Authorization` headers', async function () {
     const authorizationHeader = 'Bearer: a-random-api-key';
     function getAuthorizationHeader() {

--- a/test/integration-metrics.test.js
+++ b/test/integration-metrics.test.js
@@ -205,7 +205,7 @@ describe('Metrics SDK Integration Tests', function () {
     expect(typeof har._id).toBe('string');
   });
 
-  it('should add `x-documentation-url` to response headers', async function () {
+  it.todo('should add `x-documentation-url` to response headers', async function () {
     await fetch(`http://localhost:${PORT}`, { method: 'get' });
 
     const [, body] = await getRequest();

--- a/test/integration-metrics.test.js
+++ b/test/integration-metrics.test.js
@@ -205,7 +205,7 @@ describe('Metrics SDK Integration Tests', function () {
     expect(typeof har._id).toBe('string');
   });
 
-  it.only('should add `x-documentation-url` to response headers', async function () {
+  it('should add `x-documentation-url` to response headers', async function () {
     await fetch(`http://localhost:${PORT}`, { method: 'get' });
 
     const [, body] = await getRequest();

--- a/test/integration-metrics.test.js
+++ b/test/integration-metrics.test.js
@@ -197,7 +197,7 @@ describe('Metrics SDK Integration Tests', function () {
     expect(response.content.mimeType).toMatch(/application\/json(;\s?charset=utf-8)?/);
   });
 
-  it.only('should include an _id UUID in har payload', async function () {
+  it('should include an _id UUID in har payload', async function () {
     await fetch(`http://localhost:${PORT}`, { method: 'get' });
 
     const [, body] = await getRequest();


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

Adding support in Python for a new configuration option, `base_log_url` (e.g. "docs.example.com"), which is consumed to append a new response header, `x-documentation-url` (e.g. "docs.example.com/logs/${UUID}").  

This configuration option is supported across all other SDKs, accept for Ruby, currently. It's used both to generate a direct link to the log that ReadMe's metrics SDK has just captured, as well as to prevent double log insertion when a request is made via "Try-It" in a documentation site.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
