### PR TITLE
fix(php): open_basedir restriction

### DIFF
--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -80,7 +80,7 @@ class Metrics
         ]);
 
         $this->package_version = InstalledVersions::getVersion(self::PACKAGE_NAME);
-        $this->user_agent = 'readme-metrics-php/' . $this->package_version ?? 'unknown';
+        $this->user_agent = 'readme-metrics-php/' . ($this->package_version ?? 'unknown');
     }
 
     /**

--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -80,6 +80,7 @@ class Metrics
         ]);
 
         $this->package_version = InstalledVersions::getVersion(self::PACKAGE_NAME);
+
         $this->user_agent = 'readme-metrics-php/' . ($this->package_version ?? 'unknown');
     }
 

--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -29,7 +29,7 @@ class Metrics
     private Client $readme_api_client;
 
     private string|null $package_version;
-    private string $cache_dir;
+    private string|null $cache_dir;
     private string $user_agent;
 
     /**
@@ -80,6 +80,7 @@ class Metrics
         ]);
 
         $this->package_version = InstalledVersions::getVersion(self::PACKAGE_NAME);
+        $this->cache_dir = null;
 
         $this->user_agent = 'readme-metrics-php/' . ($this->package_version ?? 'unknown');
     }
@@ -150,7 +151,8 @@ class Metrics
             // for the user.
             return;
         }
-
+        
+        /** @psalm-suppress PossiblyInvalidArgument */
         $ex = new MetricsException(str_replace($json->_message, $json->name, $json->message));
         $ex->setErrors((array)$json->errors);
         throw $ex;
@@ -254,7 +256,7 @@ class Metrics
      */
     public function getCacheDir(): string
     {
-        if (!$this->cache_dir) {
+        if ($this->cache_dir === null) {
             $this->cache_dir = Factory::createConfig()->get('cache-dir');
         }
 

--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -151,7 +151,7 @@ class Metrics
             // for the user.
             return;
         }
-        
+
         /** @psalm-suppress PossiblyInvalidArgument */
         $ex = new MetricsException(str_replace($json->_message, $json->name, $json->message));
         $ex->setErrors((array)$json->errors);

--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -80,9 +80,7 @@ class Metrics
         ]);
 
         $this->package_version = InstalledVersions::getVersion(self::PACKAGE_NAME);
-        $this->cache_dir = Factory::createConfig()->get('cache-dir');
-
-        $this->user_agent = 'readme-metrics-php/' . ($this->package_version ?? 'unknown');
+        $this->user_agent = 'readme-metrics-php/' . $this->package_version ?? 'unknown';
     }
 
     /**
@@ -152,7 +150,6 @@ class Metrics
             return;
         }
 
-        /** @psalm-suppress PossiblyInvalidArgument */
         $ex = new MetricsException(str_replace($json->_message, $json->name, $json->message));
         $ex->setErrors((array)$json->errors);
         throw $ex;
@@ -247,7 +244,20 @@ class Metrics
         // Replace potentially unsafe characters in the cache key so it can be safely used as a filename on the server.
         $cache_key = str_replace([DIRECTORY_SEPARATOR, '@'], '-', $cache_key);
 
-        return $this->cache_dir . DIRECTORY_SEPARATOR . $cache_key;
+        return $this->getCacheDir() . DIRECTORY_SEPARATOR . $cache_key;
+    }
+
+    /**
+     * Retrieve the cache dir where the cache file will be stored.
+     *
+     */
+    public function getCacheDir(): string
+    {
+        if (!$this->cache_dir) {
+            $this->cache_dir = Factory::createConfig()->get('cache-dir');
+        }
+
+        return $this->cache_dir;
     }
 
     public function getPackageVersion(): ?string


### PR DESCRIPTION
| 🚥 Resolves #943 |
| :------------------- |

## 🧰 Changes

The composer config is only used to cache the `base_log_url`. If the `open_basedir` can't be changed within the php.ini configuration (like for [serversideup docker images](https://hub.docker.com/r/serversideup/php)) the package can't be used.

## 🧬 QA & Testing
I've tested the changes with my own and the example application.
