### PR TITLE
(feat) Add hashing of sensitive data to the Ruby gem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,11 @@ test-webhooks-python-flask: ## Run webhooks tests against the Python SDK + Flask
 test-metrics-ruby-rails: ## Run Metrics tests against the Ruby SDK + Rails
 	docker-compose up --build --detach integration_ruby_rails
 	sleep 5
-	npm run test:integration-metrics || make cleanup-failure
+	SUPPORTS_HASHING=true npm run test:integration-metrics || make cleanup-failure
 	@make cleanup
 
 test-webhooks-ruby-rails: ## Run webhooks tests against the Ruby SDK + Rails
 	docker-compose up --build --detach integration_ruby_rails
 	sleep 5
-	npm run test:integration-webhooks || make cleanup-failure
+	SUPPORTS_HASHING=true npm run test:integration-webhooks || make cleanup-failure
 	@make cleanup

--- a/packages/ruby/lib/readme/http_request.rb
+++ b/packages/ruby/lib/readme/http_request.rb
@@ -1,3 +1,4 @@
+require 'readme/mask'
 require 'rack'
 require 'rack/request'
 require_relative 'content_type_helper'
@@ -25,7 +26,12 @@ module Readme
     HTTP_NON_HEADERS.freeze
 
     def initialize(env)
+      # Sanitize the auth header, if it exists
+      if env.has_key?("HTTP_AUTHORIZATION")
+        env["HTTP_AUTHORIZATION"] = Readme::Mask.mask(env["HTTP_AUTHORIZATION"])
+      end
       @request = Rack::Request.new(env)
+
       return unless IS_RACK_V3
 
       @input = Rack::RewindableInput.new(@request.body)

--- a/packages/ruby/lib/readme/mask.rb
+++ b/packages/ruby/lib/readme/mask.rb
@@ -1,0 +1,11 @@
+require 'digest'
+
+module Readme
+    class Mask
+        def self.mask(data)
+            digest = Digest::SHA2.new(512).base64digest(data)
+            opts = data.length >= 4 ? data[-4,4] : data
+            "sha512-#{digest}?#{opts}"
+        end
+    end
+end

--- a/packages/ruby/lib/readme/payload.rb
+++ b/packages/ruby/lib/readme/payload.rb
@@ -1,3 +1,4 @@
+require 'readme/mask'
 require 'socket'
 require 'securerandom'
 
@@ -15,6 +16,7 @@ module Readme
       @har = har
       @user_info = info.slice(:id, :label, :email)
       @user_info[:id] = info[:api_key] unless info[:api_key].nil? # swap api_key for id if api_key is present
+      @user_info[:id] = Readme::Mask.mask(@user_info[:id])
       @log_id = info[:log_id]
       @ignore = info[:ignore]
       @ip_address = ip_address

--- a/packages/ruby/spec/readme/payload_spec.rb
+++ b/packages/ruby/spec/readme/payload_spec.rb
@@ -1,5 +1,7 @@
 require 'readme/payload'
+require 'readme/mask'
 require 'socket'
+require 'json'
 require 'securerandom'
 
 har_json = File.read(File.expand_path('../../fixtures/har.json', __FILE__))
@@ -9,24 +11,28 @@ RSpec.describe Readme::Payload do
   let(:ip_address) { Socket.ip_address_list.detect(&:ipv4_private?).ip_address }
 
   it 'returns JSON matching the payload schema' do
+    id = '1'
     result = described_class.new(
       har,
-      { id: '1', label: 'Owlbert', email: 'owlbert@example.com' },
+      { id: id, label: 'Owlbert', email: 'owlbert@example.com' },
       ip_address,
       development: true
     )
 
+    expect(JSON.parse(result.to_json)["group"]["id"]).to match(Readme::Mask.mask(id))
     expect(result.to_json).to match_json_schema('payload')
   end
 
   it 'substitutes api_key for id' do
+    api_key = '1'
     result = described_class.new(
       har,
-      { api_key: '1', label: 'Owlbert', email: 'owlbert@example.com' },
+      { api_key: api_key, label: 'Owlbert', email: 'owlbert@example.com' },
       ip_address,
       development: true
     )
 
+    expect(JSON.parse(result.to_json)["group"]["id"]).to match(Readme::Mask.mask(api_key))
     expect(result.to_json).to match_json_schema('payload')
   end
 


### PR DESCRIPTION
| 🚥 Resolves CX-674 |
| :------------------- |

## 🧰 Changes

Masks the `Authorization` header and API keys sent via the Ruby Rack middleware.

## 🧬 QA & Testing

Added automated tests to verify the sensitive data gets hashed properly and matches the same expected output as the Node.js app
