### PR TITLE
ci: lint PR titles, removes husky

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,19 @@
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx commitlint --edit $1

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "form-data-encoder": "^2.1.0",
         "formdata-node": "^5.0.0",
         "har-validator": "^5.1.5",
-        "husky": "^8.0.3",
         "isomorphic-fetch": "^3.0.0",
         "prettier": "^3.0.2",
         "vitest": "^0.34.2"
@@ -7859,21 +7858,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "clean": "npx lerna clean",
     "lint": "eslint test/ && npm run lint --workspaces",
     "lint:docs": "alex .",
-    "prepare": "husky install",
     "prettier": "prettier --list-different \"./**/**.{js,ts,md}\"",
     "prettier:write": "prettier --list-different --write \"./**/**.{js,ts,md}\"",
     "publish": "npx lerna publish",
@@ -38,7 +37,6 @@
     "form-data-encoder": "^2.1.0",
     "formdata-node": "^5.0.0",
     "har-validator": "^5.1.5",
-    "husky": "^8.0.3",
     "isomorphic-fetch": "^3.0.0",
     "prettier": "^3.0.2",
     "vitest": "^0.34.2"


### PR DESCRIPTION
## 🧰 Changes

Lints PR titles so our release generation works properly! This feels like a more robust check than husky, so I removed that as well.

## 🧬 QA & Testing

Confirmed locally that the VSCode GitHub Actions extension likes this ✅
