### PR TITLE
fix(ruby): Add `_version`

### DIFF
--- a/packages/ruby/Gemfile.lock
+++ b/packages/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    readme-metrics (2.4.0)
+    readme-metrics (2.4.1)
       httparty (~> 0.18)
       rack (>= 2.2, < 4)
 

--- a/packages/ruby/lib/readme/metrics/version.rb
+++ b/packages/ruby/lib/readme/metrics/version.rb
@@ -2,6 +2,6 @@
 
 module Readme
   class Metrics
-    VERSION = '2.4.0'
+    VERSION = '2.4.1'
   end
 end

--- a/packages/ruby/lib/readme/payload.rb
+++ b/packages/ruby/lib/readme/payload.rb
@@ -27,7 +27,7 @@ module Readme
     def to_json(*_args)
       {
         _id: validate_uuid(@log_id) ? @log_id : @uuid,
-        _version: 3, 
+        _version: 3,
         group: @user_info,
         clientIPAddress: @ip_address,
         development: @development,

--- a/packages/ruby/lib/readme/payload.rb
+++ b/packages/ruby/lib/readme/payload.rb
@@ -27,6 +27,7 @@ module Readme
     def to_json(*_args)
       {
         _id: validate_uuid(@log_id) ? @log_id : @uuid,
+        _version: 3, 
         group: @user_info,
         clientIPAddress: @ip_address,
         development: @development,

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe Readme::Metrics do
       expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
       expect(last_response.status).to eq 200
     end
-    
+
     it 'is submitted to Readme when the body is empty with reject_params configured' do
       def app
         json_app_with_middleware(buffer_length: 1, reject_params: ['reject'])

--- a/packages/ruby/spec/readme/metrics_spec.rb
+++ b/packages/ruby/spec/readme/metrics_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe Readme::Metrics do
       expect(WebMock).to have_requested(:post, Readme::Metrics::ENDPOINT)
       expect(last_response.status).to eq 200
     end
-
+    
     it 'is submitted to Readme when the body is empty with reject_params configured' do
       def app
         json_app_with_middleware(buffer_length: 1, reject_params: ['reject'])

--- a/packages/ruby/spec/readme/payload_spec.rb
+++ b/packages/ruby/spec/readme/payload_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe Readme::Payload do
     expect(result.to_json).to match_json_schema('payload')
   end
 
+  it 'has the version param set' do
+    id = '1'
+    result = described_class.new(
+      har,
+      { id: id, label: 'Owlbert', email: 'owlbert@example.com' },
+      ip_address,
+      development: true
+    )
+
+    expect(JSON.parse(result.to_json)['_version']).to match(3)
+    expect(result.to_json).to match_json_schema('payload')
+  end
+
   it 'substitutes api_key for id' do
     api_key = '1'
     result = described_class.new(


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

Add the `_version` parameter to the payload so the server does not process the headers.

## 🧬 QA & Testing

Updated a test to ensure the `_version` parameter is on the payload request.
