### PR TITLE
fix: Stop requiring composer itself

### DIFF
--- a/packages/php/composer.json
+++ b/packages/php/composer.json
@@ -18,7 +18,6 @@
     "illuminate/http": "^9.0 | ^10.0",
     "illuminate/support": "^9.0 | ^10.0",
     "ramsey/uuid": "^3.7 | ^4.0",
-    "composer/composer": "^2.0",
     "guzzlehttp/guzzle": "^7.0",
     "composer-runtime-api": "^2.2"
   },


### PR DESCRIPTION
Requiring composer itself might lead to a difference between the project composer version and the locally installed version. By this no composer actions can be performed any more in case of breaking changes.

See https://github.com/composer/composer/issues/11940

| 🚥 Resolves ISSUE_ID |
| :------------------- |
| https://github.com/readmeio/metrics-sdks/issues/987 |

## 🧰 Changes
The [readme/metrics](https://packagist.org/packages/readme/metrics) requires Composer itself. As mentioned by the maintainers of Composer, see https://github.com/composer/composer/issues/11940#issuecomment-2068728878, this is a bad design and lead to unusable composer installation if the version within the `vendor` folder differs from the system-wide installation.

I'm not quite sure, what are the reasons to require `composer/composer` itself, but not other package are requiring composer, so one should be safe to remove.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
