### PR TITLE
fix(node): avoid rethrowing errors when development=true

### DIFF
--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -27,7 +27,10 @@ function doSend(readmeApiKey: string, options: Options) {
   // Make the log call
   metricsAPICall(readmeApiKey, json).catch(e => {
     // Silently discard errors and timeouts.
-    if (options.development) throw e;
+    if (options.development) {
+      // maybe a console.log(e) ?
+      // throw e;
+    }
   });
 }
 // Make sure we flush the queue if the process is exited


### PR DESCRIPTION
When development=true, the SDK re-throws in a floating promise, leaving no way for the caller to catch it. This crashes the node process.

In lieu of proposing an error handling or logging API to use, this PR/commit is more to point out the problem than suggest a long-term solve.
