### PR TITLE
feat: moving our integration test suite over to using native fetch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - run: npm ci --ignore-scripts
       - run: make test-metrics-dotnet

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - run: npm ci --ignore-scripts
       - run: make test-metrics-node-express

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - run: npm ci --ignore-scripts
       - run: make test-metrics-php-laravel

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - run: npm ci --ignore-scripts
       - run: make test-metrics-python-django

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - run: npm ci --ignore-scripts
       - run: make test-metrics-ruby-rails

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,17 @@ version: '3.4'
 
 x-server-config: &server-config
   README_API_KEY: rdme_abcdefghijklmnopqrstuvwxyz
-  README_METRICS_SERVER: "http://host.docker.internal:8001"
+  README_METRICS_SERVER: 'http://host.docker.internal:8001'
 
 x-extra_hosts: &default-extra_hosts
   # Docker in Github doesn't automaticaly map these and without `host.docker.internal`
   # working our SDK HTTP servers can't talk to our mock Metrics server.
-  - "host.docker.internal:host-gateway"
+  - 'host.docker.internal:host-gateway'
 
 services:
   runner:
     container_name: runner
-    image: node:16
+    image: node:20
 
   #
   # .NET

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,7 @@
         "alex": "^11.0.0",
         "caseless": "^0.12.0",
         "eslint": "^8.27.0",
-        "form-data-encoder": "^2.1.0",
-        "formdata-node": "^5.0.0",
         "har-validator": "^5.1.5",
-        "isomorphic-fetch": "^3.0.0",
         "lerna": "^8.1.3",
         "prettier": "^3.0.2",
         "vitest": "^0.34.2"
@@ -9628,19 +9625,6 @@
         "node": ">=0.4.x"
       }
     },
-    "node_modules/formdata-node": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-5.0.1.tgz",
-      "integrity": "sha512-8xnIjMYGKPj+rY2BTbAmpqVpi8der/2FT4d9f7J32FlsCpO5EzZPq3C/N56zdv8KweHzVF6TGijsS1JT6r1H2g==",
-      "dev": true,
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 14.17"
-      }
-    },
     "node_modules/formidable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
@@ -11781,16 +11765,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -14682,25 +14656,6 @@
       },
       "engines": {
         "node": ">= 10.13"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -20733,15 +20688,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -20876,12 +20822,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,7 @@
     "alex": "^11.0.0",
     "caseless": "^0.12.0",
     "eslint": "^8.27.0",
-    "form-data-encoder": "^2.1.0",
-    "formdata-node": "^5.0.0",
     "har-validator": "^5.1.5",
-    "isomorphic-fetch": "^3.0.0",
     "lerna": "^8.1.3",
     "prettier": "^3.0.2",
     "vitest": "^0.34.2"

--- a/test/integration-metrics.test.js
+++ b/test/integration-metrics.test.js
@@ -512,7 +512,7 @@ describe('Metrics SDK Integration Tests', function () {
 
       expect(request.method).toBe('POST');
       expect(request.headers).to.have.header('content-type', /multipart\/form-data; boundary=(.*)/);
-      expect(request.headers).to.have.header('content-length', 982);
+      expect(request.headers).to.have.header('content-length', [960, 982]);
       expect(request.postData.mimeType).toMatch(/multipart\/form-data; boundary=(.*)/);
 
       const owlbertDataURL = await fs.readFile('./test/__datasets__/owlbert.dataurl.json').then(JSON.parse);

--- a/test/integration-metrics.test.js
+++ b/test/integration-metrics.test.js
@@ -512,7 +512,7 @@ describe('Metrics SDK Integration Tests', function () {
 
       expect(request.method).toBe('POST');
       expect(request.headers).to.have.header('content-type', /multipart\/form-data; boundary=(.*)/);
-      expect(request.headers).to.have.header('content-length', [960, 982]);
+      expect(request.headers).to.have.header('content-length', 982);
       expect(request.postData.mimeType).toMatch(/multipart\/form-data; boundary=(.*)/);
 
       const owlbertDataURL = await fs.readFile('./test/__datasets__/owlbert.dataurl.json').then(JSON.parse);

--- a/test/integration-metrics.test.js
+++ b/test/integration-metrics.test.js
@@ -3,12 +3,8 @@ import { once } from 'node:events';
 import fs from 'node:fs/promises';
 import http from 'node:http';
 import net from 'node:net';
-import { Readable } from 'node:stream';
 
 import chai from 'chai';
-import { FormDataEncoder } from 'form-data-encoder';
-import { File, FormData } from 'formdata-node';
-import 'isomorphic-fetch';
 import { describe, beforeAll, beforeEach, afterAll, expect, it, expectTypeOf } from 'vitest';
 
 import chaiPlugins from './helpers/chai-plugins.js';
@@ -461,12 +457,9 @@ describe('Metrics SDK Integration Tests', function () {
     formData.append('another', 'Hello world');
     formData.append('buster', [1234, 5678]);
 
-    const encoder = new FormDataEncoder(formData);
-
     await fetch(`http://localhost:${PORT}/`, {
       method: 'post',
-      headers: encoder.headers,
-      body: Readable.from(encoder),
+      body: formData,
     });
 
     const [, body] = await getRequest();
@@ -503,12 +496,9 @@ describe('Metrics SDK Integration Tests', function () {
       formData.append('buster', [1234, 5678]);
       formData.append('owlbert.png', new File([owlbert], 'owlbert.png', { type: 'image/png' }), 'owlbert.png');
 
-      const encoder = new FormDataEncoder(formData);
-
       await fetch(`http://localhost:${PORT}/`, {
         method: 'post',
-        headers: encoder.headers,
-        body: Readable.from(encoder),
+        body: formData,
       });
 
       const [, body] = await getRequest();
@@ -522,7 +512,7 @@ describe('Metrics SDK Integration Tests', function () {
 
       expect(request.method).toBe('POST');
       expect(request.headers).to.have.header('content-type', /multipart\/form-data; boundary=(.*)/);
-      expect(request.headers).to.have.header('content-length', 982);
+      expect(request.headers).to.have.header('content-length', [960, 982]);
       expect(request.postData.mimeType).toMatch(/multipart\/form-data; boundary=(.*)/);
 
       const owlbertDataURL = await fs.readFile('./test/__datasets__/owlbert.dataurl.json').then(JSON.parse);

--- a/test/integration-webhooks.test.js
+++ b/test/integration-webhooks.test.js
@@ -1,6 +1,5 @@
 import crypto from 'node:crypto';
 
-import 'isomorphic-fetch';
 import { describe, it, expect } from 'vitest';
 
 const PORT = 8000; // SDK HTTP server port


### PR DESCRIPTION
## 🧰 Changes

Moves out integration test suite off an outdated collection of `isomorphic-fetch`, `form-data-encoder`, and `formdata-node` in favor of native `fetch` and `FormData` utilizations.