### PR TITLE
chore(python): Update type hinting on VerifyWebhook's signature

### DIFF
--- a/packages/python/readme_metrics/VerifyWebhook.py
+++ b/packages/python/readme_metrics/VerifyWebhook.py
@@ -1,5 +1,6 @@
-import json
 import hmac
+import json
+import typing as t
 from datetime import datetime, timedelta
 
 
@@ -8,7 +9,7 @@ class VerificationError(Exception):
 
 
 class VerifyWebhook:
-    def __init__(self, body: dict, signature: str, secret: str):
+    def __init__(self, body: dict, signature: t.Optional[str], secret: str):
         if signature is None:
             raise VerificationError("Missing Signature")
 


### PR DESCRIPTION
The function checks if it's None, so the type hinting should accept None

| 🚥 Resolves ISSUE_ID |
| :------------------- |

I didn't create an issue for this, but I can if that helps.

## 🧰 Changes

Update the type hinting on VerifyWebhook to accurately reflect what the function can accept. In my application code, I call `signature` with a variable that can be a `str` or  `None`, and mypy is flagging that as a problem because the function says it only accepts `str`.

## 🧬 QA & Testing

No testing required, since it's just a type hinting change.

I chose to use `typing.Optional[str]` instead of `str | None` because that works on more versions of python.