### PR TITLE
ci(ruby): don't run `bundle update`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           make install
           gem install rack ${{ matrix.rack-version }}
-        # bundle update
 
       - name: Run linter
         run: make lint

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 16
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 16
 
-    - run: npm ci --ignore-scripts
-    - run: make test-metrics-ruby-rails
-    - run: make test-webhooks-ruby-rails
+      - run: npm ci --ignore-scripts
+      - run: make test-metrics-ruby-rails
+      - run: make test-webhooks-ruby-rails
 
-    - name: Cleanup
-      if: always()
-      run: docker-compose down
+      - name: Cleanup
+        if: always()
+        run: docker-compose down
 
   build:
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
         run: |
           make install
           gem install rack ${{ matrix.rack-version }}
-          bundle update
+        # bundle update
 
       - name: Run linter
         run: make lint


### PR DESCRIPTION
## 🧰 Changes

We're running `bundle update` in our Ruby CI before running unit tests and this is upgrading all of our dependencies. Our usage of some of these dependencies apparently needs some work as every Ruby unit test fails on these updated deps.