### PR TITLE
chore(uuid): deprecate `uuid` package in favor of `node:crypto`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3176,12 +3176,6 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
-    "node_modules/@types/uuid": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
-      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.0.tgz",
@@ -20749,6 +20743,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -21869,8 +21864,7 @@
         "oas": "^20.10.2",
         "ssri": "^10.0.1",
         "timeout-signal": "^1.1.0",
-        "type-is": "^1.6.18",
-        "uuid": "^9.0.0"
+        "type-is": "^1.6.18"
       },
       "devDependencies": {
         "@readme/eslint-config": "^14.0.0",
@@ -21884,7 +21878,6 @@
         "@types/ssri": "^7.1.1",
         "@types/supertest": "^2.0.12",
         "@types/type-is": "^1.6.3",
-        "@types/uuid": "^9.0.2",
         "@vitest/coverage-v8": "^0.34.2",
         "caseless": "^0.12.0",
         "eslint": "^8.34.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -37,8 +37,7 @@
     "oas": "^20.10.2",
     "ssri": "^10.0.1",
     "timeout-signal": "^1.1.0",
-    "type-is": "^1.6.18",
-    "uuid": "^9.0.0"
+    "type-is": "^1.6.18"
   },
   "devDependencies": {
     "@readme/eslint-config": "^14.0.0",
@@ -52,7 +51,6 @@
     "@types/ssri": "^7.1.1",
     "@types/supertest": "^2.0.12",
     "@types/type-is": "^1.6.3",
-    "@types/uuid": "^9.0.2",
     "@vitest/coverage-v8": "^0.34.2",
     "caseless": "^0.12.0",
     "eslint": "^8.34.0",

--- a/packages/node/src/lib/construct-payload.ts
+++ b/packages/node/src/lib/construct-payload.ts
@@ -3,11 +3,11 @@ import type { UUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { TLSSocket } from 'tls';
 
+import { randomUUID } from 'node:crypto';
 import os from 'os';
 import { URL } from 'url';
 
 import ssri from 'ssri';
-import { v4 as uuidv4 } from 'uuid';
 
 import { version } from '../../package.json';
 
@@ -142,7 +142,7 @@ export function constructPayload(
   const serverTime = payloadData.responseEndDateTime.getTime() - payloadData.startedDateTime.getTime();
 
   return {
-    _id: payloadData.logId || (uuidv4() as UUID),
+    _id: payloadData.logId || randomUUID(),
     _version: 3,
     group: {
       id: mask(payloadData.apiKey),

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -1,12 +1,11 @@
 import type { LogOptions } from './construct-payload';
 import type { GroupingObject, OutgoingLogBody } from './metrics-log';
-import type { UUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
+import { randomUUID } from 'node:crypto';
 import * as url from 'url';
 
 import clamp from 'lodash/clamp';
-import { v4 as uuidv4 } from 'uuid';
 
 import config from '../config';
 
@@ -108,7 +107,7 @@ export function log(
   const bufferLength = clamp(options.bufferLength || config.bufferLength, 1, 30);
 
   const startedDateTime = new Date();
-  const logId = uuidv4() as UUID;
+  const logId = randomUUID();
 
   // baseLogUrl can be provided, but if it isn't then we
   // attempt to fetch it from the ReadMe API

--- a/packages/node/src/lib/metrics-log.ts
+++ b/packages/node/src/lib/metrics-log.ts
@@ -1,7 +1,7 @@
 import type { Options } from './log';
-import type { UUID } from 'crypto';
 import type { Har } from 'har-format';
 import type { Response } from 'node-fetch';
+import type { UUID } from 'node:crypto';
 
 import fetch from 'node-fetch';
 import timeoutSignal from 'timeout-signal';


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

Removing `uuid` dep. We should be able to use `node:crypto` for any UUID generation going forward.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
