### PR TITLE
feat(node): pluggable logging class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6309,6 +6309,12 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "devOptional": true
+    },
     "node_modules/columnify": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
@@ -7647,7 +7653,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -9340,6 +9346,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "optional": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9387,7 +9399,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -10632,6 +10644,12 @@
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "optional": true
     },
     "node_modules/hexoid": {
       "version": "1.0.0",
@@ -12004,6 +12022,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -14200,7 +14227,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -16659,6 +16686,119 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.2.2.tgz",
+      "integrity": "sha512-2FnyGir8nAJAqD3srROdrF1J5BIcMT4nwj7hHSc60El6Uxlym00UbCCd8pYIterstVBFlMyF1yFV8XdGIPbj4A==",
+      "optional": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.2",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "optional": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/pino-pretty/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
@@ -17967,6 +18107,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "optional": true
+    },
     "node_modules/semver": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
@@ -18933,7 +19079,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       },
@@ -20986,12 +21132,6 @@
         }
       }
     },
-    "node_modules/webpack-cli/node_modules/colorette": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
-      "dev": true
-    },
     "node_modules/webpack-cli/node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -21544,7 +21684,8 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "pino": "^9.3.2"
+        "pino": "^9.3.2",
+        "pino-pretty": "^11.2.2"
       }
     },
     "packages/node/node_modules/@esbuild/android-arm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5389,6 +5389,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5466,7 +5475,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -9191,7 +9200,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -9364,6 +9373,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -10743,7 +10761,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -15673,6 +15691,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -16522,6 +16549,122 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pino": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.3.2.tgz",
+      "integrity": "sha512-WtARBjgZ7LNEkrGWxMBN/jvlFiE17LTbBoH0konmBU684Kd0uIiDwBXlcTCW7iJnA6HfIKwUssS/2AC6cDEanw==",
+      "optional": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^4.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "optional": true,
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "optional": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/pino-abstract-transport/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "optional": true
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -16653,11 +16796,26 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/process-warning": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
+      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
+      "optional": true
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -16869,6 +17027,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "optional": true
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -17168,6 +17332,15 @@
     "node_modules/readmeio": {
       "resolved": "packages/node",
       "link": true
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "optional": true,
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/rechoir": {
       "version": "0.8.0",
@@ -17761,6 +17934,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -18228,6 +18410,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.0.1.tgz",
+      "integrity": "sha512-hTSD/6JMLyT4r9zeof6UtuBDpjJ9sO08/nmS5djaA9eozT9oOlNdpXSnzcgj4FTqpk3nkLrs61l4gip9r1HCrQ==",
+      "optional": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/sort-keys": {
@@ -19086,6 +19277,15 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "optional": true,
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -21342,6 +21542,9 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "pino": "^9.3.2"
       }
     },
     "packages/node/node_modules/@esbuild/android-arm": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -70,6 +70,7 @@
   },
   "prettier": "@readme/eslint-config/prettier",
   "optionalDependencies": {
-    "pino": "^9.3.2"
+    "pino": "^9.3.2",
+    "pino-pretty": "^11.2.2"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -68,5 +68,8 @@
     "prettier": "prettier --list-different --write \"./**/**.{js,ts}\"",
     "test": "vitest run --coverage"
   },
-  "prettier": "@readme/eslint-config/prettier"
+  "prettier": "@readme/eslint-config/prettier",
+  "optionalDependencies": {
+    "pino": "^9.3.2"
+  }
 }

--- a/packages/node/src/lib/ReadMe.ts
+++ b/packages/node/src/lib/ReadMe.ts
@@ -202,7 +202,7 @@ export default class ReadMe {
           const webhookData = await testVerifyWebhook(baseUrl, email, this.readmeProjectData.jwtSecret as string);
           return res.json({ ...webhookData });
         } catch (err) {
-          logger.error({ err, message: 'Test verify webhook error' });
+          logger.error({ err, message: 'Webhook verification failed.' });
           return res.status(400).json({ error: (err as Error).message });
         }
       }

--- a/packages/node/src/lib/ReadMe.ts
+++ b/packages/node/src/lib/ReadMe.ts
@@ -103,21 +103,17 @@ export default class ReadMe {
 
       const getUser: GetUserFunction = async ({ byAPIKey, byEmail, manualAPIKey }) => {
         if (!byAPIKey && !options.disableMetrics) {
-          if (options.logger) {
-            logger.error({
-              message:
-                'Missing required definition for `byAPIKey`. Learn more here: https://docs.readme.com/main/docs/unified-snippet-docs#getuserbyapikey',
-            });
-          }
+          logger.error({
+            message:
+              'Missing required definition for `byAPIKey`. Learn more here: https://docs.readme.com/main/docs/unified-snippet-docs#getuserbyapikey',
+          });
           return next();
         }
         if (!byEmail && !options.disableWebhook) {
-          if (options.logger) {
-            logger.error({
-              message:
-                'Missing required definition for `byEmail`. Learn more here: https://docs.readme.com/main/docs/unified-snippet-docs#getuserbyapikey',
-            });
-          }
+          logger.error({
+            message:
+              'Missing required definition for `byEmail`. Learn more here: https://docs.readme.com/main/docs/unified-snippet-docs#getuserbyapikey',
+          });
           return next();
         }
 
@@ -138,13 +134,11 @@ export default class ReadMe {
         try {
           requestAPIKey = findAPIKey(req);
         } catch (err) {
-          if (options.logger) {
-            logger.error({
-              err,
-              message:
-                'Could not automatically find an API key in the request. You should pass the API key via `manualAPIKey` in the `getUser` function. Learn more here: https://docs.readme.com/main/docs/unified-snippet-docs#getuserbyapikey',
-            });
-          }
+          logger.error({
+            err,
+            message:
+              'Could not automatically find an API key in the request. You should pass the API key via `manualAPIKey` in the `getUser` function. Learn more here: https://docs.readme.com/main/docs/unified-snippet-docs#getuserbyapikey',
+          });
         }
         return byAPIKey(requestAPIKey);
       };
@@ -168,13 +162,11 @@ export default class ReadMe {
             headers,
           }).then(r => r.json() as Promise<ReadMeVersion[]>);
         } catch (err) {
-          if (options.logger) {
-            // TODO: Maybe send this to sentry?
-            if (err.status === 401) {
-              logger.error({ err, message: 'Invalid ReadMe API key. Contact support@readme.io for help!' });
-            } else {
-              logger.error({ err, message: 'Error calling ReadMe API. Contact support@readme.io for help!' });
-            }
+          // TODO: Maybe send this to sentry?
+          if (err.status === 401) {
+            logger.error({ err, message: 'Invalid ReadMe API key. Contact support@readme.io for help!' });
+          } else {
+            logger.error({ err, message: 'Error calling ReadMe API. Contact support@readme.io for help!' });
           }
           // Don't want to cause an error in their API
           return next();
@@ -191,9 +183,7 @@ export default class ReadMe {
           const user = await userFunction(req, getUser);
           return res.send(user);
         } catch (err) {
-          if (options.logger) {
-            logger.error({ err, message: 'Verify webhook error' });
-          }
+          logger.error({ err, message: 'Verify webhook error' });
           return res.status(400).json({ error: (err as Error).message });
         }
       } else if (req.path === '/readme-setup' && options.development) {
@@ -212,9 +202,7 @@ export default class ReadMe {
           const webhookData = await testVerifyWebhook(baseUrl, email, this.readmeProjectData.jwtSecret as string);
           return res.json({ ...webhookData });
         } catch (err) {
-          if (options.logger) {
-            logger.error({ err, message: 'Test verify webhook error' });
-          }
+          logger.error({ err, message: 'Test verify webhook error' });
           return res.status(400).json({ error: (err as Error).message });
         }
       }
@@ -225,13 +213,11 @@ export default class ReadMe {
 
         const group = getGroupByApiKey(user, requestAPIKey);
         if (!group) {
-          if (options.logger) {
-            logger.error({
-              message: usingManualAPIKey
-                ? 'The API key you passed in via `manualAPIKey` could not be found in the user object you provided.'
-                : 'Could not automatically find an API key in the request. You should pass the API key via `manualAPIKey` in the `getUser` function. Learn more here: https://docs.readme.com/main/docs/unified-snippet-docs#/getuserbyapikey',
-            });
-          }
+          logger.error({
+            message: usingManualAPIKey
+              ? 'The API key you passed in via `manualAPIKey` could not be found in the user object you provided.'
+              : 'Could not automatically find an API key in the request. You should pass the API key via `manualAPIKey` in the `getUser` function. Learn more here: https://docs.readme.com/main/docs/unified-snippet-docs#/getuserbyapikey',
+          });
           return next();
         }
 

--- a/packages/node/src/lib/console-logger.ts
+++ b/packages/node/src/lib/console-logger.ts
@@ -9,17 +9,17 @@ export default class ConsoleLogger implements LoggerStrategy {
    * @returns A formatted log message
    */
   // eslint-disable-next-line class-methods-use-this
-  private formatMessage(level: 'DEBUG' | 'ERROR' | 'TRACE', message: string): string[] {
+  private formatMessage(level: 'DEBUG' | 'ERROR' | 'INFO' | 'VERBOSE', message: string): string[] {
     return [`${level} ${new Date().toISOString()} [readmeio] ${message}`];
   }
 
   /**
-   * Logs a trace message to the console.
-   * @param log The trace log entry. Contains the message as required field and optional args.
+   * Logs a verbose message to the console.
+   * @param log The verbose log entry. Contains the message as required field and optional args.
    */
-  trace({ message, args }: Log): void {
-    const params: unknown[] = this.formatMessage('TRACE', message);
-    console.trace(...params);
+  verbose({ message, args }: Log): void {
+    const params: unknown[] = this.formatMessage('VERBOSE', message);
+    console.log(...params);
     if (args) {
       console.dir(args, { depth: null });
       console.log('\n');
@@ -36,6 +36,18 @@ export default class ConsoleLogger implements LoggerStrategy {
       params.push('\nArguments:', args);
     }
     console.debug(...params, '\n');
+  }
+
+  /**
+   * Logs an info message to the console.
+   * @param log The debug log entry. Contains the message as required field and optional args.
+   */
+  info({ message, args }: Log): void {
+    const params: unknown[] = this.formatMessage('INFO', message);
+    if (args) {
+      params.push('\nArguments:', args);
+    }
+    console.info(...params, '\n');
   }
 
   /**

--- a/packages/node/src/lib/console-logger.ts
+++ b/packages/node/src/lib/console-logger.ts
@@ -1,0 +1,55 @@
+import type { Log, ErrorLog, LoggerStrategy } from './logger';
+
+/**
+ * Implementation of the console logger strategy.
+ */
+export default class ConsoleLogger implements LoggerStrategy {
+  /**
+   * This method takes a level of the log and a message and formats it to the unified log format
+   * @returns A formatted log message
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private formatMessage(level: 'DEBUG' | 'ERROR' | 'TRACE', message: string): string[] {
+    return [`${level} ${new Date().toISOString()} [readmeio] ${message}`];
+  }
+
+  /**
+   * Logs a trace message to the console.
+   * @param log The trace log entry. Contains the message as required field and optional args.
+   */
+  trace({ message, args }: Log): void {
+    const params: unknown[] = this.formatMessage('TRACE', message);
+    console.trace(...params);
+    if (args) {
+      console.dir(args, { depth: null });
+      console.log('\n');
+    }
+  }
+
+  /**
+   * Logs a debug message to the console.
+   * @param log The debug log entry. Contains the message as required field and optional args.
+   */
+  debug({ message, args }: Log): void {
+    const params: unknown[] = this.formatMessage('DEBUG', message);
+    if (args) {
+      params.push('\nArguments:', args);
+    }
+    console.debug(...params, '\n');
+  }
+
+  /**
+   * Logs an error message to the console.
+   * @param log The error log entry. Contains the message and error object as required fields and optional args.
+   */
+  error({ message, args, err }: ErrorLog): void {
+    const params: unknown[] = this.formatMessage('ERROR', message);
+    if (args) {
+      params.push('\nArguments:', args);
+    }
+    if (err) {
+      params.push('\n', err);
+    }
+    console.error(...params, '\n');
+  }
+}

--- a/packages/node/src/lib/construct-payload.ts
+++ b/packages/node/src/lib/construct-payload.ts
@@ -55,6 +55,11 @@ export interface LogOptions {
   fireAndForget?: boolean;
 
   /**
+   * If true, the errors and other logs will be displayed in console.
+   */
+  logger?: boolean;
+
+  /**
    * @deprecated use `allowList` instead
    */
   whitelist?: string[];

--- a/packages/node/src/lib/construct-payload.ts
+++ b/packages/node/src/lib/construct-payload.ts
@@ -1,3 +1,4 @@
+import type { LoggerStrategy } from './logger';
 import type { OutgoingLogBody } from './metrics-log';
 import type { UUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
@@ -55,9 +56,9 @@ export interface LogOptions {
   fireAndForget?: boolean;
 
   /**
-   * If true, the errors and other logs will be displayed in console.
+   * If true, the errors and other logs will be displayed in console. Your own logger strategy can be passed.
    */
-  logger?: boolean;
+  logger?: LoggerStrategy | boolean;
 
   /**
    * @deprecated use `allowList` instead

--- a/packages/node/src/lib/get-project-base-url.ts
+++ b/packages/node/src/lib/get-project-base-url.ts
@@ -50,7 +50,8 @@ export async function getProjectBaseUrl(readmeApiKey: string, requestTimeout = c
         if (res.status >= 400 && res.status <= 599) {
           throw res;
         }
-        logger.debug({ message: `Fetch Base URL: Service responded with status ${res.status}: ${res.statusText}` });
+        const logLevel = res.ok ? 'info' : 'error';
+        logger[logLevel]({ message: `Fetch Base URL: Service responded with status ${res.status}: ${res.statusText}.` });
         return res.json() as Promise<{ baseUrl: string }>;
       })
       .then(project => {
@@ -73,6 +74,7 @@ export async function getProjectBaseUrl(readmeApiKey: string, requestTimeout = c
 
     return baseUrl;
   }
-
-  return cache.getKey('baseUrl');
+  const cachedBaseUrl = cache.getKey('baseUrl');
+  logger.verbose({ message: 'Retrieved baseUrl from cache.', args: { baseUrl: cachedBaseUrl } });
+  return cachedBaseUrl;
 }

--- a/packages/node/src/lib/get-project-base-url.ts
+++ b/packages/node/src/lib/get-project-base-url.ts
@@ -7,6 +7,8 @@ import timeoutSignal from 'timeout-signal';
 import pkg from '../../package.json';
 import config from '../config';
 
+import { logger } from './logger';
+
 export function getCache(readmeApiKey: string) {
   const encodedApiKey = Buffer.from(`${readmeApiKey}:`).toString('base64');
   const cacheDir = findCacheDir({ name: pkg.name, create: true });
@@ -48,7 +50,7 @@ export async function getProjectBaseUrl(readmeApiKey: string, requestTimeout = c
         if (res.status >= 400 && res.status <= 599) {
           throw res;
         }
-
+        logger.debug({ message: `Fetch Base URL: Service responded with status ${res.status}: ${res.statusText}` });
         return res.json() as Promise<{ baseUrl: string }>;
       })
       .then(project => {

--- a/packages/node/src/lib/get-project-base-url.ts
+++ b/packages/node/src/lib/get-project-base-url.ts
@@ -51,7 +51,9 @@ export async function getProjectBaseUrl(readmeApiKey: string, requestTimeout = c
           throw res;
         }
         const logLevel = res.ok ? 'info' : 'error';
-        logger[logLevel]({ message: `Fetch Base URL: Service responded with status ${res.status}: ${res.statusText}.` });
+        logger[logLevel]({
+          message: `Fetch Base URL: Service responded with status ${res.status}: ${res.statusText}.`,
+        });
         return res.json() as Promise<{ baseUrl: string }>;
       })
       .then(project => {

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -173,7 +173,7 @@ export function log(
     );
 
     queue.push(payload);
-    logger.debug({ message: 'Queue is appended.', args: { queue } });
+    logger.debug({ message: 'Request enqueued.', args: { queue } });
     if (queue.length >= bufferLength) doSend(readmeApiKey, options);
 
     cleanup(); // eslint-disable-line @typescript-eslint/no-use-before-define

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -28,11 +28,11 @@ function doSend(readmeApiKey: string, options: Options) {
   metricsAPICall(readmeApiKey, json, options).catch(err => {
     // Silently discard errors and timeouts.
     if (options.development) {
-      logger.error({ message: 'Error making API call', err });
+      logger.error({ message: 'Failed to capture API request.', err });
     }
   });
 
-  logger.debug({ message: 'Queue is cleared.', args: { queue } });
+  logger.debug({ message: 'Queue flushed.', args: { queue } });
 }
 // Make sure we flush the queue if the process is exited
 process.on('exit', doSend);
@@ -83,7 +83,7 @@ function setDocumentationHeader(res: ServerResponse, baseLogUrl: string, logId: 
   if (res.headersSent) return;
   const documentationUrl = `${baseLogUrl}/logs/${logId}`;
   logger.verbose({
-    message: 'The documentation URL is created.',
+    message: 'Created URL to your API request log.',
     args: { 'x-documentation-url': documentationUrl },
   });
   res.setHeader('x-documentation-url', documentationUrl);

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -107,7 +107,10 @@ export function log(
 ) {
   if (!readmeApiKey) throw new Error('You must provide your ReadMe API key');
   if (!group) throw new Error('You must provide a group');
-  if (options.logger) logger.configure({ isLoggingEnabled: true });
+  if (options.logger) {
+    if (typeof options.logger === 'boolean') logger.configure({ isLoggingEnabled: true });
+    else logger.configure({ isLoggingEnabled: true, strategy: options.logger });
+  }
 
   // Ensures the buffer length is between 1 and 30
   const bufferLength = clamp(options.bufferLength || config.bufferLength, 1, 30);

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -27,7 +27,7 @@ function doSend(readmeApiKey: string, options: Options) {
   // Make the log call
   metricsAPICall(readmeApiKey, json, options).catch(err => {
     // Silently discard errors and timeouts.
-    if (options.development && options.logger) {
+    if (options.development) {
       logger.error({ message: 'Error making API call', err });
     }
   });
@@ -105,6 +105,7 @@ export function log(
 ) {
   if (!readmeApiKey) throw new Error('You must provide your ReadMe API key');
   if (!group) throw new Error('You must provide a group');
+  if (options.logger) logger.configure({ isLoggingEnabled: true });
 
   // Ensures the buffer length is between 1 and 30
   const bufferLength = clamp(options.bufferLength || config.bufferLength, 1, 30);

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -12,6 +12,7 @@ import config from '../config';
 import { constructPayload } from './construct-payload';
 import { getProjectBaseUrl } from './get-project-base-url';
 import isRequest from './is-request';
+import { logger } from './logger';
 import { metricsAPICall } from './metrics-log';
 import { patchRequest } from './patch-request';
 import { patchResponse } from './patch-response';
@@ -24,9 +25,11 @@ function doSend(readmeApiKey: string, options: Options) {
   queue = [];
 
   // Make the log call
-  metricsAPICall(readmeApiKey, json, options).catch(e => {
+  metricsAPICall(readmeApiKey, json, options).catch(err => {
     // Silently discard errors and timeouts.
-    if (options.development) throw e;
+    if (options.development && options.logger) {
+      logger.error({ message: 'Error making API call', err });
+    }
   });
 }
 // Make sure we flush the queue if the process is exited

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -81,8 +81,12 @@ function setDocumentationHeader(res: ServerResponse, baseLogUrl: string, logId: 
   // do with a test, but it's a little difficult to test. Maybe with a nock()
   // delay timeout.
   if (res.headersSent) return;
-
-  res.setHeader('x-documentation-url', `${baseLogUrl}/logs/${logId}`);
+  const documentationUrl = `${baseLogUrl}/logs/${logId}`;
+  logger.verbose({
+    message: 'The documentation URL is created.',
+    args: { 'x-documentation-url': documentationUrl },
+  });
+  res.setHeader('x-documentation-url', documentationUrl);
 }
 
 /**

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -31,6 +31,8 @@ function doSend(readmeApiKey: string, options: Options) {
       logger.error({ message: 'Error making API call', err });
     }
   });
+
+  logger.debug({ message: 'Queue is cleared.', args: { queue } });
 }
 // Make sure we flush the queue if the process is exited
 process.on('exit', doSend);
@@ -168,6 +170,7 @@ export function log(
     );
 
     queue.push(payload);
+    logger.debug({ message: 'Queue is appended.', args: { queue } });
     if (queue.length >= bufferLength) doSend(readmeApiKey, options);
 
     cleanup(); // eslint-disable-line @typescript-eslint/no-use-before-define

--- a/packages/node/src/lib/logger.ts
+++ b/packages/node/src/lib/logger.ts
@@ -25,7 +25,7 @@ export interface Logger extends LoggerStrategy {
 /**
  * Default implementation of the Logger interface. Represents a signleton class of logger with selected strategy.
  */
-class DefaultLogger implements Logger {
+export class DefaultLogger implements Logger {
   private static instance: Logger;
 
   private config: LoggerConfig;

--- a/packages/node/src/lib/logger.ts
+++ b/packages/node/src/lib/logger.ts
@@ -1,0 +1,80 @@
+interface Log {
+  args?: Record<string, unknown>;
+  message: string;
+}
+
+type ErrorLog = Log & { err?: Error };
+
+export interface Logger {
+  debug(log: Log): void;
+  error(log: ErrorLog): void;
+  trace(log: Log): void;
+}
+
+/**
+ * Default implementation of the Logger interface. Represents a signleton class of console logger.
+ */
+class DefaultLogger implements Logger {
+  private static instance: Logger;
+
+  /**
+   * Method for getting instance of the logger class
+   * @returns A single instance of the logger
+   */
+  static getInstance(): Logger {
+    if (!DefaultLogger.instance) {
+      DefaultLogger.instance = new DefaultLogger();
+    }
+    return DefaultLogger.instance;
+  }
+
+  /**
+   * This method takes a level of the log and a message and formats it to the unified log format
+   * @returns A formatted log message
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private formatMessage(level: 'DEBUG' | 'ERROR' | 'TRACE', message: string): string[] {
+    return [`${level} ${new Date().toISOString()} [readmeio] ${message}`];
+  }
+
+  /**
+   * Logs a trace message.
+   * @param log The trace log entry. Contains the message as required field and optional args.
+   */
+  trace({ message, args }: Log): void {
+    const params: unknown[] = this.formatMessage('TRACE', message);
+    if (args) {
+      params.push('\nArguments:', args);
+    }
+    console.debug(...params);
+  }
+
+  /**
+   * Logs a debug message.
+   * @param log The debug log entry. Contains the message as required field and optional args.
+   */
+  debug({ message, args }: Log): void {
+    const params: unknown[] = this.formatMessage('DEBUG', message);
+    if (args) {
+      params.push('\nArguments:', args);
+    }
+    console.debug(...params);
+  }
+
+  /**
+   * Logs an error message.
+   * @param log The error log entry. Contains the message and error object as required fields and optional args.
+   */
+  error({ message, args, err }: ErrorLog): void {
+    const params: unknown[] = this.formatMessage('ERROR', message);
+    if (args) {
+      params.push('\nArguments:', args);
+    }
+    if (err) {
+      params.push('\n', err);
+    }
+    console.error(...params);
+  }
+}
+
+export const logger = DefaultLogger.getInstance();

--- a/packages/node/src/lib/logger.ts
+++ b/packages/node/src/lib/logger.ts
@@ -68,10 +68,11 @@ class DefaultLogger implements Logger {
   trace({ message, args }: Log): void {
     if (!this.config.isLoggingEnabled) return;
     const params: unknown[] = this.formatMessage('TRACE', message);
+    console.log(...params);
     if (args) {
-      params.push('\nArguments:', args);
+      console.dir(args, { depth: null });
+      console.log('\n');
     }
-    console.debug(...params);
   }
 
   /**
@@ -84,7 +85,7 @@ class DefaultLogger implements Logger {
     if (args) {
       params.push('\nArguments:', args);
     }
-    console.debug(...params);
+    console.debug(...params, '\n');
   }
 
   /**
@@ -100,7 +101,7 @@ class DefaultLogger implements Logger {
     if (err) {
       params.push('\n', err);
     }
-    console.error(...params);
+    console.error(...params, '\n');
   }
 }
 

--- a/packages/node/src/lib/logger.ts
+++ b/packages/node/src/lib/logger.ts
@@ -1,4 +1,5 @@
 import ConsoleLogger from './console-logger';
+import PinoLogger from './pino-logger';
 
 interface LoggerConfig {
   isLoggingEnabled: boolean;
@@ -15,7 +16,8 @@ export type ErrorLog = Log & { err?: Error };
 export interface LoggerStrategy {
   debug(log: Log): void;
   error(log: ErrorLog): void;
-  trace(log: Log): void;
+  info(log: Log): void;
+  verbose(log: Log): void;
 }
 
 export interface Logger extends LoggerStrategy {
@@ -40,10 +42,18 @@ export class DefaultLogger implements Logger {
    */
   static getInstance(): Logger {
     if (!DefaultLogger.instance) {
-      const defaultConfig: LoggerConfig = {
-        isLoggingEnabled: false,
-        strategy: new ConsoleLogger(),
-      };
+      let defaultConfig: LoggerConfig;
+      try {
+        defaultConfig = {
+          isLoggingEnabled: false,
+          strategy: new PinoLogger(),
+        };
+      } catch (e) {
+        defaultConfig = {
+          isLoggingEnabled: false,
+          strategy: new ConsoleLogger(),
+        };
+      }
       DefaultLogger.instance = new DefaultLogger(defaultConfig);
     }
     return DefaultLogger.instance;
@@ -79,9 +89,14 @@ export class DefaultLogger implements Logger {
    * Logs a trace message.
    * @param log The trace log entry. Contains the message as required field and optional args.
    */
-  trace(log: Log): void {
+  verbose(log: Log): void {
     if (!this.config.isLoggingEnabled) return;
-    this.config.strategy.trace(log);
+    this.config.strategy.verbose(log);
+  }
+
+  info(log: Log): void {
+    if (!this.config.isLoggingEnabled) return;
+    this.config.strategy.info(log);
   }
 }
 

--- a/packages/node/src/lib/metrics-log.ts
+++ b/packages/node/src/lib/metrics-log.ts
@@ -7,6 +7,8 @@ import timeoutSignal from 'timeout-signal';
 import pkg from '../../package.json';
 import config from '../config';
 
+import { logger } from './logger';
+
 export interface GroupingObject {
   /**
    * API Key used to make the request. Note that this is different from the `readmeAPIKey`

--- a/packages/node/src/lib/metrics-log.ts
+++ b/packages/node/src/lib/metrics-log.ts
@@ -101,6 +101,7 @@ export function metricsAPICall(readmeAPIKey: string, body: OutgoingLogBody[], op
       // after the backoff expires, erase the old expiration time
       backoffExpiresAt = undefined;
     }
+    logger.trace({ message: 'Making a POST request to a service...', args: { body } });
     return fetch(new URL('/v1/request', config.host), {
       method: 'post',
       body: JSON.stringify(body),
@@ -121,6 +122,7 @@ export function metricsAPICall(readmeAPIKey: string, body: OutgoingLogBody[], op
             backoffExpiresAt.setSeconds(backoffExpiresAt.getSeconds() + BACKOFF_SECONDS);
           }
         }
+        logger.debug({ message: `Service responded with status ${response.status}: ${response.statusText}` });
         return response;
       })
       .finally(() => {

--- a/packages/node/src/lib/metrics-log.ts
+++ b/packages/node/src/lib/metrics-log.ts
@@ -122,8 +122,8 @@ export function metricsAPICall(readmeAPIKey: string, body: OutgoingLogBody[], op
             backoffExpiresAt.setSeconds(backoffExpiresAt.getSeconds() + BACKOFF_SECONDS);
           }
         }
-        const logLevel = response.ok ? 'debug' : 'error';
-        logger[logLevel]({ message: `Service responded with status ${response.status}: ${response.statusText}` });
+        const logLevel = response.ok ? 'info' : 'error';
+        logger[logLevel]({ message: `Service responded with status ${response.status}: ${response.statusText}.` });
         return response;
       })
       .finally(() => {

--- a/packages/node/src/lib/metrics-log.ts
+++ b/packages/node/src/lib/metrics-log.ts
@@ -101,7 +101,7 @@ export function metricsAPICall(readmeAPIKey: string, body: OutgoingLogBody[], op
       // after the backoff expires, erase the old expiration time
       backoffExpiresAt = undefined;
     }
-    logger.trace({ message: 'Making a POST request to a service...', args: { body } });
+    logger.verbose({ message: 'Making a POST request to a service...', args: { body } });
     return fetch(new URL('/v1/request', config.host), {
       method: 'post',
       body: JSON.stringify(body),

--- a/packages/node/src/lib/metrics-log.ts
+++ b/packages/node/src/lib/metrics-log.ts
@@ -122,7 +122,8 @@ export function metricsAPICall(readmeAPIKey: string, body: OutgoingLogBody[], op
             backoffExpiresAt.setSeconds(backoffExpiresAt.getSeconds() + BACKOFF_SECONDS);
           }
         }
-        logger.debug({ message: `Service responded with status ${response.status}: ${response.statusText}` });
+        const logLevel = response.ok ? 'debug' : 'error';
+        logger[logLevel]({ message: `Service responded with status ${response.status}: ${response.statusText}` });
         return response;
       })
       .finally(() => {

--- a/packages/node/src/lib/pino-logger.ts
+++ b/packages/node/src/lib/pino-logger.ts
@@ -27,6 +27,14 @@ export default class PinoLogger implements LoggerStrategy {
         customLevels: customLogLevels,
         level: 'debug',
         useOnlyCustomLevels: true,
+        transport: {
+          target: 'pino-pretty',
+          options: {
+            customLevels: Object.entries(customLogLevels)
+              .map(([key, value]) => `${key}:${value}`)
+              .join(','),
+          },
+        },
         formatters: {
           level: (label: string) => {
             return { level: label.toUpperCase() };

--- a/packages/node/src/lib/pino-logger.ts
+++ b/packages/node/src/lib/pino-logger.ts
@@ -1,0 +1,56 @@
+import type { ErrorLog, Log, LoggerStrategy } from './logger';
+
+const customLogLevels = {
+  debug: 10,
+  info: 20,
+  verbose: 30,
+  error: 40,
+};
+
+interface PinoCustomLevelsLogger {
+  debug: (obj: Record<string, unknown>, msg: string) => void;
+  error: (obj: Record<string, unknown>, msg: string) => void;
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  verbose: (obj: Record<string, unknown>, msg: string) => void;
+}
+
+/**
+ * Implementation of the pino logger strategy.
+ */
+export default class PinoLogger implements LoggerStrategy {
+  externalLogger?: PinoCustomLevelsLogger;
+
+  constructor() {
+    try {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires, import/no-extraneous-dependencies
+      this.externalLogger = require('pino')({
+        customLevels: customLogLevels,
+        level: 'debug',
+        useOnlyCustomLevels: true,
+        formatters: {
+          level: (label: string) => {
+            return { level: label.toUpperCase() };
+          },
+        },
+      });
+    } catch (e) {
+      throw new Error('Error creating a pino instance');
+    }
+  }
+
+  debug({ args, message }: Log): void {
+    this.externalLogger?.debug({ args }, message);
+  }
+
+  error({ args, message, err }: ErrorLog): void {
+    this.externalLogger?.error({ args, err }, message);
+  }
+
+  info({ args, message }: Log): void {
+    this.externalLogger?.info({ args }, message);
+  }
+
+  verbose({ args, message }: Log): void {
+    this.externalLogger?.verbose({ args }, message);
+  }
+}

--- a/packages/node/src/lib/process-request.ts
+++ b/packages/node/src/lib/process-request.ts
@@ -113,7 +113,7 @@ function parseRequestBody(body: string, mimeType: string): Record<string, unknow
     try {
       return JSON.parse(body);
     } catch (err) {
-      logger.error({ message: 'Error parsing request body JSON (process-request)', err });
+      logger.error({ message: 'Error parsing request body JSON.', err });
     }
   }
 

--- a/packages/node/src/lib/process-request.ts
+++ b/packages/node/src/lib/process-request.ts
@@ -12,6 +12,7 @@ import pick from 'lodash/pick';
 import set from 'lodash/set';
 
 import { getProto, mask } from './construct-payload';
+import { logger } from './logger';
 import { objectToArray, searchToArray } from './object-to-array';
 
 /**
@@ -112,7 +113,7 @@ function parseRequestBody(body: string, mimeType: string): Record<string, unknow
     try {
       return JSON.parse(body);
     } catch (err) {
-      // no-op
+      logger.error({ message: 'Error parsing request body JSON (process-request)', err });
     }
   }
 

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -185,7 +185,7 @@ describe('#metrics', function () {
     it('should log response status after the metrics server responds', async function () {
       metricsServerResponseCode = 202;
       await makeRequest();
-      expect(mockLogger.debug).toHaveBeenCalledWith({
+      expect(mockLogger.info).toHaveBeenCalledWith({
         message: expect.stringContaining(`Service responded with status ${metricsServerResponseCode}`),
       });
     });

--- a/packages/node/test/lib/console-logger.test.ts
+++ b/packages/node/test/lib/console-logger.test.ts
@@ -11,7 +11,8 @@ describe('ConsoleLogger', () => {
   beforeEach(() => {
     logger = new ConsoleLogger();
     // Mock console methods
-    vi.spyOn(console, 'trace').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'debug').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(console, 'dir').mockImplementation(() => {});
@@ -22,26 +23,26 @@ describe('ConsoleLogger', () => {
     vi.restoreAllMocks();
   });
 
-  describe('trace', () => {
-    it('should format and log trace messages correctly with args if provided', () => {
-      const log: Log = { message: 'Trace test message', args: { key: 'value' } };
-      const expectedLevel = 'TRACE';
+  describe('verbose', () => {
+    it('should format and log verbose messages correctly with args if provided', () => {
+      const log: Log = { message: 'Verbose test message', args: { key: 'value' } };
+      const expectedLevel = 'VERBOSE';
 
-      logger.trace(log);
+      logger.verbose(log);
 
-      expect(console.trace).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(
         expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
       );
       expect(console.dir).toHaveBeenCalledWith(log.args, { depth: null });
     });
 
-    it('should format and log trace messages correctly without args if not provided', () => {
-      const log: Log = { message: 'Trace test message' };
-      const expectedLevel = 'TRACE';
+    it('should format and log verbose messages correctly without args if not provided', () => {
+      const log: Log = { message: 'Verbose test message' };
+      const expectedLevel = 'VERBOSE';
 
-      logger.trace(log);
+      logger.verbose(log);
 
-      expect(console.trace).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(
         expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
       );
       expect(console.dir).not.toHaveBeenCalled();
@@ -70,6 +71,34 @@ describe('ConsoleLogger', () => {
       logger.debug(log);
 
       expect(console.debug).toHaveBeenCalledWith(
+        expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+        '\n',
+      );
+    });
+  });
+
+  describe('info', () => {
+    it('should format and log info messages correctly with args if provided', () => {
+      const log: Log = { message: 'Info test message', args: { key: 'value' } };
+      const expectedLevel = 'INFO';
+
+      logger.info(log);
+
+      expect(console.info).toHaveBeenCalledWith(
+        expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+        '\nArguments:',
+        log.args,
+        '\n',
+      );
+    });
+
+    it('should format and log debug messages correctly without args if not provided', () => {
+      const log: Log = { message: 'Info test message' };
+      const expectedLevel = 'INFO';
+
+      logger.info(log);
+
+      expect(console.info).toHaveBeenCalledWith(
         expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
         '\n',
       );

--- a/packages/node/test/lib/console-logger.test.ts
+++ b/packages/node/test/lib/console-logger.test.ts
@@ -1,0 +1,134 @@
+import type { ErrorLog, Log } from 'src/lib/logger';
+
+import { describe, beforeEach, afterEach, vi, expect, it } from 'vitest';
+
+import ConsoleLogger from '../../src/lib/console-logger';
+
+describe('ConsoleLogger', () => {
+  let logger: ConsoleLogger;
+  const isoDateRegex = '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z';
+
+  beforeEach(() => {
+    logger = new ConsoleLogger();
+    // Mock console methods
+    vi.spyOn(console, 'trace').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'dir').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Restore original implementations
+    vi.restoreAllMocks();
+  });
+
+  describe('trace', () => {
+    it('should format and log trace messages correctly with args if provided', () => {
+      const log: Log = { message: 'Trace test message', args: { key: 'value' } };
+      const expectedLevel = 'TRACE';
+
+      logger.trace(log);
+
+      expect(console.trace).toHaveBeenCalledWith(
+        expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+      );
+      expect(console.dir).toHaveBeenCalledWith(log.args, { depth: null });
+    });
+
+    it('should format and log trace messages correctly without args if not provided', () => {
+      const log: Log = { message: 'Trace test message' };
+      const expectedLevel = 'TRACE';
+
+      logger.trace(log);
+
+      expect(console.trace).toHaveBeenCalledWith(
+        expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+      );
+      expect(console.dir).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('debug', () => {
+    it('should format and log debug messages correctly with args if provided', () => {
+      const log: Log = { message: 'Debug test message', args: { key: 'value' } };
+      const expectedLevel = 'DEBUG';
+
+      logger.debug(log);
+
+      expect(console.debug).toHaveBeenCalledWith(
+        expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+        '\nArguments:',
+        log.args,
+        '\n',
+      );
+    });
+
+    it('should format and log debug messages correctly without args if not provided', () => {
+      const log: Log = { message: 'Debug test message' };
+      const expectedLevel = 'DEBUG';
+
+      logger.debug(log);
+
+      expect(console.debug).toHaveBeenCalledWith(
+        expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+        '\n',
+      );
+    });
+  });
+
+  describe('error', () => {
+    it('should format and log error messages correctly with args if provided', () => {
+      const log: ErrorLog = { message: 'Error test message', args: { key: 'value' } };
+      const expectedLevel = 'ERROR';
+
+      logger.error(log);
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+        '\nArguments:',
+        log.args,
+        '\n',
+      );
+    });
+
+    it('should format and log error messages correctly with error if provided', () => {
+      const log: ErrorLog = { message: 'Error test message', err: new Error('Test error') };
+      const expectedLevel = 'ERROR';
+
+      logger.error(log);
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringMatching(`${expectedLevel} ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+        '\n',
+        log.err,
+        '\n',
+      );
+    });
+
+    it('should format and log error messages correctly with error and args if provided', () => {
+      const log: ErrorLog = { message: 'Error test message', err: new Error('Test error'), args: { key: 'value' } };
+
+      logger.error(log);
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringMatching(`ERROR ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+        '\nArguments:',
+        log.args,
+        '\n',
+        log.err,
+        '\n',
+      );
+    });
+
+    it('should format and log error messages correctly without error and args if not provided', () => {
+      const log: ErrorLog = { message: 'Error test message' };
+
+      logger.error(log);
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringMatching(`ERROR ${isoDateRegex} \\[readmeio\\] ${log.message}$`),
+        '\n',
+      );
+    });
+  });
+});

--- a/packages/node/test/lib/logger.test.ts
+++ b/packages/node/test/lib/logger.test.ts
@@ -5,7 +5,9 @@ import { type LoggerStrategy, type Log, type ErrorLog, logger } from '../../src/
 export class MockLoggerStrategy implements LoggerStrategy {
   debug = vi.fn();
 
-  trace = vi.fn();
+  verbose = vi.fn();
+
+  info = vi.fn();
 
   error = vi.fn();
 }
@@ -21,15 +23,15 @@ describe('Default Logger', () => {
   describe('trace', () => {
     it('should log trace messages when logging is enabled', () => {
       const log: Log = { message: 'Trace test message.' };
-      logger.trace(log);
-      expect(mockStrategy.trace).toHaveBeenCalledWith(log);
+      logger.verbose(log);
+      expect(mockStrategy.verbose).toHaveBeenCalledWith(log);
     });
 
     it('should not log trace messages when logging is disabled', () => {
       const log: Log = { message: 'Trace test message.' };
       logger.configure({ isLoggingEnabled: false });
-      logger.trace(log);
-      expect(mockStrategy.trace).not.toHaveBeenCalled();
+      logger.verbose(log);
+      expect(mockStrategy.verbose).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/node/test/lib/logger.test.ts
+++ b/packages/node/test/lib/logger.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { type LoggerStrategy, type Log, type ErrorLog, logger } from '../../src/lib/logger';
+
+export class MockLoggerStrategy implements LoggerStrategy {
+  debug = vi.fn();
+
+  trace = vi.fn();
+
+  error = vi.fn();
+}
+
+describe('Default Logger', () => {
+  let mockStrategy: LoggerStrategy;
+
+  beforeEach(() => {
+    mockStrategy = new MockLoggerStrategy();
+    logger.configure({ isLoggingEnabled: true, strategy: mockStrategy });
+  });
+
+  describe('trace', () => {
+    it('should log trace messages when logging is enabled', () => {
+      const log: Log = { message: 'Trace test message.' };
+      logger.trace(log);
+      expect(mockStrategy.trace).toHaveBeenCalledWith(log);
+    });
+
+    it('should not log trace messages when logging is disabled', () => {
+      const log: Log = { message: 'Trace test message.' };
+      logger.configure({ isLoggingEnabled: false });
+      logger.trace(log);
+      expect(mockStrategy.trace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('debug', () => {
+    it('should log debug messages when logging is enabled', () => {
+      const log: Log = { message: 'Debug test message.' };
+      logger.debug(log);
+      expect(mockStrategy.debug).toHaveBeenCalledWith(log);
+    });
+
+    it('should not log debug messages when logging is disabled', () => {
+      const log: Log = { message: 'Debug test message.' };
+      logger.configure({ isLoggingEnabled: false });
+      logger.debug(log);
+      expect(mockStrategy.debug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error', () => {
+    it('should log error messages when logging is enabled', () => {
+      const log: ErrorLog = { message: 'Error test message.', err: new Error('Test error') };
+      logger.error(log);
+      expect(mockStrategy.error).toHaveBeenCalledWith(log);
+    });
+
+    it('should not log error messages when logging is disabled', () => {
+      const log: ErrorLog = { message: 'Error test message.', err: new Error('Test error') };
+      logger.configure({ isLoggingEnabled: false });
+      logger.error(log);
+      expect(mockStrategy.error).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
| 🚥 Resolves #1045 |
| :------------------- |

## 🧰 Changes

Implementation of the Node.js console logger for trace, debug and error logs.
Implemented as a singleton class to make sure that its instance is the only one in the Node.js SDK. It has a config that allows you to customize the log prefix or disable the logging option, by default logging option is set to disabled and prefix is "[readmeio]". It has 3 main methods: trace, debug and errors. They can be called anywhere in the code. You need to import the logger instance from the "logger.ts" file and call the required method (logger.error(...) and so on). It takes the following fields in the object as a parameter: 
- message (required)
- args (optional)
- err (only for logger.error)

## 🧬 QA & Testing

Set "logger" option in options object to true and try to send a test request.
Some of the example logs provided here: 

<img width="445" alt="image" src="https://github.com/user-attachments/assets/b7e01af3-d637-4395-9c34-fe40d42c6a84">
<img width="815" alt="image" src="https://github.com/user-attachments/assets/9969cd26-e995-4235-9dcd-3d6910d54f42">
<img width="615" alt="image" src="https://github.com/user-attachments/assets/b3bfc0ba-a2b5-48c2-93b7-90695395096f">
