### PR TITLE
feat(dotnet, node, php, python): exclude OPTIONS requests from being logged

### DIFF
--- a/packages/dotnet/ReadMe/Metrics.cs
+++ b/packages/dotnet/ReadMe/Metrics.cs
@@ -21,6 +21,12 @@ namespace ReadMe
 
     public async Task InvokeAsync(HttpContext context)
     {
+      if (context.Request.Method == HttpMethods.Options)
+      {
+        await this.next(context);
+        return;
+      }
+
       if (!context.Request.Path.Value.Contains("favicon.ico"))
       {
         this.group = new Group()

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -109,7 +109,7 @@ export function log(
   group: GroupingObject,
   options: Options = {},
 ) {
-  if (req.method === 'OPTIONS') return;
+  if (req.method === 'OPTIONS') return undefined;
   if (!readmeApiKey) throw new Error('You must provide your ReadMe API key');
   if (!group) throw new Error('You must provide a group');
   if (options.logger) {

--- a/packages/node/src/lib/log.ts
+++ b/packages/node/src/lib/log.ts
@@ -109,6 +109,7 @@ export function log(
   group: GroupingObject,
   options: Options = {},
 ) {
+  if (req.method === 'OPTIONS') return;
   if (!readmeApiKey) throw new Error('You must provide your ReadMe API key');
   if (!group) throw new Error('You must provide a group');
   if (options.logger) {

--- a/packages/node/test/lib/log.test.ts
+++ b/packages/node/test/lib/log.test.ts
@@ -1,0 +1,46 @@
+import type { ExtendedIncomingMessage, ExtendedResponse, Options } from 'src/lib/log';
+import type { GroupingObject } from 'src/lib/metrics-log';
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { log } from '../../src/lib/log';
+import { metricsAPICall } from '../../src/lib/metrics-log';
+
+describe('log', function () {
+  vi.mock('../../src/lib/metrics-log');
+
+  let req: ExtendedIncomingMessage;
+  let res: ExtendedResponse;
+  let group: GroupingObject;
+  let options: Options;
+
+  beforeEach(() => {
+    req = {
+      method: 'GET',
+      headers: {},
+      url: '/',
+    } as ExtendedIncomingMessage;
+
+    res = {
+      statusCode: 200,
+      getHeader: vi.fn(),
+      setHeader: vi.fn(),
+      removeListener: vi.fn(),
+      once: vi.fn(),
+    } as unknown as ExtendedResponse;
+
+    group = { apiKey: 'test-api-key' };
+    options = { bufferLength: 1 };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should not log OPTIONS requests', function () {
+    req.method = 'OPTIONS';
+    const logId = log('api-key', req, res, group, options);
+    expect(logId).toBeUndefined();
+    expect(metricsAPICall).not.toHaveBeenCalled();
+  });
+});

--- a/packages/php/src/Metrics.php
+++ b/packages/php/src/Metrics.php
@@ -92,6 +92,10 @@ class Metrics
      */
     public function track(Request $request, Response &$response): void
     {
+        if ($request->getMethod() === 'OPTIONS') {
+            return;
+        }
+
         if (empty($this->base_log_url)) {
             $this->base_log_url = $this->getProjectBaseUrl();
         }

--- a/packages/php/tests/MetricsTest.php
+++ b/packages/php/tests/MetricsTest.php
@@ -228,6 +228,29 @@ class MetricsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @group track
+     */
+    public function testTrackIgnoresOptionsMethod(): void
+    {
+        $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'OPTIONS']);
+        $response = $this->getMockJsonResponse();
+
+        $handlers = $this->getMockHandlers(
+            new \GuzzleHttp\Psr7\Response(200, [], 'OK'),
+            new \GuzzleHttp\Psr7\Response(200, [], json_encode(['baseUrl' => $this->base_log_url]))
+        );
+
+        $this->metrics = new Metrics($this->readme_api_key, $this->group_handler, [
+            'development_mode' => false,
+            'client' => new Client(['handler' => $handlers->metrics]),
+            'client_readme' => new Client(['handler' => $handlers->readme])
+        ]);
+
+        $this->metrics->track($request, $response);
+        $this->assertEmpty($this->api_calls, 'No API calls should be made for OPTIONS requests.');
+    }
+
+    /**
      * @group getProjectBaseUrl
      * @dataProvider providerDevelopmentModeToggle
      */

--- a/packages/python/readme_metrics/django.py
+++ b/packages/python/readme_metrics/django.py
@@ -16,6 +16,9 @@ class MetricsMiddleware:
         self.metrics_core = Metrics(self.config)
 
     def __call__(self, request):
+        if request.method == "OPTIONS":
+            return self.get_response(request)
+
         try:
             request.rm_start_dt = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             request.rm_start_ts = int(time.time() * 1000)

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -42,9 +42,6 @@ class ReadMeMetrics:
             self.config.LOGGER.exception(e)
 
     def after_request(self, response):
-        if request.method == "OPTIONS":
-            return response
-
         try:
             response_info = ResponseInfoWrapper(
                 response.headers,

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -27,6 +27,9 @@ class ReadMeMetrics:
         app.after_request(self.after_request)
 
     def before_request(self):
+        if request.method == "OPTIONS":
+            return
+
         try:
             request.rm_start_dt = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             request.rm_start_ts = int(time.time() * 1000)
@@ -39,6 +42,9 @@ class ReadMeMetrics:
             self.config.LOGGER.exception(e)
 
     def after_request(self, response):
+        if request.method == "OPTIONS":
+            return response
+
         try:
             response_info = ResponseInfoWrapper(
                 response.headers,

--- a/packages/python/readme_metrics/tests/django_test.py
+++ b/packages/python/readme_metrics/tests/django_test.py
@@ -63,3 +63,11 @@ class TestDjangoMiddleware:
         request.headers = {}
         middleware(request)
         assert getattr(request, "rm_content_length") == "0"
+
+    def test_options_request(self):
+        middleware = MetricsMiddleware(Mock(), config=mock_config)
+        middleware.metrics_core = Mock()
+        request = Mock()
+        request.method = "OPTIONS"
+        result = middleware(request)
+        assert not middleware.metrics_core.process.called

--- a/packages/python/readme_metrics/tests/django_test.py
+++ b/packages/python/readme_metrics/tests/django_test.py
@@ -69,5 +69,5 @@ class TestDjangoMiddleware:
         middleware.metrics_core = Mock()
         request = Mock()
         request.method = "OPTIONS"
-        result = middleware(request)
+        middleware(request)
         assert not middleware.metrics_core.process.called

--- a/packages/python/readme_metrics/tests/flask_test.py
+++ b/packages/python/readme_metrics/tests/flask_test.py
@@ -69,3 +69,15 @@ class TestFlaskExtension:
         assert call_args[0][0] == request
         assert isinstance(call_args[0][1], ResponseInfoWrapper)
         assert call_args[0][1].headers.get("X-Header") == "X Value!"
+
+    def test_before_request_options(self):
+        app = Flask(__name__)
+        extension = ReadMeMetrics(config=mock_config, app=app)
+
+        with app.test_request_context("/", method="OPTIONS"):
+            extension.before_request()
+
+            assert not hasattr(request, "rm_start_dt")
+            assert not hasattr(request, "rm_start_ts")
+            assert not hasattr(request, "rm_content_length")
+            assert not hasattr(request, "rm_body")


### PR DESCRIPTION
| 🚥 Resolves #58  |
| :------------------- |

## 🧰 Changes

Add a middleware checks for skipping OPTIONS requests