### PR TITLE
feat(ruby): Add Nested path filtering support with dot notation

### DIFF
--- a/packages/ruby/lib/readme/filter.rb
+++ b/packages/ruby/lib/readme/filter.rb
@@ -1,55 +1,132 @@
+# frozen_string_literal: true
+
 module Readme
   class Filter
     def self.for(reject: nil, allow_only: nil)
-      if !reject.nil? && !allow_only.nil?
-        raise FilterArgsError
-      elsif !reject.nil?
-        RejectParams.new(reject)
-      elsif !allow_only.nil?
-        AllowOnly.new(allow_only)
+      raise FilterArgsError if reject && allow_only
+      return RejectParams.new(reject) if reject
+      return AllowOnly.new(allow_only) if allow_only
+
+      None.new
+    end
+
+    def self.redact(value)
+      value.is_a?(String) ? "[REDACTED #{value.length}]" : '[REDACTED]'
+    end
+
+    def self.redact_json(json_str)
+      return json_str unless json_str.is_a?(String)
+
+      begin
+        data = JSON.parse(json_str)
+        JSON.generate(process_value(data))
+      rescue JSON::ParserError
+        json_str
+      end
+    end
+
+    def self.process_value(value)
+      case value
+      when Hash
+        value.transform_values { |v| process_value(v) }
+      when Array
+        value.map { |item| process_value(item) }
+      when String
+        "[REDACTED #{value.length}]"
       else
-        None.new
+        '[REDACTED]'
       end
     end
 
-    def self.redact(rejected_params)
-      rejected_params.each_with_object({}) do |(k, v), hash|
-        # If it's a string then return the length of the redacted field
-        hash[k.to_str] = "[REDACTED#{v.is_a?(String) ? " #{v.length}" : ''}]"
-      end
-    end
-
-    class AllowOnly
-      def initialize(filter_fields)
-        @allowed_fields = filter_fields
+    module PathProcessor
+      def parse_path(path)
+        case path
+        when String
+          path.gsub('[]', '').downcase.split('.')
+        else
+          [path.to_s.downcase]
+        end
       end
 
-      def filter(hash)
-        allowed_fields = @allowed_fields.map(&:downcase)
-        allowed_params, rejected_params = hash.partition { |key, _value| allowed_fields.include?(key.downcase) }.map(&:to_h)
+      def process_hash(hash, current_path = [])
+        return hash unless hash.is_a?(Hash)
 
-        allowed_params.merge(Filter.redact(rejected_params))
+        hash.each_with_object({}) do |(key, value), result|
+          path = current_path + [key.downcase]
+          result[key] = process_value(value, path)
+        end
       end
 
-      def pass_through?
-        false
+      def process_value(value, path)
+        if should_process_deeper?(path)
+          if value.is_a?(Hash)
+            process_hash(value, path)
+          elsif value.is_a?(Array)
+            value.map { |item| item.is_a?(Hash) ? process_hash(item, path) : item }
+          else
+            value
+          end
+        else
+          should_redact?(path) ? Filter.redact(value) : value
+        end
+      end
+
+      def path_starts_with?(path_a, path_b)
+        return false if path_a.length > path_b.length
+
+        path_a.zip(path_b).all? { |a, b| a == b }
       end
     end
 
     class RejectParams
+      include PathProcessor
+
       def initialize(filter_fields)
-        @rejected_fields = filter_fields
+        @paths = filter_fields.map { |field| parse_path(field) }
       end
 
       def filter(hash)
-        rejected_fields = @rejected_fields.map(&:downcase)
-        rejected_params, allowed_params = hash.partition { |key, _value| rejected_fields.include?(key.downcase) }.map(&:to_h)
-
-        allowed_params.merge(Filter.redact(rejected_params))
+        process_hash(hash)
       end
 
       def pass_through?
         false
+      end
+
+      private
+
+      def should_process_deeper?(current_path)
+        @paths.any? { |path| path.length > current_path.length && path_starts_with?(current_path, path) }
+      end
+
+      def should_redact?(current_path)
+        @paths.any?(current_path)
+      end
+    end
+
+    class AllowOnly
+      include PathProcessor
+
+      def initialize(filter_fields)
+        @paths = filter_fields.map { |field| parse_path(field) }
+      end
+
+      def filter(hash)
+        process_hash(hash)
+      end
+
+      def pass_through?
+        false
+      end
+
+      private
+
+      def should_process_deeper?(current_path)
+        @paths.any? { |path| path_starts_with?(current_path, path) || path_starts_with?(path, current_path) }
+      end
+
+      def should_redact?(current_path)
+        @paths.none?(current_path)
       end
     end
 
@@ -65,8 +142,7 @@ module Readme
 
     class FilterArgsError < StandardError
       def initialize
-        msg = 'Can only supply either reject_params or allow_only, not both.'
-        super(msg)
+        super('Can only supply either reject_params or allow_only, not both.')
       end
     end
   end

--- a/packages/ruby/lib/readme/har/collection.rb
+++ b/packages/ruby/lib/readme/har/collection.rb
@@ -13,7 +13,12 @@ module Readme
       end
 
       def to_a
-        filtered_hash.map { |name, value| { name: name, value: value.is_a?(Hash) ? value.to_json : value } }
+        filtered_hash.map do |name, value|
+          {
+            name: name,
+            value: value.is_a?(Hash) ? value.to_json : value
+          }
+        end
       end
 
       private

--- a/packages/ruby/spec/readme/har/response_serializer_spec.rb
+++ b/packages/ruby/spec/readme/har/response_serializer_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Readme::Har::ResponseSerializer do
       )
       json = serializer.as_json
 
-      expect(json.dig(:content, :text)).to eq({ keep: 'keep', reject: '[REDACTED 6]' }.to_json)
+      expect(json.dig(:content, :text)).to eq({ reject: '[REDACTED 6]', keep: 'keep' }.to_json)
       expect(json.dig(:content, :size)).to eq response.content_length
       expect(json.dig(:content, :mimeType)).to eq 'application/json'
     end


### PR DESCRIPTION
## 🧰 Changes

This PR adds the abuility to filter nested objects using dot notation (e.g. `user.password`, `payment.card.number`). The feature improves API logging security by allowing precise filtering of nested sensitive data. 

Key changes:

- Added `PathProcessor` module to handling dot notation paths
- Support for array path notation (`users[].password`)
- Case-insensitive path matching
- Maintains string length in redacted values
- Adds support for both reject and allow-only filtering

Example usage:

```ruby
# Reject specific nested fields
filter = Readme::Filter.for(reject: ['user.password', 'payment.card.number'])
filter.filter({
  user: { 
    name: 'John',
    password: 'secret'
  }
})
# => { user: { name: 'John', password: '[REDACTED 6]' } }

# Allow only specific nested fields
filter = Readme::Filter.for(allow_only: ['user.name'])
```


## 🧬 QA & Testing
<img width="465" alt="Screenshot 2024-11-14 at 14 40 21" src="https://github.com/user-attachments/assets/4b17033f-3847-41a5-9100-6bf990e9c2be">

