### PR TITLE
chore(python): remove support for Python 3.8 (EOL)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,6 @@ jobs:
           - windows-latest
         python-version:
           # https://endoflife.date/python
-          - 3.8 # EOL: October 14th, 2024
           - 3.9 # EOL: October 5rd, 2025
           - '3.10' # EOL: October 4rd, 2026
           - '3.11' # EOL: October 24th, 2027


### PR DESCRIPTION
## 🧰 Changes

Remove Python 3.8 from Github workflow since it is deprecated (EOL). 