### PR TITLE
chore(dotnet): bump dotnet to 2.2.0 and updates maintainer readme

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -22,7 +22,7 @@ To publish a new version of the Ruby [package](https://rubygems.org/gems/readme-
 
 If you're not a maintainer of `readme-metrics` on [PyPI](https://pypi.org), [register for an account](https://pypi.org/account/register/), enable two-factor auth on your [account settings](https://pypi.org/manage/account/), and ask someone to add you as a maintainer.
 
-You may also want to create a `.pypirc` file in your home directory ([example](https://gist.github.com/RyanGWU82/893fb63e6d182f90ef227fd1fd4e9da5)).  `.pypirc` now uses API keys so you will need to generate one.  See PyPI's [help guide](https://pypi.org/help/) on how to generate  it.
+You may also want to create a `.pypirc` file in your home directory ([example](https://gist.github.com/RyanGWU82/893fb63e6d182f90ef227fd1fd4e9da5)). `.pypirc` now uses API keys so you will need to generate one. See PyPI's [help guide](https://pypi.org/help/) on how to generate it.
 
 To publish a new version:
 
@@ -45,7 +45,7 @@ NEW_VERSION="x.x.x"; sed -i '' "s/\(__version__ = \)\"\([^\"]*\)\"/\1\"$NEW_VERS
 
 ### .NET
 
-If you're not a maintainer of [`ReadMe.Metrics`](https://www.nuget.org/packages/ReadMe.Metrics/) on [NuGet](https://www.nuget.org/), [register for a Microsoft account by going through this flow](https://www.nuget.org/users/account/LogOn), enable two-factor auth on your [account settings](https://account.live.com/proofs/manage/additional), and ask someone to add you as a maintainer.  Also ensure that you have [.Net CLI](https://dotnet.microsoft.com/en-us/download) installed.
+If you're not a maintainer of [`ReadMe.Metrics`](https://www.nuget.org/packages/ReadMe.Metrics/) on [NuGet](https://www.nuget.org/), [register for a Microsoft account by going through this flow](https://www.nuget.org/users/account/LogOn), enable two-factor auth on your [account settings](https://account.live.com/proofs/manage/additional), and ask someone to add you as a maintainer. Also ensure that you have [.Net CLI](https://dotnet.microsoft.com/en-us/download) installed.
 
 To publish a new version:
 

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -22,7 +22,7 @@ To publish a new version of the Ruby [package](https://rubygems.org/gems/readme-
 
 If you're not a maintainer of `readme-metrics` on [PyPI](https://pypi.org), [register for an account](https://pypi.org/account/register/), enable two-factor auth on your [account settings](https://pypi.org/manage/account/), and ask someone to add you as a maintainer.
 
-You may also want to create a `.pypirc` file in your home directory ([example](https://gist.github.com/RyanGWU82/893fb63e6d182f90ef227fd1fd4e9da5)).
+You may also want to create a `.pypirc` file in your home directory ([example](https://gist.github.com/RyanGWU82/893fb63e6d182f90ef227fd1fd4e9da5)).  `.pypirc` now uses API keys so you will need to generate one.  See PyPI's [help guide](https://pypi.org/help/) on how to generate  it.
 
 To publish a new version:
 
@@ -40,11 +40,12 @@ NEW_VERSION="x.x.x"; sed -i '' "s/\(__version__ = \)\"\([^\"]*\)\"/\1\"$NEW_VERS
    - If you get errors about `invalid command 'bdist_wheel'`, install the wheel package: `pip3 install wheel`
 5. `python3 -m twine upload dist/*`
    - If you get errors about `twine` not being installed, install it with `pip3 install twine`.
+   - If you get errors about `setuptools` not being installed, install it with `pip3 install setuptools`.
    - On the first run you'll be asked to log into PyPi, so if you don't have access to `readme-metrics` there ask someone to hook you up with access.
 
 ### .NET
 
-If you're not a maintainer of [`ReadMe.Metrics`](https://www.nuget.org/packages/ReadMe.Metrics/) on [NuGet](https://www.nuget.org/), [register for a Microsoft account by going through this flow](https://www.nuget.org/users/account/LogOn), enable two-factor auth on your [account settings](https://account.live.com/proofs/manage/additional), and ask someone to add you as a maintainer.
+If you're not a maintainer of [`ReadMe.Metrics`](https://www.nuget.org/packages/ReadMe.Metrics/) on [NuGet](https://www.nuget.org/), [register for a Microsoft account by going through this flow](https://www.nuget.org/users/account/LogOn), enable two-factor auth on your [account settings](https://account.live.com/proofs/manage/additional), and ask someone to add you as a maintainer.  Also ensure that you have [.Net CLI](https://dotnet.microsoft.com/en-us/download) installed.
 
 To publish a new version:
 
@@ -66,7 +67,7 @@ NEW_VERSION="x.x.x"; sed -i '' "s/\(Version = \)\"\([^\"]*\)\"/\1\"$NEW_VERSION\
 6. Publish!
 
 ```sh
-dotnet nuget push ./bin/Debug/ReadMe.Metrics.<version>.nupkg --api-key <apiKey> --source https://api.nuget.org/v3/index.json
+dotnet nuget push ./bin/Release/ReadMe.Metrics.<version>.nupkg --api-key <apiKey> --source https://api.nuget.org/v3/index.json
 ```
 
 ### Tag-based release management

--- a/packages/dotnet/ReadMe/ConstValues.cs
+++ b/packages/dotnet/ReadMe/ConstValues.cs
@@ -6,7 +6,7 @@ namespace ReadMe
   {
     public static readonly string Name = "readmeio.net";
 
-    public static readonly string Version = "2.1.0";
+    public static readonly string Version = "2.2.0";
 
     public static readonly int Wait = 0;
 

--- a/packages/dotnet/ReadMe/ReadMe.csproj
+++ b/packages/dotnet/ReadMe/ReadMe.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>ReadMe.Metrics</PackageId>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <Authors>ReadMe</Authors>
     <Company>ReadMe</Company>
     <Product>ReadMe.Metrics DotnetCore</Product>


### PR DESCRIPTION
## 🧰 Changes

Version bump of the .Net package and updates Maintainers.md with additional details and updated steps.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
