### PR TITLE
PHP: Fix blacklist/whitelist props in config file

### DIFF
--- a/packages/php/examples/laravel/config/readme.php
+++ b/packages/php/examples/laravel/config/readme.php
@@ -36,7 +36,7 @@ return [
      * Note that this does not support dot-notation, so only top-level keys can
      * be blacklisted.
      */
-    'denylist' => [],
+    'blacklist' => [],
 
     /**
      * An array of values from your API requests and responses that you only
@@ -45,7 +45,7 @@ return [
      * Note that this does not support dot-notation, so only top-level keys can
      * be whitelisted.
      */
-    'allowlist' => [],
+    'whitelist' => [],
 
     /**
      * Optionally, this is the base URL for your ReadMe project.


### PR DESCRIPTION
`packages/php/src/Middleware.php` class expects blacklist/whitelist properties
