### PR TITLE
fix(python/fastapi): prefix path capturing

### DIFF
--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -380,10 +380,10 @@ class PayloadBuilder:
         if hasattr(request, "base_url"):
             # Werkzeug request objects already have exactly what we need
             base_url = str(request.base_url)
-            if hasattr(request, "scope") and hasattr(request.scope, "path"):
+            if hasattr(request, "url") and hasattr(request.url, "path"):
                 base_url = base_url[:-1]
-                if len(request.scope.path) > 1:
-                    base_url += request.scope.path
+                if len(request.url.path) > 1:
+                    base_url += request.url.path
             if len(query_string) > 0:
                 base_url += f"?{query_string}"
             return base_url

--- a/packages/python/readme_metrics/PayloadBuilder.py
+++ b/packages/python/readme_metrics/PayloadBuilder.py
@@ -325,6 +325,10 @@ class PayloadBuilder:
         if hasattr(request, "base_url"):
             # Werkzeug request objects already have exactly what we need
             base_url = str(request.base_url)
+            if hasattr(request, "url"):
+                base_url = base_url[:-1]
+                if hasattr(request.url, "path") and len(request.url.path) > 1:
+                    base_url += request.url.path
             if len(query_string) > 0:
                 base_url += f"?{query_string}"
             return base_url


### PR DESCRIPTION
## 🧰 Changes

Fix prefix path not captured issue.
We had a problem with FastAPI integration that the Middleware did not captured the path for each request and sent only “/” instead. 

## 🧬 QA & Testing

Try sending a few test requests with paths, for example, “/hello/world”. Now it should not be empty.