### PR TITLE
fix(python): ignore the middleware when groupingFn is None

### DIFF
--- a/packages/python/readme_metrics/django.py
+++ b/packages/python/readme_metrics/django.py
@@ -58,7 +58,7 @@ class MetricsMiddleware:
             self.config.LOGGER.exception(e)
 
     def sync_process(self, request):
-        if request.method == "OPTIONS":
+        if request.method == "OPTIONS" or self.config.GROUPING_FUNCTION is None:
             return self.get_response(request)
         self.preamble(request)
         response = self.get_response(request)
@@ -66,7 +66,7 @@ class MetricsMiddleware:
         return response
 
     async def async_process(self, request):
-        if request.method == "OPTIONS":
+        if request.method == "OPTIONS" or self.config.GROUPING_FUNCTION is None:
             return await self.get_response(request)
         self.preamble(request)
         response = await self.get_response(request)

--- a/packages/python/readme_metrics/fastapi.py
+++ b/packages/python/readme_metrics/fastapi.py
@@ -58,7 +58,7 @@ class ReadMeMetricsMiddleware(BaseHTTPMiddleware):
             self.config.LOGGER.exception(e)
 
     async def dispatch(self, request: Request, call_next):
-        if request.method == "OPTIONS":
+        if request.method == "OPTIONS" or self.config.GROUPING_FUNCTION is None:
             return await call_next(request)
 
         await self.preamble(request)

--- a/packages/python/readme_metrics/flask_readme.py
+++ b/packages/python/readme_metrics/flask_readme.py
@@ -27,7 +27,7 @@ class ReadMeMetrics:
         app.after_request(self.after_request)
 
     def before_request(self):
-        if request.method == "OPTIONS":
+        if request.method == "OPTIONS" or self.config.GROUPING_FUNCTION is None:
             return
 
         try:


### PR DESCRIPTION
## 🧰 Changes

Add a handler to ignore middleware when we have an empty groupingFn (grouping_function is None).

## 🧬 QA & Testing

Try sending test requests with grouping function that returns None. 
In this case, the middleware should be ignored.
