### PR TITLE
ci: get `rdme` docs upload workflow working again

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -13,6 +13,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Sync docs to ReadMe
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v10.2.0-next.5
         with:
-          rdme: docs ./docs --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ secrets.README_DEVELOPERS_MAIN_VERSION }}
+          rdme: docs upload ./docs --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }}

--- a/docs/alternative-methods.md
+++ b/docs/alternative-methods.md
@@ -1,7 +1,8 @@
 ---
 title: Other Ways to Send API Requests
 slug: other-ways-to-use-api-metrics
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 Are you interested in insights on your users and API request logs in your documentation, but using a language or API gateway that we don't yet support? [Let us know](https://docs.readme.com/docs/contact-support) what you're using! We're actively working on new integrations and would love to support your API.

--- a/docs/aws-webhook.md
+++ b/docs/aws-webhook.md
@@ -1,7 +1,8 @@
 ---
 title: Using Amazon API Gateway with the Personalized Docs Webhook
 slug: amazon-api-gateway-webhook
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 > 📘 Don't use Amazon API Gateway?

--- a/docs/cloudflare-workers.md
+++ b/docs/cloudflare-workers.md
@@ -1,7 +1,8 @@
 ---
 title: Cloudflare Workers
 slug: sending-logs-to-readme-with-cloudflare
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 > 🚧 Any issues?

--- a/docs/dotnet-setup.md
+++ b/docs/dotnet-setup.md
@@ -1,7 +1,8 @@
 ---
 title: .NET Setup
 slug: net-setup
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 > 🚧 Any issues?

--- a/docs/nodejs-setup.md
+++ b/docs/nodejs-setup.md
@@ -1,7 +1,8 @@
 ---
 title: Node.js Setup
 slug: sending-logs-to-readme-with-nodejs
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 > 🚀 Upgrading to v6.0?

--- a/docs/php-laravel-setup.md
+++ b/docs/php-laravel-setup.md
@@ -1,7 +1,8 @@
 ---
 title: PHP (Laravel) Setup
 slug: sending-logs-to-readme-with-php-laravel
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 > 🚀 Upgrading to v2.0?

--- a/docs/python-django-setup.md
+++ b/docs/python-django-setup.md
@@ -1,7 +1,8 @@
 ---
 title: Python (Django) Setup
 slug: python-django-api-metrics
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 > 🚧 Any issues?

--- a/docs/python-flask-setup.md
+++ b/docs/python-flask-setup.md
@@ -1,7 +1,8 @@
 ---
 title: Python (Flask) Setup
 slug: python-flask-api-metrics
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 > 🚧 Any issues?

--- a/docs/python-wsgi-setup.md
+++ b/docs/python-wsgi-setup.md
@@ -1,7 +1,8 @@
 ---
 title: Python (Flask) Setup
 slug: python-wsgi-api-metrics
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 > 🚧 Any issues?

--- a/docs/ruby-setup.md
+++ b/docs/ruby-setup.md
@@ -1,7 +1,8 @@
 ---
 title: Ruby (Rails/Rack) Setup
 slug: ruby-api-metrics-set-up
-category: 62292aea889520008ed0113b
+category:
+  uri: project-setup
 ---
 
 > 🚧 Any issues?


### PR DESCRIPTION
## 🧰 Changes

gets the `sync-docs` workflow working again. thankfully a much less messy upgrade this time around 😮‍💨

![CleanShot 2025-03-18 at 11 19 21@2x](https://github.com/user-attachments/assets/979ea92f-1474-4cb6-8560-1d0f329cceca)

sadly these docs are still unable to sync due to MDX validation errors. for example:

![CleanShot 2025-03-18 at 11 31 57@2x](https://github.com/user-attachments/assets/6b43f75a-a549-4f95-90e6-65a2c2392767)

will mark this as ready for review once we can get those resolved!


## 🧬 QA & Testing

do the changes look sound?
