### PR TITLE
fix(python/fastapi): empty groupingFn exception handling

### DIFF
--- a/packages/python/readme_metrics/fastapi.py
+++ b/packages/python/readme_metrics/fastapi.py
@@ -58,7 +58,7 @@ class ReadMeMetricsMiddleware(BaseHTTPMiddleware):
             self.config.LOGGER.exception(e)
 
     async def dispatch(self, request: Request, call_next):
-        if request.method == "OPTIONS" or self.config.GROUPING_FUNCTION is None:
+        if request.method == "OPTIONS" or self.config.GROUPING_FUNCTION(request) is None:
             return await call_next(request)
 
         await self.preamble(request)
@@ -81,6 +81,7 @@ class ReadMeMetricsMiddleware(BaseHTTPMiddleware):
 
         except Exception as e:
             self.config.LOGGER.exception(e)
+            return await call_next(request)
 
         return Response(
             content=response_body,

--- a/packages/python/readme_metrics/fastapi.py
+++ b/packages/python/readme_metrics/fastapi.py
@@ -58,7 +58,10 @@ class ReadMeMetricsMiddleware(BaseHTTPMiddleware):
             self.config.LOGGER.exception(e)
 
     async def dispatch(self, request: Request, call_next):
-        if request.method == "OPTIONS" or self.config.GROUPING_FUNCTION(request) is None:
+        if (
+            request.method == "OPTIONS"
+            or self.config.GROUPING_FUNCTION(request) is None
+        ):
             return await call_next(request)
 
         await self.preamble(request)


### PR DESCRIPTION
## 🧰 Changes

Small fix for a groupingFn exception handling (just to make sure app is not crashing)
