### PR TITLE
fix: drop timeout-signal

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -30,7 +30,6 @@
     "flat-cache": "^6.1.1",
     "lodash": "^4.17.15",
     "ssri": "^12.0.0",
-    "timeout-signal": "^1.1.0",
     "type-is": "^1.6.18"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🧰 Changes

Due to compatibility issues with Node.js v24 - where most tests were failing and the SDK was not functioning correctly, throwing the error: `TypeError: RequestInit: Expected signal ("AbortSignal {}") to be an instance of AbortSignal.` - the third-party `timeout-signal` package has been removed in favor of the native `AbortSignal.timeout`, which is now supported in Node.js 18 and above.

## 🧬 QA & Testing

Run `make test` for Node.js SDK 