### PR TITLE
feat(php): add PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,6 +37,7 @@ jobs:
           - 8.1 # EOL: December 31th, 2025
           - 8.2 # EOL: December 31th, 2026
           - 8.3 # EOL: December 31th, 2027
+          - 8.4 # EOL: December 31th, 2028
         # https://endoflife.date/laravel
         laravel:
           - 10.* # EOL: February 4th, 2025
@@ -89,6 +90,7 @@ jobs:
         php:
           - 8.2 # EOL: December 31th, 2026
           - 8.3 # EOL: December 31th, 2027
+          - 8.4 # EOL: December 31th, 2028
         # https://endoflife.date/laravel
         laravel:
           - 11.* # EOL: March 12th, 2026

--- a/packages/php/composer.json
+++ b/packages/php/composer.json
@@ -14,7 +14,7 @@
     "readme"
   ],
   "require": {
-    "php": "^8.1 | ^8.2 | ^8.3",
+    "php": "^8.1 | ^8.2 | ^8.3 | ^8.4",
     "illuminate/http": "^10.0 | ^11.0",
     "illuminate/support": "^10.0 | ^11.0",
     "ramsey/uuid": "^4.7",


### PR DESCRIPTION
## Summary

- Extend the PHP version constraint in `packages/php/composer.json` from `^8.1 | ^8.2 | ^8.3` to `^8.1 | ^8.2 | ^8.3 | ^8.4`
- Add PHP 8.4 to the CI test matrix in `.github/workflows/php.yml` for both the Laravel 10 (`build`) and Laravel 11 (`build-laravel11`) jobs

No source code changes were required: the codebase already uses explicit union types (`string|null`) and contains no implicit nullable parameter patterns that were deprecated in PHP 8.4.